### PR TITLE
Invert boolean display logic for overdue skill trees on admin users index

### DIFF
--- a/app/admin/admin_users.rb
+++ b/app/admin/admin_users.rb
@@ -100,8 +100,8 @@ ActiveAdmin.register AdminUser do
     column :has_dei_response? do |resource|
       !resource.should_nag_for_dei_data?
     end
-    column :skill_tree_overdue? do |resource|
-      resource.should_nag_for_skill_tree?
+    column :has_current_skill_tree? do |resource|
+      !resource.should_nag_for_skill_tree?
     end
     column :projected_psu_by_eoy do |resource|
       resource.projected_psu_by_eoy


### PR DESCRIPTION
This simply flips the boolean logic / wording for whether team members have a current skill tree, allowing ActiveAdmin to render the yes/no labels in the appropriate color for the situation (right now it's a little visually confusing because the page is showing green labels for the "bad" status).

With this change:

green = good (the user has a current skill tree)
yellow = bad (the user's skill tree is out of date)

Current version:
![users_index_current](https://github.com/sanctuarycomputer/stacks/assets/34255985/183d8a59-b007-4f21-92df-4705511943f1)

Updated version:
![user_index_updated](https://github.com/sanctuarycomputer/stacks/assets/34255985/503241c9-ba5f-4bab-8087-e49eef761619)
