### PR TITLE
Always show associated forecast projects for project tracker, even if associated with another

### DIFF
--- a/test/models/forecast_project_test.rb
+++ b/test/models/forecast_project_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class ForecastProjectTest < ActiveSupport::TestCase
+  test "#candidates_for_association_with_project_tracker returns already-associated forecast projects even if already associated with a separate project tracker" do
+    client = ForecastClient.create!
+
+    forecast_project = ForecastProject.create!({
+      id: 1,
+      forecast_client: client,
+      code: "ABCD-1",
+      data: {
+        archived: false
+      }
+    })
+
+    project_tracker_links = [
+      ProjectTrackerLink.new({
+        name: "SOW link",
+        url: "https://example.com",
+        link_type: "sow"
+      }),
+      ProjectTrackerLink.new({
+        name: "MSA link",
+        url: "https://example.com",
+        link_type: "msa"
+      })
+    ]
+
+    ProjectTracker.create!({
+      name: "Test project 1",
+      forecast_projects: [forecast_project],
+      project_tracker_links: project_tracker_links
+    })
+
+    newer_project_tracker = ProjectTracker.new({
+      name: "Test project 2",
+      forecast_projects: [forecast_project],
+      project_tracker_links: project_tracker_links
+    })
+
+    # For the purposes of this test, bypass the validation that prevents
+    # duplicate association of the same forecast project with multiple trackers.
+    newer_project_tracker.save(validate: false)
+
+    candidates = ForecastProject.candidates_for_association_with_project_tracker(newer_project_tracker)
+
+    assert_includes(candidates, forecast_project)
+  end
+end


### PR DESCRIPTION
## What does this do?
@mokaymokay and I ran into this issue while pairing on the Stacks codebase earlier today.

This PR fixes a display issue in the UI when editing an existing project tracker. Currently, if the same forecast project has been associated with multiple project trackers, its name will not be displayed in the dropdown for the forecast project section in any of the associated trackers (even though it's actually associated). This creates unnecessary confusion.

This should only affect historical projects, since [validation was added](https://github.com/sanctuarycomputer/stacks/commit/88a9b898#diff-3cb93ccd9020f2d8811df70c074671fffe775c67276f7a95717abf8aef63c978R73-R82) to prevent multiple trackers from being associated with the same forecast project code going forward.

I've redacted the project codes and names in the screenshots below, but you can view two examples of this in the wild (two project trackers referencing the same code) [here](https://stacks.garden3d.net/admin/project_trackers/43/edit) and [here](https://stacks.garden3d.net/admin/project_trackers/44/edit).

## Current behavior
![missing_forecast_projects](https://github.com/sanctuarycomputer/stacks/assets/34255985/8ec34edd-86b6-41f9-a4e3-68a5ae041080)

## Updated behavior
![forecast_projects_fixed](https://github.com/sanctuarycomputer/stacks/assets/34255985/ad996b09-c759-41b0-9a33-dd85ac975cca)

