### PR TITLE
[WIP] Update project COSR logic to read historical hourly costs for assignments

### DIFF
--- a/app/models/forecast_person.rb
+++ b/app/models/forecast_person.rb
@@ -2,6 +2,7 @@ class ForecastPerson < ApplicationRecord
   self.primary_key = "forecast_id"
   has_many :forecast_assignments, class_name: "ForecastAssignment", foreign_key: "person_id"
   has_one :admin_user, class_name: "AdminUser", foreign_key: "email", primary_key: "email"
+  has_many :forecast_person_cost_windows
 
   def missing_allocation_during_range_in_hours(start_of_range, end_of_range)
     missing =

--- a/app/models/forecast_person_cost_window.rb
+++ b/app/models/forecast_person_cost_window.rb
@@ -1,0 +1,3 @@
+class ForecastPersonCostWindow < ApplicationRecord
+  belongs_to :forecast_person
+end

--- a/db/migrate/20240304041442_create_forecast_person_cost_windows.rb
+++ b/db/migrate/20240304041442_create_forecast_person_cost_windows.rb
@@ -1,0 +1,17 @@
+class CreateForecastPersonCostWindows < ActiveRecord::Migration[6.0]
+  def change
+    create_table :forecast_person_cost_windows do |t|
+      t.references :forecast_person, null: false, foreign_key: {
+        primary_key: "forecast_id"
+      }, index: {
+        name: "idx_forecast_person_cost_windows_on_forecast_person_id"
+      }
+
+      t.date :started_at
+      t.date :ended_at
+      t.decimal :hourly_cost
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_01_29_013623) do
+ActiveRecord::Schema.define(version: 2024_03_04_041442) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -221,6 +221,16 @@ ActiveRecord::Schema.define(version: 2024_01_29_013623) do
     t.integer "updated_by_id"
     t.jsonb "data"
     t.index ["forecast_id"], name: "index_forecast_people_on_forecast_id", unique: true
+  end
+
+  create_table "forecast_person_cost_windows", force: :cascade do |t|
+    t.bigint "forecast_person_id", null: false
+    t.date "started_at"
+    t.date "ended_at"
+    t.decimal "hourly_cost"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["forecast_person_id"], name: "idx_forecast_person_cost_windows_on_forecast_person_id"
   end
 
   create_table "forecast_projects", force: :cascade do |t|
@@ -664,6 +674,7 @@ ActiveRecord::Schema.define(version: 2024_01_29_013623) do
   add_foreign_key "atc_periods", "admin_users"
   add_foreign_key "atc_periods", "project_trackers"
   add_foreign_key "finalizations", "reviews"
+  add_foreign_key "forecast_person_cost_windows", "forecast_people", primary_key: "forecast_id"
   add_foreign_key "full_time_periods", "admin_users"
   add_foreign_key "gifted_profit_shares", "admin_users"
   add_foreign_key "invoice_trackers", "admin_users"

--- a/lib/stacks/cost_of_services_rendered_calculator.rb
+++ b/lib/stacks/cost_of_services_rendered_calculator.rb
@@ -1,0 +1,52 @@
+class Stacks::CostOfServicesRenderedCalculator
+  def initialize(start_date:, end_date:, assignments:, cost_windows:, studios:)
+    @start_date = start_date
+    @end_date = end_date
+    @assignments = assignments
+    @cost_windows = cost_windows
+    @studios = studios
+  end
+
+  def calculate
+    (@start_date..@end_date).reduce({}) do |acc, date|
+      @assignments.each do |assignment|
+        hours = assignment.allocation_during_range_in_hours(
+          date,
+          date,
+          only_during_working_days = true
+        )
+
+        next if hours == 0
+
+        cost_window = @cost_windows.find do |cost_window|
+          next false unless cost_window.forecast_person_id == assignment.forecast_person.id
+          next false unless cost_window.started_at <= date && cost_window.ended_at >= date
+
+          true
+        end
+
+        next unless cost_window.present?
+
+        acc[date] ||= {}
+
+        studio = assignment.forecast_person.studio(@studios)
+
+        acc[date][studio.id] ||= {
+          total_hours: 0,
+          total_cost: 0,
+          assignment_costs: []
+        }
+
+        acc[date][studio.id][:total_hours] += hours
+        acc[date][studio.id][:total_cost] += hours * cost_window.hourly_cost
+        acc[date][studio.id][:assignment_costs].push({
+          forecast_assignment_id: assignment.forecast_id,
+          hourly_cost: cost_window.hourly_cost,
+          hours: hours
+        })
+      end
+
+      acc
+    end
+  end
+end

--- a/test/lib/cost_of_services_rendered_calculator_test.rb
+++ b/test/lib/cost_of_services_rendered_calculator_test.rb
@@ -1,0 +1,283 @@
+require "test_helper"
+
+class CostOfServicesRenderedCalculatorTest < ActiveSupport::TestCase
+  test "#calculate returns the expected data for a two-person project with cost windows changing midway through" do
+    start_date = Date.new(2024, 1, 1) # January 1st was a Monday.
+    end_date = Date.new(2024, 1, 10)
+
+    studio = Studio.create!({
+      name: "Sanctuary Computer",
+      accounting_prefix: "Development",
+      mini_name: "sc"
+    })
+
+    forecast_client = ForecastClient.create!
+
+    forecast_project = ForecastProject.create!({
+      id: 1,
+      name: "Test project",
+      forecast_client: forecast_client,
+      code: "ABCD-1",
+    })
+
+    user_one = AdminUser.create!({
+      email: "josh@sanctuary.computer",
+      password: "password",
+    })
+
+    user_two = AdminUser.create!({
+      email: "antijosh@sanctuary.computer",
+      password: "password",
+    })
+
+    person_one = ForecastPerson.create!({
+      forecast_id: "123",
+      roles: [studio.name],
+      email: user_one.email
+    })
+
+    person_two = ForecastPerson.create!({
+      forecast_id: "456",
+      roles: [studio.name],
+      email: user_two.email
+    })
+
+    FullTimePeriod.create!({
+      admin_user: user_one,
+      started_at: Date.new(2020, 1, 1),
+      ended_at: nil,
+      contributor_type: :five_day,
+      expected_utilization: 0.8
+    })
+
+    FullTimePeriod.create!({
+      admin_user: user_two,
+      started_at: Date.new(2020, 1, 1),
+      ended_at: nil,
+      contributor_type: :five_day,
+      expected_utilization: 0.8
+    })
+
+    ForecastAssignment.create!({
+      forecast_id: "111",
+      start_date: start_date,
+      end_date: start_date + 4.days,
+      forecast_person: person_one,
+      forecast_project: forecast_project
+    })
+
+    ForecastAssignment.create!({
+      forecast_id: "222",
+      start_date: start_date,
+      end_date: start_date + 4.days,
+      forecast_person: person_two,
+      forecast_project: forecast_project
+    })
+
+    ForecastAssignment.create!({
+      forecast_id: "333",
+      start_date: start_date + 1.week,
+      end_date: start_date + 1.week + 2.days,
+      forecast_person: person_one,
+      forecast_project: forecast_project
+    })
+
+    ForecastAssignment.create!({
+      forecast_id: "444",
+      start_date: start_date + 1.week,
+      end_date: start_date + 1.week + 2.days,
+      forecast_person: person_two,
+      forecast_project: forecast_project
+    })
+
+    ForecastPersonCostWindow.create!({
+      forecast_person: person_one,
+      started_at: start_date - 5.days,
+      ended_at: end_date - 5.days,
+      hourly_cost: 33
+    })
+
+    ForecastPersonCostWindow.create!({
+      forecast_person: person_two,
+      started_at: start_date - 5.days,
+      ended_at: end_date - 5.days,
+      hourly_cost: 44
+    })
+
+    ForecastPersonCostWindow.create!({
+      forecast_person: person_one,
+      started_at: start_date + 5.days,
+      ended_at: end_date + 5.days,
+      hourly_cost: 55
+    })
+
+    ForecastPersonCostWindow.create!({
+      forecast_person: person_two,
+      started_at: start_date + 5.days,
+      ended_at: end_date + 5.days,
+      hourly_cost: 66
+    })
+
+    all_assignments = [
+      *person_one.forecast_assignments,
+      *person_two.forecast_assignments
+    ]
+
+    calculator = Stacks::CostOfServicesRenderedCalculator.new(
+      start_date: start_date,
+      end_date: end_date,
+      assignments: all_assignments,
+      cost_windows: ForecastPersonCostWindow.all,
+      studios: Studio.all
+    )
+
+    cosr = calculator.calculate
+
+    assert_equal({
+      start_date => {
+        studio.id => {
+          total_hours: 16,
+          total_cost: 616,
+          assignment_costs: [
+            {
+              forecast_assignment_id: 111,
+              hourly_cost: 33,
+              hours: 8
+            },
+            {
+              forecast_assignment_id: 222,
+              hourly_cost: 44,
+              hours: 8
+            }
+          ]
+        }
+      },
+      start_date + 1.day => {
+        studio.id => {
+          total_hours: 16,
+          total_cost: 616,
+          assignment_costs: [
+            {
+              forecast_assignment_id: 111,
+              hourly_cost: 33,
+              hours: 8
+            },
+            {
+              forecast_assignment_id: 222,
+              hourly_cost: 44,
+              hours: 8
+            }
+          ]
+        }
+      },
+      start_date + 2.days => {
+        studio.id => {
+          total_hours: 16,
+          total_cost: 616,
+          assignment_costs: [
+            {
+              forecast_assignment_id: 111,
+              hourly_cost: 33,
+              hours: 8
+            },
+            {
+              forecast_assignment_id: 222,
+              hourly_cost: 44,
+              hours: 8
+            }
+          ]
+        }
+      },
+      start_date + 3.days => {
+        studio.id => {
+          total_hours: 16,
+          total_cost: 616,
+          assignment_costs: [
+            {
+              forecast_assignment_id: 111,
+              hourly_cost: 33,
+              hours: 8
+            },
+            {
+              forecast_assignment_id: 222,
+              hourly_cost: 44,
+              hours: 8
+            }
+          ]
+        }
+      },
+      start_date + 4.days => {
+        studio.id => {
+          total_hours: 16,
+          total_cost: 616,
+          assignment_costs: [
+            {
+              forecast_assignment_id: 111,
+              hourly_cost: 33,
+              hours: 8
+            },
+            {
+              forecast_assignment_id: 222,
+              hourly_cost: 44,
+              hours: 8
+            }
+          ]
+        }
+      },
+      start_date + 7.days => {
+        studio.id => {
+          total_hours: 16,
+          total_cost: 968,
+          assignment_costs: [
+            {
+              forecast_assignment_id: 333,
+              hourly_cost: 55,
+              hours: 8
+            },
+            {
+              forecast_assignment_id: 444,
+              hourly_cost: 66,
+              hours: 8
+            }
+          ]
+        }
+      },
+      start_date + 8.days => {
+        studio.id => {
+          total_hours: 16,
+          total_cost: 968,
+          assignment_costs: [
+            {
+              forecast_assignment_id: 333,
+              hourly_cost: 55,
+              hours: 8
+            },
+            {
+              forecast_assignment_id: 444,
+              hourly_cost: 66,
+              hours: 8
+            }
+          ]
+        }
+      },
+      start_date + 9.days => {
+        studio.id => {
+          total_hours: 16,
+          total_cost: 968,
+          assignment_costs: [
+            {
+              forecast_assignment_id: 333,
+              hourly_cost: 55,
+              hours: 8
+            },
+            {
+              forecast_assignment_id: 444,
+              hourly_cost: 66,
+              hours: 8
+            }
+          ]
+        }
+      }
+    }, cosr)
+  end
+end


### PR DESCRIPTION
**TLDR: We want to update COSR to use actual historical hourly costs, instead of average studio-wide costs. This is a WIP PR to get input on the direction I'm considering for this problem.**

The overall approach I'm using consists of:
- Creating a new `forecast_person_cost_windows` table. This is meant to contain historical snapshots of the effective hourly rate for each `ForecastPerson`. Right now I've set this up to be range-based, so any time someone's effective hourly cost changes (ie, skill tree band changes), we'll need to insert a new record into this table to reflect the new cost to the studio.
- Creating a new `CostOfServicesRenderedCalculator` utility class and passing it the necessary ingredients to calculate the daily costs for each `ForecastAssignment` during a given window of time.

Miscellaneous notes / caveats:
- This PR does *not* cover the actual insertion of records into the new `forecast_person_cost_windows` table. That happens out of band. I have some work done around this but I wanted to get some input on the larger direction before muddying the waters with that.
- This PR does *not* update any of the template logic to reflect these changes (eg, in the COSR explorer). Some changes there will be necessary because A) we'll no longer be able to show a topline cost/hr on the studio level like we do today and B) given the possibility that a person's cost/hr could change midway through the month, we'll need to potentially display multiple lines per person to reflect those different hourly costs. That's out of band for now.

I'll add additional notes inline explaining my thinking on various things.