### PR TITLE
Rename ATC to Project Lead and allow one Project Lead per studio

### DIFF
--- a/app/admin/project_trackers.rb
+++ b/app/admin/project_trackers.rb
@@ -13,7 +13,6 @@ ActiveAdmin.register ProjectTracker do
     :budget_low_end,
     :budget_high_end,
     :notes,
-    :atc_id,
     adhoc_invoice_trackers_attributes: [
       :id,
       :qbo_invoice_id,
@@ -35,9 +34,10 @@ ActiveAdmin.register ProjectTracker do
       :_destroy,
       :_edit
     ],
-    atc_periods_attributes: [
+    project_lead_periods_attributes: [
       :id,
       :admin_user_id,
+      :studio_id,
       :started_at,
       :ended_at,
       :_destroy,
@@ -69,13 +69,13 @@ ActiveAdmin.register ProjectTracker do
 
     def scoped_collection
       super.includes(
-        :atc_periods,
+        :project_lead_periods,
         :project_capsule,
         :project_tracker_forecast_projects,
         :forecast_projects,
         :adhoc_invoice_trackers,
       ).includes(
-        atc_periods: :admin_user,
+        project_lead_periods: :admin_user,
         adhoc_invoice_trackers: :qbo_invoice
       )
     end
@@ -153,11 +153,11 @@ ActiveAdmin.register ProjectTracker do
         span("No Forecast Project Connected", class: "pill error")
       end
     end
-    column :ATC do |resource|
-      if resource.current_atc.present?
-        resource.current_atc
+    column :project_leads do |resource|
+      if resource.current_project_leads.any?
+        resource.current_project_leads
       else
-        span("No ATC", class: "pill error")
+        span("No Project Leadsd", class: "pill error")
       end
     end
     column :project_safety_reps do |resource|
@@ -337,12 +337,13 @@ ActiveAdmin.register ProjectTracker do
       f.input :budget_low_end
       f.input :budget_high_end
 
-      f.has_many :atc_periods, heading: false, allow_destroy: true, new_record: 'Add an ATC' do |a|
+      f.has_many :project_lead_periods, heading: false, allow_destroy: true, new_record: 'Add a Project Lead' do |a|
         a.input :admin_user
+        a.input :studio
         a.input :started_at,
           hint: "Leave blank to default to the date of the first recorded hour"
         a.input :ended_at,
-          hint: "Leave blank unless this ATC role was passed off to another person"
+          hint: "Leave blank unless this role was passed off to another person"
       end
 
       f.has_many :project_safety_representative_periods, heading: false, allow_destroy: true, new_record: 'Add a Project Safety Rep' do |a|

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -4,7 +4,7 @@ class AdminUser < ApplicationRecord
   has_one :associates_award_agreement, dependent: :delete
   validate :all_but_latest_full_time_periods_are_closed?
 
-  has_many :atc_periods, dependent: :delete_all
+  has_many :project_lead_periods, dependent: :delete_all
   has_many :studio_coordinator_periods, dependent: :delete_all
 
   has_many :invoice_trackers, dependent: :nullify
@@ -297,11 +297,11 @@ class AdminUser < ApplicationRecord
     [psu_requirement_met_at, skill_band_met_at].max.to_date
   end
 
-  def atc_months
+  def project_lead_months
     # TODO: Take into account wether this user is active or not
-    atc_periods.reduce(0.0) do |acc, atcp|
+    project_lead_periods.reduce(0.0) do |acc, p|
       acc +=
-        (((atcp.period_ended_at || Date.today).to_time - atcp.period_started_at.to_time)/1.month.second)
+        (((p.period_ended_at || Date.today).to_time - p.period_started_at.to_time)/1.month.second)
     end
   end
 

--- a/app/models/project_lead_period.rb
+++ b/app/models/project_lead_period.rb
@@ -1,7 +1,7 @@
-# TODO: Delete this file and drop ATC Period Table after Project Lead Migration
-class AtcPeriod < ApplicationRecord
+class ProjectLeadPeriod < ApplicationRecord
   belongs_to :project_tracker
   belongs_to :admin_user
+  belongs_to :studio
   validate :does_not_overlap
   validate :ended_at_before_started_at?
 
@@ -14,17 +14,19 @@ class AtcPeriod < ApplicationRecord
   end
 
   def does_not_overlap
-    overlapping_atc_period =
-      project_tracker.atc_periods
-        .reject{|atcp| atcp.id.nil?}
-        .reject{|atcp| atcp == self}
-        .find{|atcp| self.overlaps?(atcp)}
-    if overlapping_atc_period.present?
-      errors.add(:admin_user, "Must not overlap with another ATC")
+    overlapping_project_lead_period =
+      project_tracker.project_lead_periods
+        .reject{|p| p.id.nil?}
+        .reject{|p| p == self}
+        .find{|p| self.overlaps?(p)}
+    if overlapping_project_lead_period.present?
+      errors.add(:admin_user, "Must not overlap with another Project Lead for this studio")
     end
   end
 
   def overlaps?(other)
+    return false if studio != other.studio
+
     period_started_at <= (other.period_ended_at || Date.today) &&
     other.period_started_at <= (period_ended_at || Date.today)
   end

--- a/app/models/project_tracker.rb
+++ b/app/models/project_tracker.rb
@@ -27,9 +27,8 @@ class ProjectTracker < ApplicationRecord
   has_many :forecast_projects, through: :project_tracker_forecast_projects
   accepts_nested_attributes_for :project_tracker_forecast_projects, allow_destroy: true
 
-  has_many :atc_periods, dependent: :delete_all
-  accepts_nested_attributes_for :atc_periods, allow_destroy: true
-  belongs_to :atc, class_name: "AdminUser", optional: true
+  has_many :project_lead_periods, dependent: :delete_all
+  accepts_nested_attributes_for :project_lead_periods, allow_destroy: true
 
   has_many :project_safety_representative_periods, dependent: :delete_all
   accepts_nested_attributes_for :project_safety_representative_periods, allow_destroy: true
@@ -203,13 +202,13 @@ class ProjectTracker < ApplicationRecord
     end
   end
 
-  def current_atc
-    current_atc_period.try(:admin_user)
+  def current_project_leads
+    current_project_lead_periods.map(&:admin_user)
   end
 
-  def current_atc_period
-    atc_periods.find do |atc_period|
-      atc_period.period_started_at <= Date.today && atc_period.period_ended_at.nil?
+  def current_project_lead_periods
+    project_lead_periods.select do |p|
+      p.period_started_at <= Date.today && p.period_ended_at.nil?
     end
   end
 

--- a/app/views/admin/admin_users/_show.html.erb
+++ b/app/views/admin/admin_users/_show.html.erb
@@ -47,7 +47,7 @@
         <p><strong>Met Associates Requirements At:</strong> <%= resource.met_associates_requirements_at.strftime("%B %d, %Y") %></p>
       <% end %>
       <p><strong>Projected PSU by EOY:</strong> <%= resource.projected_psu_by_eoy %></p>
-      <p><strong>ATC Months:</strong> <%= resource.atc_months.round(2) %></p>
+      <p><strong>Project Lead Months:</strong> <%= resource.project_lead_months.round(2) %></p>
       <p><strong>Studio Coordinator Months:</strong> <%= resource.studio_coordinator_months.round(2) %></p>
     </div>
   </div>

--- a/app/views/admin/project_trackers/_show.html.erb
+++ b/app/views/admin/project_trackers/_show.html.erb
@@ -167,10 +167,14 @@
 <div class="skill_tree_hint markdown-body" style="margin-top: 40px; margin-bottom:40px;">
   <%= sanitize RDiscount.new(@project_tracker.notes).to_html %>
 
-  <% if @project_tracker.current_atc.present? %>
-    <p style="margin-top:80px;"><strong>Project ATC: </strong><%= link_to @project_tracker.current_atc.email, admin_admin_user_path(@project_tracker.current_atc) %></p>
+  <% if @project_tracker.current_project_leads.any? %>
+    <p style="margin-top:80px;"><strong>Project Safety Reps: </strong>
+      <% @project_tracker.current_project_leads.each do |pl| %>
+        <%= link_to pl.email, admin_admin_user_path(pl) %>
+      <% end %>
+    </p>
   <% else %>
-    <span class="pill error">No ATC</span>
+    <span class="pill error">No Project Safety Reps</span>
   <% end %>
 
   <% if @project_tracker.current_project_safety_representatives.any? %>

--- a/app/views/admin/project_trackers/_show.html.erb
+++ b/app/views/admin/project_trackers/_show.html.erb
@@ -174,7 +174,7 @@
       <% end %>
     </p>
   <% else %>
-    <span class="pill error">No Project Safety Reps</span>
+    <span class="pill error">No Project Leads</span>
   <% end %>
 
   <% if @project_tracker.current_project_safety_representatives.any? %>

--- a/app/views/admin/systems/_show.html.erb
+++ b/app/views/admin/systems/_show.html.erb
@@ -108,8 +108,8 @@
                 The <strong><%= n.params[:subject].name %></strong> Project Tracker has not registered any new hours for over a month (and is not "ongoing"). Should it be marked as <span class="pill complete">Complete</span>?
               <% when :over_budget %>
                 The <strong><%= n.params[:subject].name %></strong> Project Tracker is <span class="pill over_budget">Over budget</span>. Can we support them?
-              <% when :no_atc %>
-                The <strong><%= n.params[:subject].name %></strong> Project Tracker has <span class="pill error">No ATC</span>.
+              <% when :no_project_lead %>
+                The <strong><%= n.params[:subject].name %></strong> Project Tracker has <span class="pill error">No Project Lead</span>.
               <% when :capsule_pending %>
                 The <strong><%= n.params[:subject].name %></strong> Project Tracker is currently <span class="pill capsule_pending">Capsule pending</span>. Let's finalize a project capsule?
               <% else %>

--- a/db/migrate/20240314200201_convert_atc_periods_to_pl_periods.rb
+++ b/db/migrate/20240314200201_convert_atc_periods_to_pl_periods.rb
@@ -1,0 +1,26 @@
+class ConvertAtcPeriodsToPlPeriods < ActiveRecord::Migration[6.0]
+  def change
+    create_table :project_lead_periods do |t|
+      t.references :project_tracker, null: false, foreign_key: true
+      t.references :admin_user, null: false, foreign_key: true
+      t.references :studio, null: false, foreign_key: true
+
+      t.date :started_at
+      t.date :ended_at
+
+      t.timestamps
+    end
+
+    AtcPeriod.all.each do |atcp|
+      raise "No Studio Present for this admin_user" if atcp.admin_user.studios.first.nil?
+      
+      ProjectLeadPeriod.create!({
+        project_tracker: atcp.project_tracker,
+        admin_user: atcp.admin_user,
+        studio: atcp.admin_user.studios.first,
+        started_at: atcp.started_at,
+        ended_at: atcp.ended_at
+      })
+    end
+  end
+end

--- a/db/migrate/20240314200201_convert_atc_periods_to_pl_periods.rb
+++ b/db/migrate/20240314200201_convert_atc_periods_to_pl_periods.rb
@@ -11,9 +11,7 @@ class ConvertAtcPeriodsToPlPeriods < ActiveRecord::Migration[6.0]
       t.timestamps
     end
 
-    AtcPeriod.all.each do |atcp|
-      raise "No Studio Present for this admin_user" if atcp.admin_user.studios.first.nil?
-      
+    AtcPeriod.all.each do |atcp|      
       ProjectLeadPeriod.create!({
         project_tracker: atcp.project_tracker,
         admin_user: atcp.admin_user,
@@ -22,5 +20,7 @@ class ConvertAtcPeriodsToPlPeriods < ActiveRecord::Migration[6.0]
         ended_at: atcp.ended_at
       })
     end
+
+    drop_table :atc_periods
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -115,17 +115,6 @@ ActiveRecord::Schema.define(version: 2024_03_14_200201) do
     t.index ["admin_user_id"], name: "index_associates_award_agreements_on_admin_user_id"
   end
 
-  create_table "atc_periods", force: :cascade do |t|
-    t.bigint "project_tracker_id", null: false
-    t.bigint "admin_user_id", null: false
-    t.date "started_at"
-    t.date "ended_at"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["admin_user_id"], name: "index_atc_periods_on_admin_user_id"
-    t.index ["project_tracker_id"], name: "index_atc_periods_on_project_tracker_id"
-  end
-
   create_table "budgets", force: :cascade do |t|
     t.string "name", null: false
     t.text "notes"
@@ -674,8 +663,6 @@ ActiveRecord::Schema.define(version: 2024_03_14_200201) do
   add_foreign_key "admin_user_racial_backgrounds", "admin_users"
   add_foreign_key "admin_user_racial_backgrounds", "racial_backgrounds"
   add_foreign_key "associates_award_agreements", "admin_users"
-  add_foreign_key "atc_periods", "admin_users"
-  add_foreign_key "atc_periods", "project_trackers"
   add_foreign_key "finalizations", "reviews"
   add_foreign_key "full_time_periods", "admin_users"
   add_foreign_key "gifted_profit_shares", "admin_users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_01_29_013623) do
+ActiveRecord::Schema.define(version: 2024_03_14_200201) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -417,6 +417,19 @@ ActiveRecord::Schema.define(version: 2024_01_29_013623) do
     t.index ["project_tracker_id"], name: "index_project_capsules_on_project_tracker_id"
   end
 
+  create_table "project_lead_periods", force: :cascade do |t|
+    t.bigint "project_tracker_id", null: false
+    t.bigint "admin_user_id", null: false
+    t.bigint "studio_id", null: false
+    t.date "started_at"
+    t.date "ended_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["admin_user_id"], name: "index_project_lead_periods_on_admin_user_id"
+    t.index ["project_tracker_id"], name: "index_project_lead_periods_on_project_tracker_id"
+    t.index ["studio_id"], name: "index_project_lead_periods_on_studio_id"
+  end
+
   create_table "project_safety_representative_periods", force: :cascade do |t|
     t.bigint "project_tracker_id", null: false
     t.bigint "admin_user_id", null: false
@@ -677,6 +690,9 @@ ActiveRecord::Schema.define(version: 2024_01_29_013623) do
   add_foreign_key "peer_reviews", "reviews"
   add_foreign_key "pre_profit_share_purchases", "admin_users"
   add_foreign_key "project_capsules", "project_trackers"
+  add_foreign_key "project_lead_periods", "admin_users"
+  add_foreign_key "project_lead_periods", "project_trackers"
+  add_foreign_key "project_lead_periods", "studios"
   add_foreign_key "project_safety_representative_periods", "admin_users"
   add_foreign_key "project_safety_representative_periods", "project_trackers"
   add_foreign_key "project_safety_representative_periods", "studios"

--- a/lib/stacks/notifications.rb
+++ b/lib/stacks/notifications.rb
@@ -88,7 +88,7 @@ class Stacks::Notifications
 
       active_project_trackers = ProjectTracker
         .includes([
-          :atc_periods,
+          :project_lead_periods,
           :adhoc_invoice_trackers,
           :forecast_projects
         ]).where(work_completed_at: nil)
@@ -97,8 +97,8 @@ class Stacks::Notifications
           :project_capsule
         ]).where.not(work_completed_at: nil)
 
-      project_trackers_no_atc = active_project_trackers.select do |pt|
-        pt.current_atc_period == nil
+      project_trackers_no_project_lead = active_project_trackers.select do |pt|
+        pt.current_project_leads.empty?
       end
 
       project_trackers_over_budget = active_project_trackers.select do |pt|
@@ -265,12 +265,12 @@ class Stacks::Notifications
         }
       end
 
-      project_trackers_no_atc.each do |pt|
+      project_trackers_no_project_lead.each do |pt|
         notifications << {
           subject: pt,
           type: :project_tracker,
           link: admin_project_tracker_path(pt),
-          error: :no_atc,
+          error: :no_project_lead,
           priority: 2
         }
       end


### PR DESCRIPTION
We used to call our Project Lead role an ATC (or Air Traffic Controller). This was silly because clients don't know what that means, and XXIX never really used it.

Info: https://twist.com/a/133876/ch/352129/t/5888058/

Also, Stacks historically only allowed a single ATC per project, but often there's a design PL & Dev PL. So know you can have one per studio.