### PR TITLE
feat: surface addl data for psu calculation

### DIFF
--- a/app/serializers/api/profit_share_pass_serializer.rb
+++ b/app/serializers/api/profit_share_pass_serializer.rb
@@ -6,6 +6,10 @@ class Api::ProfitSharePassSerializer < ActiveModel::Serializer
   :gross_expenses,
   :gross_payroll,
   :gross_revenue,
+  :gross_benefits,
+  :subcontractors,
+  :pre_spent,
+  :pre_spent_reinvestment,
   :internals_budget_multiplier,
   :projected_monthly_cost_of_doing_business,
   :total_psu_issued,
@@ -33,6 +37,22 @@ class Api::ProfitSharePassSerializer < ActiveModel::Serializer
   
   def gross_revenue
     object.snapshot&.dig("inputs", "actuals", "gross_revenue").to_f
+  end
+
+  def gross_benefits
+    object.snapshot&.dig("inputs", "actuals", "gross_benefits").to_f
+  end
+
+  def subcontractors
+    object.snapshot&.dig("inputs", "actuals", "gross_subcontractors").to_f
+  end
+
+  def pre_spent
+    object.snapshot&.dig("inputs", "pre_spent").to_f
+  end
+
+  def pre_spent_reinvestment
+    object.snapshot&.dig("inputs", "pre_spent_reinvestment").to_f
   end
   
   def internals_budget_multiplier


### PR DESCRIPTION
In recent years, our psu calculations have taken in more information. That's why the calculations for 2021, 2022, and 2023 were previously wrong in https://github.com/sanctuarycomputer/studio/pull/91.

This PR surfaces the missing information from the `api/profit_share_passes` endpoint.