### PR TITLE
[FEAT] Create system notifications for any Forecast cost windows that are flagged as needing review

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ group :test do
   gem 'capybara', '>= 2.15'
   gem 'selenium-webdriver'
   gem 'webdrivers'
+  gem 'mocha'
 end
 
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,6 +238,7 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)
+    mocha (2.0.0)
     msgpack (1.4.2)
     multi_json (1.15.0)
     multi_xml (0.6.0)
@@ -466,6 +467,7 @@ DEPENDENCIES
   intuit-oauth
   listen (~> 3.2)
   mini_portile2 (= 2.5.0)
+  mocha
   noticed (~> 1.5)
   omniauth-google-oauth2
   omniauth-rails_csrf_protection

--- a/app/models/forecast_person_cost_window.rb
+++ b/app/models/forecast_person_cost_window.rb
@@ -1,4 +1,8 @@
 class ForecastPersonCostWindow < ApplicationRecord
   belongs_to :forecast_person
   belongs_to :forecast_project
+
+  scope :needs_review, -> {
+    where(needs_review: true)
+  }
 end

--- a/app/views/admin/systems/_show.html.erb
+++ b/app/views/admin/systems/_show.html.erb
@@ -125,6 +125,8 @@
                 <strong><%= n.params[:subject].display_name %></strong> has multiple hourly rates (the first will be used).
               <% when :no_explicit_hourly_rate %>
                 <strong><%= n.params[:subject].display_name %></strong> does not have an explicit hourly rate (the Stacks default will be used).
+              <% when :person_missing_hourly_rate %>
+                <strong><%= n.params[:subject].email %></strong> does not have an hourly rate set for this project. Add an hourly rate for this user to the notes for the project in Forecast, eg: <em>"john.doe@example.com: $123.45"</em>
               <% else %>
                 Unknown Forecast Project Error
               <% end %>

--- a/lib/stacks/notifications.rb
+++ b/lib/stacks/notifications.rb
@@ -195,6 +195,17 @@ class Stacks::Notifications
         } if fp.has_no_explicit_hourly_rate?
       end
 
+      ForecastPersonCostWindow.needs_review.each do |cost_window|
+        notifications << {
+          # Deliberately set to the forecast person instead of the project:
+          subject: cost_window.forecast_person,
+          type: :forecast_project,
+          link: cost_window.forecast_project.edit_link,
+          error: :person_missing_hourly_rate,
+          priority: 1
+        }
+      end
+
       forecast_clients.each do |fc|
         notifications << {
           subject: fc,

--- a/test/lib/stacks/notifications_test.rb
+++ b/test/lib/stacks/notifications_test.rb
@@ -1,0 +1,76 @@
+require "test_helper"
+
+class ProjectTrackertTest < ActiveSupport::TestCase
+  test "#make_notifications! creates notifications for cost windows needing review" do
+    Stacks::Quickbooks.stubs(:fetch_all_customers).returns([])
+    Stacks::Team.stubs(:fetch_from_google_workspace).returns([])
+    Stacks::Forecast.any_instance.stubs(:people).returns({
+      "people" => []
+    })
+
+    Stacks::Notion.any_instance.stubs(:get_users).returns([])
+    Stacks::Availability.stubs(:load_allocations_from_notion).returns([[], []])
+
+    Stacks::Twist.any_instance.stubs(:get_workspace_users).returns(
+      Struct.new(:parsed_response).new([])
+    )
+
+    studio = Studio.create!({
+      name: "Sanctuary Computer",
+      accounting_prefix: "Development",
+      mini_name: "sc"
+    })
+
+    forecast_client = ForecastClient.create!
+
+    forecast_project = ForecastProject.create!({
+      id: 55,
+      name: "Test project",
+      forecast_client: forecast_client,
+      code: "ABCD-1",
+    })
+
+    person_one = ForecastPerson.create!({
+      forecast_id: "123",
+      roles: ["Subcontractor", studio.name],
+      email: "subcontractor-1@some-other-company.com"
+    })
+
+    person_two = ForecastPerson.create!({
+      forecast_id: "456",
+      roles: ["Subcontractor", studio.name],
+      email: "subcontractor-2@some-other-company.com"
+    })
+
+    ForecastPersonCostWindow.create!({
+      forecast_person: person_one,
+      forecast_project: forecast_project,
+      start_date: Date.today,
+      end_date: nil,
+      hourly_cost: 123,
+      needs_review: false
+    })
+
+    ForecastPersonCostWindow.create!({
+      forecast_person: person_two,
+      forecast_project: forecast_project,
+      start_date: Date.today,
+      end_date: nil,
+      hourly_cost: 0,
+      needs_review: true
+    })
+
+    Stacks::Notifications.make_notifications!
+
+    notification = Notification.all.find do |notification|
+      notification.params[:error] == :person_missing_hourly_rate
+    end
+
+    refute_nil(notification, "Expected notification not found")
+
+    assert_equal(notification.params[:type], :forecast_project)
+    assert_equal(notification.params[:subject].forecast_id, person_two.forecast_id)
+    assert_equal(notification.params[:priority], 1)
+    assert(notification.params[:link].end_with?("/projects/55/edit"))
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 require 'rails/test_help'
+require 'mocha/minitest'
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers


### PR DESCRIPTION
This PR builds on top of the cost window changes in https://github.com/sanctuarycomputer/stacks/pull/38. In that PR, we are flagging cost windows as `needs_review` if we are unable to calculate a cost for them.

This PR adds a query to the daily system notification creation cron to fetch all of the `needs_review` cost windows and generate system notifications for them.

I'm adding mocha as a dependency in order to stub out a lot of API adapter calls that the system notification creator makes, which are unnecessary for testing the cost window notifications specifically.