### PR TITLE
Add nightly cron for rebuilding all Forecast cost windows

### DIFF
--- a/lib/stacks/forecast_person_cost_window_syncer.rb
+++ b/lib/stacks/forecast_person_cost_window_syncer.rb
@@ -1,7 +1,6 @@
 class Stacks::ForecastPersonCostWindowSyncer
   HISTORICAL_SUBCONTRACTOR_RATES = {}
 
-
   def initialize(forecast_project:, forecast_person:, target_date:)
     @forecast_project = forecast_project
     @forecast_person = forecast_person
@@ -15,7 +14,10 @@ class Stacks::ForecastPersonCostWindowSyncer
     )
 
     max_end_date = @forecast_project.start_date || @target_date
-    cost_windows = @forecast_person.forecast_person_cost_windows
+    cost_windows = @forecast_person.forecast_person_cost_windows.filter do |cost_window|
+      cost_window.forecast_project == @forecast_project
+    end
+
     needs_new_cost_window = cost_windows.empty?
 
     cost_windows.each do |cost_window|

--- a/lib/tasks/stacks.rake
+++ b/lib/tasks/stacks.rake
@@ -87,7 +87,7 @@ namespace :stacks do
       Parallel.map(Studio.internal, in_threads: 2) { |s| s.generate_snapshot! }
       # Next, do reinvestment studios
       Parallel.map(Studio.reinvestment, in_threads: 2) { |s| s.generate_snapshot! }
-      # Finally, do client_services, which require data from internal studios 
+      # Finally, do client_services, which require data from internal studios
       # (and garden3d hides reinvestment data)
       Parallel.map(Studio.client_services, in_threads: 2) { |s| s.generate_snapshot! }
       # Now, generate project snapshots
@@ -109,5 +109,10 @@ namespace :stacks do
       puts e.backtrace
       Sentry.capture_exception(e)
     end
+  end
+
+  desc "Nightly cost window rebuild"
+  task :nightly_cost_window_rebuild => :environment do
+    Stacks::Forecast.new.sync_cost_windows!
   end
 end

--- a/test/lib/stacks/forecast_test.rb
+++ b/test/lib/stacks/forecast_test.rb
@@ -1,0 +1,104 @@
+require "test_helper"
+
+class Stacks::ForecastTest < ActiveSupport::TestCase
+  test "#sync_cost_windows! builds the expected cost windows for all projects" do
+    studio = Studio.create!({
+      name: "Sanctuary Computer",
+      accounting_prefix: "Development",
+      mini_name: "sc"
+    })
+
+    forecast_client = ForecastClient.create!
+
+    old_project = ForecastProject.create!({
+      id: 1,
+      name: "Old project",
+      forecast_client: forecast_client,
+      code: "ABCD-1",
+      start_date: Date.today - 1.year
+    })
+
+    new_project = ForecastProject.create!({
+      id: 2,
+      name: "Current project",
+      forecast_client: forecast_client,
+      code: "ABCD-2",
+      start_date: Date.today - 1.week
+    })
+
+    user = AdminUser.create!({
+      email: "josh@sanctuary.computer",
+      password: "password"
+    })
+
+    person_one = ForecastPerson.create!({
+      forecast_id: "123",
+      roles: [studio.name],
+      email: user.email
+    })
+
+    person_two = ForecastPerson.create!({
+      forecast_id: "456",
+      roles: [studio.name, "Subcontractor"],
+      email: "subcontractor@some-other-company.com"
+    })
+
+    FullTimePeriod.create!({
+      admin_user: user,
+      started_at: Date.new(2020, 1, 1),
+      ended_at: nil,
+      contributor_type: :five_day,
+      expected_utilization: 0.8
+    })
+
+    ForecastAssignment.create!({
+      forecast_id: "111",
+      start_date: old_project.start_date,
+      end_date: old_project.start_date + 20.days,
+      forecast_person: person_one,
+      forecast_project: old_project
+    })
+
+    ForecastAssignment.create!({
+      forecast_id: "222",
+      start_date: old_project.start_date,
+      end_date: old_project.start_date + 10.days,
+      forecast_person: person_two,
+      forecast_project: old_project
+    })
+
+    ForecastAssignment.create!({
+      forecast_id: "333",
+      start_date: new_project.start_date,
+      end_date: new_project.start_date + 20.days,
+      forecast_person: person_one,
+      forecast_project: new_project
+    })
+
+    ForecastAssignment.create!({
+      forecast_id: "444",
+      start_date: new_project.start_date,
+      end_date: new_project.start_date + 10.days,
+      forecast_person: person_two,
+      forecast_project: new_project
+    })
+
+    Stacks::Forecast.new.sync_cost_windows!
+
+    cost_window_attributes = ForecastPersonCostWindow.pluck(
+      :forecast_person_id,
+      :forecast_project_id,
+      :start_date,
+      :end_date,
+      :hourly_cost,
+      :needs_review
+    )
+
+    assert_equal([
+      [123, 1, old_project.start_date, nil, 70.89, false],
+      [456, 1, old_project.start_date, nil, 0, true],
+      [123, 2, new_project.start_date, nil, 70.61, false],
+      [456, 2, new_project.start_date, nil, 0, true]
+    ], cost_window_attributes)
+  end
+end


### PR DESCRIPTION
This builds on top of the cost windows scaffolding added in https://github.com/sanctuarycomputer/stacks/pull/38.

This PR adds a new maintenance task that we can trigger nightly in order to rebuild all of our historical Forecast cost windows. @hhff and I discussed this in the above PR and decided that this is the best approach for ensuring accurate data: by recreating all of the cost windows on a daily basis, we will catch and correct past situations where the costs for a given forecast person may have changed over time:
- Compensation changes from skill tree updates
- Hourly contractor rates being added to the `notes` field on a Forecast project
- Cases where a Forecast project or person is deleted in Forecast
- etc