### PR TITLE
Adds Role Explorer

### DIFF
--- a/app/admin/roles_explorer.rb
+++ b/app/admin/roles_explorer.rb
@@ -1,0 +1,46 @@
+ActiveAdmin.register_page "Roles Explorer" do
+  menu label: "Roles Explorer", parent: "Team"
+
+  content title: proc { I18n.t("active_admin.roles_explorer") } do
+    # Right now, this is hardcoded as a Project Lead role explorer, but in the future it will include
+    # UI to explore Technical Lead, Creative Lead & Project Safety Lead role holders.
+
+    admin_users_by_pl_role_last_held =
+      AdminUser.active.core.sort { |a,b| b.time_in_days_since_last_project_lead_role <=> a.time_in_days_since_last_project_lead_role }
+
+    plp_sorted_by_ended_at =
+      ProjectLeadPeriod.all.sort { |a,b| b.period_ended_at <=> a.period_ended_at }
+
+    h2 "Team by Last Held Project Lead Role"
+    table_for(admin_users_by_pl_role_last_held, class: 'index_table') do
+      column "Admin User", :admin_user do |admin_user|
+        admin_user
+      end
+      column "Studios", :studios
+      column "Time in days since last Project Lead role", :time_in_days_since_last_project_lead_role do |admin_user|
+        time_in_days = admin_user.time_in_days_since_last_project_lead_role
+        if time_in_days.infinite?
+          "Never held"
+        else
+          "#{time_in_days} days"
+        end
+      end
+    end
+
+    h2 "All Project Lead Role Holders"
+    table_for(plp_sorted_by_ended_at, class: 'index_table') do
+      column "Admin User", :admin_user
+      column "Studio", :studio
+      column "Project Tracker", :project_tracker
+      column "Current?", :current? do |plp|
+        plp.period_ended_at >= Date.today - 14.days
+      end
+      column "Started At", :period_started_at
+      column "Ended At", :period_ended_at
+      column "Time Held", :time_held_in_days do |plp|
+        time_held_in_days = plp.time_held_in_days
+        "#{time_held_in_days} days"
+      end
+    end
+  end
+end

--- a/app/admin/roles_explorer.rb
+++ b/app/admin/roles_explorer.rb
@@ -17,13 +17,16 @@ ActiveAdmin.register_page "Roles Explorer" do
         admin_user
       end
       column "Studios", :studios
-      column "Time in days since last Project Lead role", :time_in_days_since_last_project_lead_role do |admin_user|
+      column "Time in days since role last held", :time_in_days_since_role_last_held do |admin_user|
         time_in_days = admin_user.time_in_days_since_last_project_lead_role
         if time_in_days.infinite?
           "Never held"
         else
           "#{time_in_days} days"
         end
+      end
+      column "Aggregate time spent holding role", :aggregate_time_spent_holding_role do |admin_user|
+        "#{admin_user.total_time_in_days_holding_project_lead_role} days"
       end
     end
 

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -304,11 +304,16 @@ class AdminUser < ApplicationRecord
     [psu_requirement_met_at, skill_band_met_at].max.to_date
   end
 
+  def time_in_days_since_last_project_lead_role
+    return Float::INFINITY if project_lead_periods.empty?
+    (Date.today - project_lead_periods.map(&:period_ended_at).max).to_i
+  end
+
   def project_lead_months
     # TODO: Take into account wether this user is active or not
     project_lead_periods.reduce(0.0) do |acc, p|
       acc +=
-        (((p.period_ended_at || Date.today).to_time - p.period_started_at.to_time)/1.month.second)
+        (((p.period_ended_at).to_time - p.period_started_at.to_time)/1.month.second)
     end
   end
 

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -309,6 +309,12 @@ class AdminUser < ApplicationRecord
     (Date.today - project_lead_periods.map(&:period_ended_at).max).to_i
   end
 
+  def total_time_in_days_holding_project_lead_role
+    project_lead_periods.reduce(0) do |acc, plp|
+      acc += (plp.period_ended_at - plp.period_started_at).to_i
+    end
+  end
+
   def project_lead_months
     # TODO: Take into account wether this user is active or not
     project_lead_periods.reduce(0.0) do |acc, p|

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -311,7 +311,7 @@ class AdminUser < ApplicationRecord
 
   def total_time_in_days_holding_project_lead_role
     project_lead_periods.reduce(0) do |acc, plp|
-      acc += (plp.period_ended_at - plp.period_started_at).to_i
+      acc += plp.time_held_in_days
     end
   end
 

--- a/app/models/project_lead_period.rb
+++ b/app/models/project_lead_period.rb
@@ -6,11 +6,15 @@ class ProjectLeadPeriod < ApplicationRecord
   validate :ended_at_before_started_at?
 
   def period_started_at
-    started_at || (project_tracker.first_recorded_assignment && project_tracker.first_recorded_assignment.start_date) || Date.today
+    started_at || project_tracker.first_recorded_assignment&.start_date || Date.today
   end
 
   def period_ended_at
-    ended_at
+    ended_at || project_tracker.last_recorded_assignment&.end_date || Date.today
+  end
+
+  def time_held_in_days
+    (period_ended_at - period_started_at).to_i
   end
 
   def does_not_overlap
@@ -27,8 +31,8 @@ class ProjectLeadPeriod < ApplicationRecord
   def overlaps?(other)
     return false if studio != other.studio
 
-    period_started_at <= (other.period_ended_at || Date.today) &&
-    other.period_started_at <= (period_ended_at || Date.today)
+    period_started_at <= (other.ended_at || Date.today) &&
+    other.period_started_at <= (ended_at || Date.today)
   end
 
   def ended_at_before_started_at?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,7 @@
 
 en:
   active_admin:
+    roles_explorer: "Roles Explorer"
     retention_explorer: "Retention Explorer"
     skill_filter: "Skill Filter"
     dei_explorer: "DEI Explorer"


### PR DESCRIPTION
A DEI concern recently was that the PL role is not always distributed equitably (there was a concern that it's gendered, for the record I don't think that's the case, I believe the PL role is usually given to our most accountable people, which provides them further career growth opportunities, a genuine & positive glowup), I wanted to give our team a tool so that we could ensure that we are spreading this responsibility out fairly. 

See these Notion tasks:
- [Introduce a system to ensure we know who is a competent PL and who’s had the longest period since last holding an PL role](https://www.notion.so/garden3d/Introduce-a-system-to-ensure-we-know-who-is-a-competent-PL-and-who-s-had-the-longest-period-since-la-510405a32b48469da618c606036b878e)
- [Consolidate DEI concerns around PL assignments](https://www.notion.so/garden3d/Consolidate-DEI-concerns-around-PL-assignments-a6edd93819ba40caae03b233d8c7970f)

# Preview of how it looks

<img width="1840" alt="image" src="https://github.com/sanctuarycomputer/stacks/assets/2865404/5d57a963-53ce-4a67-9beb-724acc61d72e">

<img width="1840" alt="image" src="https://github.com/sanctuarycomputer/stacks/assets/2865404/a835dc20-9df4-4e27-b8ed-4e0f5c1e6699">

