### PR TITLE
Adds table for project lead roles on Admins#Show

### DIFF
--- a/app/admin/roles_explorer.rb
+++ b/app/admin/roles_explorer.rb
@@ -35,14 +35,11 @@ ActiveAdmin.register_page "Roles Explorer" do
       column "Admin User", :admin_user
       column "Studio", :studio
       column "Project Tracker", :project_tracker
-      column "Current?", :current? do |plp|
-        plp.period_ended_at >= Date.today - 14.days
-      end
+      column "Current?", :current?
       column "Started At", :period_started_at
       column "Ended At", :period_ended_at
       column "Time Held", :time_held_in_days do |plp|
-        time_held_in_days = plp.time_held_in_days
-        "#{time_held_in_days} days"
+        "#{plp.time_held_in_days} days"
       end
     end
   end

--- a/app/models/project_lead_period.rb
+++ b/app/models/project_lead_period.rb
@@ -17,6 +17,10 @@ class ProjectLeadPeriod < ApplicationRecord
     (period_ended_at - period_started_at).to_i
   end
 
+  def current?
+    period_ended_at >= Date.today - 14.days
+  end
+
   def does_not_overlap
     overlapping_project_lead_period =
       project_tracker.project_lead_periods

--- a/app/views/admin/admin_users/_show.html.erb
+++ b/app/views/admin/admin_users/_show.html.erb
@@ -53,6 +53,52 @@
   </div>
 </div>
 
+<div class="title_bar" id="title_bar" style="padding: 80px 0px 20px 0px;">
+  <div id="titlebar_left">
+    <h2 id="page_title">📏 Project Lead Roles</h2>
+  </div>
+</div>
+<table border="0" cellspacing="0" cellpadding="0" class="index_table index mb2">
+  <thead>
+    <tr>
+      <th class="col">Studio</th>
+      <th class="col">Project Tracker</th>
+      <th class="col">Current?</th>
+      <th class="col">Started At</th>
+      <th class="col">Ended At</th>
+      <th class="col text-right">Time Held in Days</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% resource.project_lead_periods.each_with_index do |plp, index| %>
+      <tr class="<%= index.even? ? "even" : "odd" %>">
+        <td class="col">
+          <%= link_to plp.studio.name, admin_studio_path(plp.studio) %>
+        </td>
+        <td class="col">
+          <%= link_to plp.project_tracker.name, admin_project_tracker_path(plp.project_tracker) %>
+        </td>
+        <td class="col">
+          <% if plp.current? %>
+            <span class="status_tag yes">Yes</span>
+          <% else %>
+            <span class="status_tag no">No</span>
+          <% end %>
+        </td>
+        <td class="col">
+          <%= plp.period_started_at.strftime("%B %d, %Y") %>
+        </td>
+        <td class="col">
+          <%= plp.period_ended_at.strftime("%B %d, %Y") %>
+        </td>
+        <td class="col text-right">
+          <%= plp.time_held_in_days %> days
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
 <!-- Profit Share -->
 
 <div class="title_bar" id="title_bar" style="padding: 80px 0px 20px 0px;">


### PR DESCRIPTION
In order to support a system where Project Leads would be gifted additional profit share units, we need to give users a way to properly see all of the roles they've historically held. That's what this is for!

<img width="1840" alt="image" src="https://github.com/sanctuarycomputer/stacks/assets/2865404/f4bb24f0-f335-4d8c-87a5-50da9e959fbb">
