### PR TITLE
Don't render raw_resourcing_cost as a HTML comment

### DIFF
--- a/app/admin/project_trackers.rb
+++ b/app/admin/project_trackers.rb
@@ -107,13 +107,13 @@ ActiveAdmin.register ProjectTracker do
     end
 
     column :name
-    
+
     column :hours do |resource|
       free_hours = resource.total_free_hours
       total_hours = resource.total_hours
       free_hours_percentage = resource.free_hours_ratio * 100
 
-      pill_class = 
+      pill_class =
         if free_hours_percentage == 0
           "exceptional"
         elsif free_hours_percentage < 1

--- a/app/views/admin/project_trackers/_show.html.erb
+++ b/app/views/admin/project_trackers/_show.html.erb
@@ -87,14 +87,14 @@
 
         <table border="0" cellspacing="0" cellpadding="0" class="index_table index">
           <tbody>
-            <!--
-            <tr class="odd">
-              <td class="col"><strong>Raw Resourcing Cost</strong></td>
-              <td class="col text-right">
-                <%= number_to_currency(@project_tracker.raw_resourcing_cost) %>
-              </td>
-            </tr>
-            -->
+            <% if false %>
+              <tr class="odd">
+                <td class="col"><strong>Raw Resourcing Cost</strong></td>
+                <td class="col text-right">
+                  <%= number_to_currency(@project_tracker.raw_resourcing_cost) %>
+                </td>
+              </tr>
+            <% end %>
             <tr class="even">
               <td class="col"><%= link_to "Estimated COSR ↗", admin_project_tracker_project_cosr_explorer_path(@project_tracker) %></td>
               <td class="col text-right">


### PR DESCRIPTION
This fixes an issue with project show pages timing out when they're in the Project Capsule state, [turns out HTML comments are still rendered into ERB](https://stackoverflow.com/questions/8514946/how-do-i-comment-out-erb-in-rails#comment10542147_8514955) so this calculation was still happening but not being shown in the UI