### PR TITLE
[FEAT] Add AdminUserSalaryWindow model, for storing historical employee salaries

### DIFF
--- a/app/models/admin_user_salary_window.rb
+++ b/app/models/admin_user_salary_window.rb
@@ -1,0 +1,3 @@
+class AdminUserSalaryWindow < ApplicationRecord
+  belongs_to :admin_user
+end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -134,5 +134,14 @@ class Review < ApplicationRecord
     workspace.sync!
     peer_reviews.each{|pr| pr.workspace.sync!}
     finalization.workspace.sync!
+
+    if archived?
+      sync_salary_windows!
+    end
+  end
+
+  def sync_salary_windows!
+    syncer = Stacks::AdminUserSalaryWindowSyncer.new(self.admin_user)
+    syncer.sync!
   end
 end

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -53,7 +53,7 @@ development:
   compile: true
 
   # Verifies that correct packages and versions are installed by inspecting package.json, yarn.lock, and node_modules
-  check_yarn_integrity: true
+  check_yarn_integrity: false
 
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:

--- a/db/migrate/20240521155122_create_admin_user_salary_windows.rb
+++ b/db/migrate/20240521155122_create_admin_user_salary_windows.rb
@@ -1,0 +1,11 @@
+class CreateAdminUserSalaryWindows < ActiveRecord::Migration[6.0]
+  def change
+    create_table :admin_user_salary_windows do |t|
+      t.references :admin_user, null: false, index: true, foreign_key: true
+      t.decimal :salary, null: false
+      t.date :start_date, null: false
+      t.date :end_date
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_05_20_174007) do
+ActiveRecord::Schema.define(version: 2024_05_21_155122) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,6 +81,16 @@ ActiveRecord::Schema.define(version: 2024_05_20_174007) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["admin_user_id"], name: "index_admin_user_racial_backgrounds_on_admin_user_id"
     t.index ["racial_background_id"], name: "index_admin_user_racial_backgrounds_on_racial_background_id"
+  end
+
+  create_table "admin_user_salary_windows", force: :cascade do |t|
+    t.bigint "admin_user_id", null: false
+    t.decimal "salary", null: false
+    t.date "start_date", null: false
+    t.date "end_date"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["admin_user_id"], name: "index_admin_user_salary_windows_on_admin_user_id"
   end
 
   create_table "admin_users", force: :cascade do |t|
@@ -695,6 +705,7 @@ ActiveRecord::Schema.define(version: 2024_05_20_174007) do
   add_foreign_key "admin_user_interests", "interests"
   add_foreign_key "admin_user_racial_backgrounds", "admin_users"
   add_foreign_key "admin_user_racial_backgrounds", "racial_backgrounds"
+  add_foreign_key "admin_user_salary_windows", "admin_users"
   add_foreign_key "associates_award_agreements", "admin_users"
   add_foreign_key "finalizations", "reviews"
   add_foreign_key "full_time_periods", "admin_users"

--- a/lib/stacks/admin_user_salary_window_syncer.rb
+++ b/lib/stacks/admin_user_salary_window_syncer.rb
@@ -1,0 +1,71 @@
+class Stacks::AdminUserSalaryWindowSyncer
+  def initialize(admin_user)
+    @admin_user = admin_user
+  end
+
+  def sync!
+    Rails.logger.info("Syncing salary windows for #{@admin_user.display_name}...")
+
+    result = target_dates.reduce({
+      windows: [],
+      last_window: nil
+    }) do |acc, date|
+      salary = salary_on_date(date)
+
+      if acc[:last_window].present?
+        next acc if acc[:last_window][:salary] == salary
+
+        acc[:last_window][:end_date] = date - 1.day
+      end
+
+      new_window = {
+        admin_user_id: @admin_user.id,
+        salary: salary,
+        start_date: date,
+        end_date: nil,
+        created_at: Date.today,
+        updated_at: Date.today
+      }
+
+      acc[:windows] << new_window
+      acc[:last_window] = new_window
+
+      acc
+    end
+
+    ActiveRecord::Base.transaction do
+      @admin_user.admin_user_salary_windows.delete_all
+      AdminUserSalaryWindow.upsert_all(result[:windows])
+    end
+  end
+
+  private
+
+  def target_dates
+    [
+      @admin_user.start_date,
+      *@admin_user.full_time_periods.map(&:started_at),
+      *@admin_user.archived_reviews.map(&:archived_at),
+      *Stacks::SkillLevelFinder.effective_dates
+    ].uniq.sort.filter do |date|
+      date >= @admin_user.start_date
+    end
+  end
+
+  def salary_on_date(date)
+    level = @admin_user.skill_tree_level_on_date(date)
+    level[:salary] * weekly_utilization_rate(date)
+  end
+
+  def weekly_utilization_rate(date)
+    ftp = @admin_user.full_time_periods.find do |ftp|
+      ftp.include?(date)
+    end
+
+    if ftp.blank?
+      return 1
+    end
+
+    ftp.contributor_type == "four_day" ? 0.8 : 1
+  end
+end

--- a/lib/stacks/skill_level_finder.rb
+++ b/lib/stacks/skill_level_finder.rb
@@ -7,6 +7,10 @@ class Stacks::SkillLevelFinder
     self.new(date).find!(key)
   end
 
+  def self.effective_dates
+    LEVELS_BY_DATE.keys
+  end
+
   def initialize(date)
     @date = date
   end

--- a/lib/tasks/stacks.rake
+++ b/lib/tasks/stacks.rake
@@ -149,4 +149,13 @@ namespace :stacks do
       Sentry.capture_exception(e)
     end
   end
+
+  desc "Resync salary windows"
+  task :resync_salary_windows => :environment do
+    begin
+      AdminUser.all.each(&:sync_salary_windows!)
+    rescue => e
+      Sentry.capture_exception(e)
+    end
+  end
 end

--- a/test/lib/stacks/admin_user_cost_window_syncer_test.rb
+++ b/test/lib/stacks/admin_user_cost_window_syncer_test.rb
@@ -1,0 +1,222 @@
+require 'test_helper'
+
+class Stacks::AdminUserCostWindowSyncerTest < ActiveSupport::TestCase
+  test "It builds the expected salary window using the default skill level for a user without any archived reviews" do
+    user = AdminUser.create!({
+      created_at: Date.today - 5.days,
+      email: "josh@sanctuary.computer",
+      password: "password"
+    })
+
+    syncer = Stacks::AdminUserSalaryWindowSyncer.new(user)
+    syncer.sync!
+
+    assert_salary_windows(user, [
+      {
+        admin_user_id: user.id,
+        salary: BigDecimal("107231.25"),
+        start_date: Date.today - 5.days,
+        end_date: nil
+      }
+    ])
+  end
+
+  test "It builds the expected salary window using the old skill level for a user without any archived reviews" do
+    user = AdminUser.create!({
+      created_at: Date.today - 5.days,
+      old_skill_tree_level: :experienced_mid_level_1,
+      email: "josh@sanctuary.computer",
+      password: "password"
+    })
+
+    syncer = Stacks::AdminUserSalaryWindowSyncer.new(user)
+    syncer.sync!
+
+    assert_salary_windows(user, [
+      {
+        admin_user_id: user.id,
+        salary: BigDecimal(84000),
+        start_date: Date.today - 5.days,
+        end_date: nil
+      }
+    ])
+  end
+
+  test "It builds the expected salary windows for a user with an archived review" do
+    user = AdminUser.create!({
+      created_at: Date.today - 1.year,
+      old_skill_tree_level: :experienced_mid_level_1,
+      email: "josh@sanctuary.computer",
+      password: "password"
+    })
+
+    create_review!(user, Date.today - 6.months)
+
+    Review.any_instance.stubs(:total_points).returns(630)
+
+    syncer = Stacks::AdminUserSalaryWindowSyncer.new(user)
+    syncer.sync!
+
+    assert_salary_windows(user, [
+      {
+        admin_user_id: user.id,
+        salary: BigDecimal(84000),
+        start_date: Date.today - 1.year,
+        end_date: Date.today - 6.months - 1.day
+      },
+      {
+        admin_user_id: user.id,
+        salary: BigDecimal("107231.25"),
+        start_date: Date.today - 6.months,
+        end_date: nil
+      }
+    ])
+  end
+
+  test "It does not build multiple windows for adjacent matching time periods" do
+    user = AdminUser.create!({
+      created_at: Date.today - 1.year,
+      old_skill_tree_level: :experienced_mid_level_1,
+      email: "josh@sanctuary.computer",
+      password: "password"
+    })
+
+    create_review!(user, Date.today - 6.months)
+    # No salary window will be created for this duplicate review period:
+    create_review!(user, Date.today - 3.months)
+
+    Review.any_instance.stubs(:total_points).returns(630)
+
+    syncer = Stacks::AdminUserSalaryWindowSyncer.new(user)
+    syncer.sync!
+
+    assert_salary_windows(user, [
+      {
+        admin_user_id: user.id,
+        salary: BigDecimal(84000),
+        start_date: Date.today - 1.year,
+        end_date: Date.today - 6.months - 1.day
+      },
+      {
+        admin_user_id: user.id,
+        salary: BigDecimal("107231.25"),
+        start_date: Date.today - 6.months,
+        end_date: nil
+      }
+    ])
+  end
+
+  test "It creates distinct windows for the user if the contributor type changes for adjacent full-time periods" do
+    user = AdminUser.create!({
+      created_at: Date.today - 1.year,
+      old_skill_tree_level: :experienced_mid_level_1,
+      email: "josh@sanctuary.computer",
+      password: "password"
+    })
+
+    user.full_time_periods.create!({
+      started_at: Date.today - 1.year,
+      ended_at: Date.today - 6.months - 1.day,
+      contributor_type: :five_day
+    })
+
+    user.full_time_periods.create!({
+      started_at: Date.today - 6.months,
+      contributor_type: :four_day
+    })
+
+    syncer = Stacks::AdminUserSalaryWindowSyncer.new(user)
+    syncer.sync!
+
+    assert_salary_windows(user, [
+      {
+        admin_user_id: user.id,
+        salary: BigDecimal(84000),
+        start_date: Date.today - 1.year,
+        end_date: Date.today - 6.months - 1.day
+      },
+      {
+        admin_user_id: user.id,
+        salary: BigDecimal(67200),
+        start_date: Date.today - 6.months,
+        end_date: nil
+      }
+    ])
+  end
+
+  test "It creates distinct windows for the user based on the time ranges of company-wide salary changes" do
+    user = AdminUser.create!({
+      created_at: Date.new(2020, 1, 1),
+      old_skill_tree_level: :senior_4,
+      email: "josh@sanctuary.computer",
+      password: "password"
+    })
+
+    syncer = Stacks::AdminUserSalaryWindowSyncer.new(user)
+    syncer.sync!
+
+    assert_salary_windows(user, [
+      {
+        admin_user_id: user.id,
+        salary: BigDecimal(110000),
+        start_date: Date.new(2020, 1, 1),
+        end_date: Date.new(2021, 12, 7)
+      },
+      {
+        admin_user_id: user.id,
+        salary: BigDecimal(115500),
+        start_date: Date.new(2021, 12, 8),
+        end_date: Date.new(2022, 7, 4)
+      },
+      {
+        admin_user_id: user.id,
+        salary: BigDecimal("141487.5"),
+        start_date: Date.new(2022, 7, 5),
+        end_date: nil
+      }
+    ])
+  end
+
+  test "It does not create distinct windows for the user across company-wide salary changes if the user's salary did not explicitly change as a result" do
+    user = AdminUser.create!({
+      created_at: Date.new(2022, 1, 1),
+      old_skill_tree_level: :junior_1,
+      email: "josh@sanctuary.computer",
+      password: "password"
+    })
+
+    syncer = Stacks::AdminUserSalaryWindowSyncer.new(user)
+    syncer.sync!
+
+    assert_salary_windows(user, [
+      {
+        admin_user_id: user.id,
+        salary: BigDecimal(63000),
+        start_date: Date.new(2022, 1, 1),
+        end_date: nil
+      }
+    ])
+  end
+
+  private
+
+  def assert_salary_windows(admin_user, expected_windows)
+    actual_windows = admin_user.admin_user_salary_windows.reload.map do |salary_window|
+      salary_window.attributes.symbolize_keys.slice(:admin_user_id, :salary, :start_date, :end_date)
+    end
+
+    assert_equal(expected_windows, actual_windows)
+  end
+
+  def create_review!(admin_user, archived_at)
+    review = admin_user.reviews.create!
+
+    review.finalization.workspace.update!({
+      status: "complete"
+    })
+
+    review.update!({
+      archived_at: archived_at
+    })
+  end
+end

--- a/test/models/admin_user_test.rb
+++ b/test/models/admin_user_test.rb
@@ -418,4 +418,24 @@ class AdminUserTest < ActiveSupport::TestCase
       salary: 107231.25
     }, AdminUser.default_skill_level)
   end
+
+  test "It creates the user's initial salary window on create" do
+    admin_user = AdminUser.create!({
+      email: "josh@sanctuary.computer",
+      password: "password"
+    })
+
+    actual_windows = admin_user.admin_user_salary_windows.reload.map do |salary_window|
+      salary_window.attributes.symbolize_keys.slice(:admin_user_id, :salary, :start_date, :end_date)
+    end
+
+    assert_equal([
+      {
+        admin_user_id: admin_user.id,
+        salary: BigDecimal("107231.25"),
+        start_date: Date.today,
+        end_date: nil
+      }
+    ], actual_windows)
+  end
 end

--- a/test/models/full_time_period_test.rb
+++ b/test/models/full_time_period_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class FullTimePeriodTest < ActiveSupport::TestCase
+  test "#include? returns true for dates that are within the specified period" do
+    period = FullTimePeriod.new({
+      started_at: Date.today - 1.year,
+      ended_at: Date.today - 6.months
+    })
+
+    assert period.include?(Date.today - 9.months)
+  end
+
+  test "#include? returns false for dates that are before the specified period" do
+    period = FullTimePeriod.new({
+      started_at: Date.today - 1.year,
+      ended_at: Date.today - 6.months
+    })
+
+    refute period.include?(Date.today - 2.years)
+  end
+
+  test "#include? returns false for dates that are after the specified period" do
+    period = FullTimePeriod.new({
+      started_at: Date.today - 1.year,
+      ended_at: Date.today - 6.months
+    })
+
+    refute period.include?(Date.today)
+  end
+
+  test "#include? returns true for dates that fall after the start date, and the period does not have an end date" do
+    period = FullTimePeriod.new({
+      started_at: Date.today - 1.year
+    })
+
+    assert period.include?(Date.today)
+  end
+end


### PR DESCRIPTION
@hhff and I had a good discussion via Twist where we reevaluated the technical direction for solving Cost of Services Rendered. We agreed on the following:
- We should be able to execute a single SQL query to determine the cost to the company on a particular date (for a project, or a person, or across all projects or persons). This will be done using a new rollup table that stores daily costs.
- We should record people's historical salaries. That way, when we're building up the daily costs table, we can just pull their salaries from the date in question.

This PR address the second bullet. It adds a new `admin_user_salary_windows` table to the database, and creates a new syncing utility to recreate their historical salary windows under certain conditions. The conditions are:
- When an `AdminUser` is created
- When a skill tree review is archived (ie, it goes into effect, potentially changing their salary)

Each time the syncer is run, we delete all of the previously recorded salary windows for that person, and create them anew.