### PR TITLE
[FEAT] Encapsulate skill level lookup in new SkillLevelFinder class, and record historical skill level changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ group :test do
   gem 'capybara', '>= 2.15'
   gem 'selenium-webdriver'
   gem 'webdrivers'
+  gem 'mocha'
 end
 
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,6 +238,7 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)
+    mocha (2.0.0)
     msgpack (1.4.2)
     multi_json (1.15.0)
     multi_xml (0.6.0)
@@ -466,6 +467,7 @@ DEPENDENCIES
   intuit-oauth
   listen (~> 3.2)
   mini_portile2 (= 2.5.0)
+  mocha
   noticed (~> 1.5)
   omniauth-google-oauth2
   omniauth-rails_csrf_protection

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -51,96 +51,21 @@ class Review < ApplicationRecord
     end
   end
 
-  LEVELS = {
-    junior_1: {
-      name: "J1",
-      min_points: 100,
-      salary: 63000
-    },
-    junior_2: {
-      name: "J2",
-      min_points: 155,
-      salary: 66675
-    },
-    junior_3: {
-      name: "J3",
-      min_points: 210,
-      salary: 70350
-    },
-    mid_level_1: {
-      name: "ML1",
-      min_points: 265,
-      salary: 73500
-    },
-    mid_level_2: {
-      name: "ML2",
-      min_points: 320,
-      salary: 77175
-    },
-    mid_level_3: {
-      name: "ML3",
-      min_points: 375,
-      salary: 80850
-    },
-    experienced_mid_level_1: {
-      name: "EML1",
-      min_points: 430,
-      salary: 84000
-    },
-    experienced_mid_level_2: {
-      name: "EML2",
-      min_points: 485,
-      salary: 89250
-    },
-    experienced_mid_level_3: {
-      name: "EML3",
-      min_points: 540,
-      salary: 96862.5
-    },
-    senior_1: {
-      name: "S1",
-      min_points: 595,
-      salary: 107231.25
-    },
-    senior_2: {
-      name: "S2",
-      min_points: 650,
-      salary: 118125.00
-    },
-    senior_3: {
-      name: "S3",
-      min_points: 690,
-      salary: 129543.75
-    },
-    senior_4: {
-      name: "S4",
-      min_points: 720,
-      salary: 141487.50
-    },
-    lead_1: {
-      name: "L1",
-      min_points: 750,
-      salary: 153956.25
-    },
-    lead_2: {
-      name: "L2",
-      min_points: 810,
-      salary: 166950.00
-    },
-  }.freeze
-
   def level
-    LEVELS.keys.reduce(nil) do |acc, l|
-      if acc.nil?
-        LEVELS[:junior_1]
-      else
-        if LEVELS[l][:min_points] <= total_points
-          LEVELS[l]
-        else
-          acc
-        end
+    levels = Stacks::SkillLevelFinder.find_all!(Date.today)
+    actual_points = total_points
+
+    descending_levels = levels.sort do |a, b|
+      b[:min_points] <=> a[:min_points]
+    end
+
+    descending_levels.each do |level|
+      if level[:min_points] < actual_points
+        return level
       end
     end
+
+    descending_levels.last
   end
 
   def score_table

--- a/lib/stacks/skill_level_finder.rb
+++ b/lib/stacks/skill_level_finder.rb
@@ -1,0 +1,278 @@
+class Stacks::SkillLevelFinder
+  def self.find_all!(date)
+    self.new(date).find_all!
+  end
+
+  def self.find!(date, key)
+    self.new(date).find!(key)
+  end
+
+  def initialize(date)
+    @date = date
+  end
+
+  def find_all!
+    matching_levels.values
+  end
+
+  def find!(key)
+    level = matching_levels[key.to_sym]
+
+    if level.nil?
+      raise "Unable to find level for date #{@date} and key #{key}"
+    end
+
+    level
+  end
+
+  private
+
+  def matching_levels
+    matching_date = LEVELS_BY_DATE.keys.reverse.find do |date|
+      date <= @date
+    end
+
+    if matching_date.nil?
+      raise "No matching levels found for date #{date}"
+    end
+
+    LEVELS_BY_DATE[matching_date]
+  end
+
+  LEVELS_BY_DATE = {
+    # The original skill levels from the beginning of the company's existence.
+    Date.new(1900, 1, 1) => {
+      junior_1: {
+        name: "J1",
+        min_points: 100,
+        salary: 60000
+      },
+      junior_2: {
+        name: "J2",
+        min_points: 155,
+        salary: 63500
+      },
+      junior_3: {
+        name: "J3",
+        min_points: 210,
+        salary: 67000
+      },
+      mid_level_1: {
+        name: "ML1",
+        min_points: 265,
+        salary: 70000
+      },
+      mid_level_2: {
+        name: "ML2",
+        min_points: 320,
+        salary: 73500
+      },
+      mid_level_3: {
+        name: "ML3",
+        min_points: 375,
+        salary: 77000
+      },
+      experienced_mid_level_1: {
+        name: "EML1",
+        min_points: 430,
+        salary: 80000
+      },
+      experienced_mid_level_2: {
+        name: "EML2",
+        min_points: 485,
+        salary: 85000
+      },
+      experienced_mid_level_3: {
+        name: "EML3",
+        min_points: 540,
+        salary: 90000
+      },
+      senior_1: {
+        name: "S1",
+        min_points: 595,
+        salary: 95000
+      },
+      senior_2: {
+        name: "S2",
+        min_points: 650,
+        salary: 100000
+      },
+      senior_3: {
+        name: "S3",
+        min_points: 690,
+        salary: 105000
+      },
+      senior_4: {
+        name: "S4",
+        min_points: 720,
+        salary: 110000
+      },
+      lead_1: {
+        name: "L1",
+        min_points: 750,
+        salary: 115000
+      },
+      lead_2: {
+        name: "L2",
+        min_points: 810,
+        salary: 120000
+      },
+    },
+    # Updated by commit 51aa4cccf51f9e30698e5628892d4d5e62859b4c
+    Date.new(2021, 12, 8) => {
+      junior_1: {
+        name: "J1",
+        min_points: 100,
+        salary: 63000
+      },
+      junior_2: {
+        name: "J2",
+        min_points: 155,
+        salary: 66675
+      },
+      junior_3: {
+        name: "J3",
+        min_points: 210,
+        salary: 70350
+      },
+      mid_level_1: {
+        name: "ML1",
+        min_points: 265,
+        salary: 73500
+      },
+      mid_level_2: {
+        name: "ML2",
+        min_points: 320,
+        salary: 77175
+      },
+      mid_level_3: {
+        name: "ML3",
+        min_points: 375,
+        salary: 80850
+      },
+      experienced_mid_level_1: {
+        name: "EML1",
+        min_points: 430,
+        salary: 84000
+      },
+      experienced_mid_level_2: {
+        name: "EML2",
+        min_points: 485,
+        salary: 89250
+      },
+      experienced_mid_level_3: {
+        name: "EML3",
+        min_points: 540,
+        salary: 94500
+      },
+      senior_1: {
+        name: "S1",
+        min_points: 595,
+        salary: 99750
+      },
+      senior_2: {
+        name: "S2",
+        min_points: 650,
+        salary: 105000
+      },
+      senior_3: {
+        name: "S3",
+        min_points: 690,
+        salary: 110250
+      },
+      senior_4: {
+        name: "S4",
+        min_points: 720,
+        salary: 115500
+      },
+      lead_1: {
+        name: "L1",
+        min_points: 750,
+        salary: 120750
+      },
+      lead_2: {
+        name: "L2",
+        min_points: 810,
+        salary: 126000
+      },
+    },
+    # Updated by commit a8b51e46f4e92fb110378ef1b599ee21b2cbe747
+    Date.new(2022, 7, 5) => {
+      junior_1: {
+        name: "J1",
+        min_points: 100,
+        salary: 63000
+      },
+      junior_2: {
+        name: "J2",
+        min_points: 155,
+        salary: 66675
+      },
+      junior_3: {
+        name: "J3",
+        min_points: 210,
+        salary: 70350
+      },
+      mid_level_1: {
+        name: "ML1",
+        min_points: 265,
+        salary: 73500
+      },
+      mid_level_2: {
+        name: "ML2",
+        min_points: 320,
+        salary: 77175
+      },
+      mid_level_3: {
+        name: "ML3",
+        min_points: 375,
+        salary: 80850
+      },
+      experienced_mid_level_1: {
+        name: "EML1",
+        min_points: 430,
+        salary: 84000
+      },
+      experienced_mid_level_2: {
+        name: "EML2",
+        min_points: 485,
+        salary: 89250
+      },
+      experienced_mid_level_3: {
+        name: "EML3",
+        min_points: 540,
+        salary: 96862.5
+      },
+      senior_1: {
+        name: "S1",
+        min_points: 595,
+        salary: 107231.25
+      },
+      senior_2: {
+        name: "S2",
+        min_points: 650,
+        salary: 118125.00
+      },
+      senior_3: {
+        name: "S3",
+        min_points: 690,
+        salary: 129543.75
+      },
+      senior_4: {
+        name: "S4",
+        min_points: 720,
+        salary: 141487.50
+      },
+      lead_1: {
+        name: "L1",
+        min_points: 750,
+        salary: 153956.25
+      },
+      lead_2: {
+        name: "L2",
+        min_points: 810,
+        salary: 166950.00
+      },
+    }
+  }.freeze
+end

--- a/test/models/review_test.rb
+++ b/test/models/review_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class ReviewTest < ActiveSupport::TestCase
+  test "#level returns the greatest matching level whose points are below the review's points" do
+    review = Review.new
+    review.expects(:total_points).returns(650)
+
+    assert_equal({
+      name: "S1",
+      min_points: 595,
+      salary: 107231.25
+    }, review.level)
+  end
+
+  test "#level returns the minimum level if no levels are below the review's points" do
+    review = Review.new
+    review.expects(:total_points).returns(-1)
+
+    assert_equal({
+      name: "J1",
+      min_points: 100,
+      salary: 63000
+    }, review.level)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 require 'rails/test_help'
+require 'mocha/minitest'
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers


### PR DESCRIPTION
This is a followup based on @hhff's feedback [here](https://github.com/sanctuarycomputer/stacks/pull/45/files#r1585152841) as part of the work to improve our COSR logic. We need to define and store the historical changes to skill levels (read: salary $) that have occurred over time, so that when we are calculating employee salary bands, we can ensure that we're using the correct salary value for a given point in time.

Rather than throwing more data in the existing `Review` model class, I decided to carve out this stuff into its own utility class for looking up particular skill levels. This is important because ultimately we should probably be accessing these values in a more ActiveRecord like way, either because we're storing these skill levels directly in the database, or because we have them stored in flat files and loaded in via something like [FrozenRecord](https://github.com/byroot/frozen_record). This future work will be easier if we prevent people from keying in directly to the `LEVELS` static map.