### PR TITLE
FIX: Clean up studio tallies by skill level

### DIFF
--- a/app/admin/studios.rb
+++ b/app/admin/studios.rb
@@ -322,26 +322,25 @@ ActiveAdmin.register Studio do
       }]
     }
 
-    skill_level_data = 
-      resource.skill_levels_on(Date.today)
+    band_tallies = resource.skill_levels_on(Date.today)
 
     studio_senior_ratio_data =
-      skill_level_data.reduce({ senior: 0, total: 0 }) do |acc, band|
-        if band[1][:name].starts_with?("S") || band[1][:name].starts_with?("L")
-          acc[:senior] += band[1][:count] || 0
+      band_tallies.reduce({ senior: 0, total: 0 }) do |acc, band_tally|
+        name, count = band_tally
+
+        if name.starts_with?("S") || name.starts_with?("L")
+          acc[:senior] += count
         end
-        acc[:total] += band[1][:count] || 0
+        acc[:total] += count
         acc
       end
 
     studio_talent_pool_data = {
-      labels: skill_level_data.values.map{|s| s[:name] },
+      labels: band_tallies.keys,
       datasets: [{
         label: 'Total',
         backgroundColor: COLORS[0],
-        data: (skill_level_data.values.map do |s|
-          s[:count] || 0
-        end)
+        data: band_tallies.values
       }]
     }
 

--- a/app/models/studio.rb
+++ b/app/models/studio.rb
@@ -300,17 +300,16 @@ class Studio < ApplicationRecord
   end
 
   def skill_levels_on(date)
-    level_data = Marshal.load(Marshal.dump(Stacks::SkillLevelFinder::LEVELS_BY_DATE.values.last))
+    archetypal_levels = Stacks::SkillLevelFinder.find_all!(date)
 
-    core_members_active_on(date).reduce(level_data) do |acc, member|
-      level_key = acc.keys.find{|k| acc[k][:name] == member.skill_tree_level_on_date(date)[:name]}
-      if level_key
-        acc[level_key][:count] ||= 0
-        acc[level_key][:count] += 1
-      else
-        acc[:unknown] ||= { name: :unknown, count: 0 }
-        acc[:unknown][:count] += 1
-      end
+    bands = archetypal_levels.reduce({}) do |acc, archetypal_level|
+      acc[archetypal_level[:name]] = 0
+      acc
+    end
+
+    core_members_active_on(date).reduce(bands) do |acc, member|
+      member_level = member.skill_tree_level_on_date(date)
+      acc[member_level[:name]] += 1
       acc
     end
   end

--- a/test/models/studio_test.rb
+++ b/test/models/studio_test.rb
@@ -110,9 +110,113 @@ class StudioTest < ActiveSupport::TestCase
     admin_user.full_time_periods.reload
 
     jan = Stacks::Period.new("January 2020", Date.new(2021, 6, 1), Date.new(2021, 6, 30))
-    u = studio.utilization_for_period(jan, [studio])[forecast_person]    
-    
+    u = studio.utilization_for_period(jan, [studio])[forecast_person]
+
     assert u[:sellable] == 0
     assert u[:non_sellable] == 0
+  end
+
+  test "#skill_levels_on returns the expected values" do
+    studio = Studio.create!({
+      name: "Sanctuary Computer",
+      accounting_prefix: "Development",
+      mini_name: "sc"
+    })
+
+    user_one = AdminUser.create!({
+      email: "senior_3a@sanctuary.computer",
+      password: "password",
+      old_skill_tree_level: :senior_3
+    })
+
+    user_two = AdminUser.create!({
+      email: "senior_3b@sanctuary.computer",
+      password: "password",
+      old_skill_tree_level: :senior_3
+    })
+
+    user_three = AdminUser.create!({
+      email: "senior_1@sanctuary.computer",
+      password: "password",
+      old_skill_tree_level: :senior_1
+    })
+
+    user_four = AdminUser.create!({
+      email: "junior_1@sanctuary.computer",
+      password: "password",
+      old_skill_tree_level: :junior_1
+    })
+
+    FullTimePeriod.create!({
+      admin_user: user_one,
+      started_at: Date.yesterday,
+      ended_at: nil,
+      contributor_type: :five_day,
+      expected_utilization: 0.8
+    })
+
+    FullTimePeriod.create!({
+      admin_user: user_two,
+      started_at: Date.yesterday,
+      ended_at: nil,
+      contributor_type: :five_day,
+      expected_utilization: 0.8
+    })
+
+    FullTimePeriod.create!({
+      admin_user: user_three,
+      started_at: Date.yesterday,
+      ended_at: nil,
+      contributor_type: :five_day,
+      expected_utilization: 0.8
+    })
+
+    FullTimePeriod.create!({
+      admin_user: user_four,
+      started_at: Date.yesterday,
+      ended_at: nil,
+      contributor_type: :five_day,
+      expected_utilization: 0.8
+    })
+
+    StudioMembership.create!({
+      studio: studio,
+      admin_user: user_one
+    })
+
+    StudioMembership.create!({
+      studio: studio,
+      admin_user: user_two
+    })
+
+    StudioMembership.create!({
+      studio: studio,
+      admin_user: user_three
+    })
+
+    StudioMembership.create!({
+      studio: studio,
+      admin_user: user_four
+    })
+
+    levels = studio.skill_levels_on(Date.today)
+
+    assert_equal({
+      "J1" => 1,
+      "J2" => 0,
+      "J3" => 0,
+      "ML1" => 0,
+      "ML2" => 0,
+      "ML3" => 0,
+      "EML1" => 0,
+      "EML2" => 0,
+      "EML3" => 0,
+      "S1" => 1,
+      "S2" => 0,
+      "S3" => 2,
+      "S4" => 0,
+      "L1" => 0,
+      "L2" => 0
+    }, levels)
   end
 end


### PR DESCRIPTION
Followup to https://github.com/sanctuarycomputer/stacks/pull/47. This cleans up the `Studio.skill_levels_on` method to not reach directly into the `SkillLevelFinder::LEVELS_BY_DATE` map, but rather uses the `find_all!` entrypoint instead.

Verified that the skill level tallies are rendered as expected on the studio `view` page:

![skill_levels](https://github.com/sanctuarycomputer/stacks/assets/34255985/4ed97bff-0fb3-435a-ae20-79374b92383d)
