### PR TITLE
[FEAT] Use new ForecastAssignmentDailyFinancialSnapshot model to calculate COSR

### DIFF
--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -79,11 +79,15 @@ class AdminUser < ApplicationRecord
   end
 
   def approximate_cost_per_sellable_hour_before_studio_expenses
-    now = DateTime.now.to_date.beginning_of_week # monday
-    data = sellable_hours_for_date(now)
+    approximate_cost_per_sellable_hour_before_studio_expenses_on_date(Date.today)
+  end
+
+  def approximate_cost_per_sellable_hour_before_studio_expenses_on_date(date)
+    date = date.beginning_of_week
+    data = sellable_hours_for_date(date)
     return nil unless data.present?
     return nil if data[:sellable] == 0
-    cost_of_employment_on_date(now) / data[:sellable]
+    cost_of_employment_on_date(date) / data[:sellable]
   end
 
   def sellable_hours_for_date(date)

--- a/app/models/forecast_assignment.rb
+++ b/app/models/forecast_assignment.rb
@@ -2,6 +2,7 @@ class ForecastAssignment < ApplicationRecord
   self.primary_key = "forecast_id"
   belongs_to :forecast_person, class_name: "ForecastPerson", foreign_key: "person_id"
   belongs_to :forecast_project, class_name: "ForecastProject", foreign_key: "project_id"
+  has_many :forecast_assignment_daily_financial_snapshots
 
   attr_accessor :_qbo_service_item
 

--- a/app/models/forecast_assignment_daily_financial_snapshot.rb
+++ b/app/models/forecast_assignment_daily_financial_snapshot.rb
@@ -1,0 +1,3 @@
+class ForecastAssignmentDailyFinancialSnapshot < ApplicationRecord
+  belongs_to :forecast_assignment
+end

--- a/app/models/project_tracker.rb
+++ b/app/models/project_tracker.rb
@@ -142,6 +142,7 @@ class ProjectTracker < ApplicationRecord
 
   def generate_snapshot!
     cosr = cost_of_services_rendered("month")
+    cosr_new = cost_of_services_rendered_new
     preloaded_studios = Studio.all
     today = Date.today
 
@@ -151,16 +152,22 @@ class ProjectTracker < ApplicationRecord
     ).reduce({
       generated_at: DateTime.now.iso8601,
       hours: [],
+      hours_new: [],
       spend: [],
       hours_total: 0,
+      hours_total_new: 0,
       spend_total: 0,
       cash: {
         cosr: [],
+        cosr_new: [],
         cosr_total: 0,
+        cosr_total_new: 0,
       },
       accrual: {
         cosr: [],
+        cosr_new: [],
         cosr_total: 0,
+        cosr_total_new: 0,
       }
     }) do |acc, date|
       hours_by_studio = self.total_hours_during_range_by_studio(preloaded_studios, date, date)
@@ -195,6 +202,36 @@ class ProjectTracker < ApplicationRecord
         x: date.iso8601,
         y: acc[:accrual][:cosr_total] += cosr_for_date[:accrual]
       })
+
+      # Once we confirm that the new COSR numbers look okay in production,
+      # we can remove all of the above logic and just use the following instead.
+
+      cosr_for_date_new = cosr_new[date]
+      total_cosr_for_date = 0
+      total_hours_for_date = 0
+
+      unless cosr_for_date_new.blank?
+        cosr_for_date_new.each do |studio_id, cosr_data|
+          total_cosr_for_date += cosr_data[:total_cost]
+          total_hours_for_date += cosr_data[:total_hours]
+        end
+      end
+
+      acc[:hours_new].push({
+        x: date.iso8601,
+        y: acc[:hours_total_new] += total_hours_for_date
+      })
+
+      acc[:cash][:cosr_new].push({
+        x: date.iso8601,
+        y: acc[:cash][:cosr_total_new] += total_cosr_for_date
+      })
+
+      acc[:accrual][:cosr_new].push({
+        x: date.iso8601,
+        y: acc[:accrual][:cosr_total_new] += total_cosr_for_date
+      })
+
       acc
     end
 
@@ -445,6 +482,28 @@ class ProjectTracker < ApplicationRecord
     periods
   end
 
+  def cost_of_services_rendered_new
+    start_date = (
+      first_recorded_assignment ?
+      first_recorded_assignment.start_date :
+      Date.today
+    )
+
+    end_date = (
+      last_recorded_assignment ?
+      last_recorded_assignment.end_date :
+      Date.today
+    )
+
+    calculator = Stacks::CostOfServicesRenderedCalculator.new(
+      start_date: start_date,
+      end_date: end_date,
+      forecast_project_ids: forecast_projects.map(&:forecast_id)
+    )
+
+    calculator.calculate
+  end
+
   def raw_resourcing_cost_during_range_in_usd(start_range, end_range)
     assignments =
       ForecastAssignment
@@ -492,7 +551,7 @@ class ProjectTracker < ApplicationRecord
       forecast_project_ids = forecast_projects.map(&:forecast_id)
       ForecastAssignment
         .where(project_id: forecast_project_ids)
-        .order(start_date: :desc)
+        .order(end_date: :desc)
         .limit(1)
         .first
     )

--- a/db/migrate/20240502041442_create_forecast_assignment_daily_financial_snapshots.rb
+++ b/db/migrate/20240502041442_create_forecast_assignment_daily_financial_snapshots.rb
@@ -1,0 +1,24 @@
+class CreateForecastAssignmentDailyFinancialSnapshots < ActiveRecord::Migration[6.0]
+  def change
+    create_table :forecast_assignment_daily_financial_snapshots do |t|
+      t.bigint :forecast_assignment_id, null: false, index: {
+        name: "idx_snapshots_on_forecast_assignment_id"
+      }
+      t.bigint :forecast_person_id, null: false, index: {
+        name: "idx_snapshots_on_forecast_person_id"
+      }
+      t.bigint :forecast_project_id, null: false, index: {
+        name: "idx_snapshots_on_forecast_project_id"
+      }
+      t.date :effective_date, null: false
+      t.bigint :studio_id, null: false
+      t.decimal :hourly_cost, null: false
+      t.decimal :hours, null: false
+      t.boolean :needs_review, null: false, index: {
+        name: "idx_snapshots_on_needs_review"
+      }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_03_20_020826) do
+ActiveRecord::Schema.define(version: 2024_05_02_041442) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -167,6 +167,23 @@ ActiveRecord::Schema.define(version: 2024_03_20_020826) do
     t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_finalizations_on_deleted_at"
     t.index ["review_id"], name: "index_finalizations_on_review_id"
+  end
+
+  create_table "forecast_assignment_daily_financial_snapshots", force: :cascade do |t|
+    t.bigint "forecast_assignment_id", null: false
+    t.bigint "forecast_person_id", null: false
+    t.bigint "forecast_project_id", null: false
+    t.date "effective_date", null: false
+    t.bigint "studio_id", null: false
+    t.decimal "hourly_cost", null: false
+    t.decimal "hours", null: false
+    t.boolean "needs_review", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["forecast_assignment_id"], name: "idx_snapshots_on_forecast_assignment_id"
+    t.index ["forecast_person_id"], name: "idx_snapshots_on_forecast_person_id"
+    t.index ["forecast_project_id"], name: "idx_snapshots_on_forecast_project_id"
+    t.index ["needs_review"], name: "idx_snapshots_on_needs_review"
   end
 
   create_table "forecast_assignments", force: :cascade do |t|

--- a/lib/stacks/cost_of_services_rendered_calculator.rb
+++ b/lib/stacks/cost_of_services_rendered_calculator.rb
@@ -1,0 +1,60 @@
+class Stacks::CostOfServicesRenderedCalculator
+  def initialize(start_date:, end_date:, forecast_project_ids:)
+    @start_date = start_date
+    @end_date = end_date
+    @forecast_project_ids = forecast_project_ids
+  end
+
+  def calculate
+    daily_snapshots = ForecastAssignmentDailyFinancialSnapshot
+      .where(forecast_project_id: @forecast_project_ids)
+      .order(effective_date: :asc)
+      .where(
+        "effective_date >=? AND effective_date <= ?",
+        @start_date,
+        @end_date
+      )
+      .pluck(
+        :forecast_assignment_id,
+        :effective_date,
+        :hours,
+        :hourly_cost,
+        :studio_id
+      )
+
+    (@start_date..@end_date).reduce({}) do |acc, date|
+      acc[date] ||= {}
+
+      while daily_snapshots.length > 0
+        (
+          forecast_assignment_id,
+          effective_date,
+          hours,
+          hourly_cost,
+          studio_id
+        ) = daily_snapshots.first
+
+        break if effective_date > date
+
+        daily_snapshots.shift
+
+        acc[date][studio_id] ||= {
+          total_hours: 0,
+          total_cost: 0,
+          assignment_costs: []
+        }
+
+        acc[date][studio_id][:total_hours] += hours.to_f
+        acc[date][studio_id][:total_cost] += (hours * hourly_cost).to_f
+
+        acc[date][studio_id][:assignment_costs] << {
+          forecast_assignment_id: forecast_assignment_id,
+          hours: hours,
+          hourly_cost: hourly_cost
+        }
+      end
+
+      acc
+    end
+  end
+end

--- a/lib/stacks/daily_financial_snapshotter.rb
+++ b/lib/stacks/daily_financial_snapshotter.rb
@@ -1,0 +1,137 @@
+class Stacks::DailyFinancialSnapshotter
+  def self.snapshot_all!
+    current_date = Stacks::System.singleton_class::UTILIZATION_START_AT
+    end_date = Date.today
+    studios = Studio.all
+
+    while current_date <= end_date
+      snapshotter = self.new(current_date, studios)
+      snapshotter.snapshot!
+      current_date += 1.day
+    end
+  end
+
+  def initialize(effective_date = nil, studios = nil)
+    @effective_date = effective_date || Date.today
+    @studios = studios || Studio.all
+  end
+
+  def snapshot!
+    Rails.logger.info(
+      "Creating daily project financial snapshots for date #{@effective_date}..."
+    )
+
+    attributes = ForecastAssignment
+      .where("start_date <= ? AND end_date >= ?", @effective_date, @effective_date)
+      .includes(:forecast_person, :forecast_project)
+      .map { |assignment| snapshot_attributes_for_assignment(assignment) }
+      .compact
+
+    ActiveRecord::Base.transaction do
+      ForecastAssignmentDailyFinancialSnapshot
+        .where(effective_date: @effective_date)
+        .delete_all
+
+      unless attributes.empty?
+        ForecastAssignmentDailyFinancialSnapshot.insert_all!(attributes)
+      end
+    end
+  end
+
+  private
+
+  def snapshot_attributes_for_assignment(forecast_assignment)
+    hours = forecast_assignment.allocation_during_range_in_hours(
+      @effective_date,
+      @effective_date
+    )
+
+    return nil if hours == 0
+
+    forecast_person = forecast_assignment.forecast_person
+    forecast_project = forecast_assignment.forecast_project
+    person_id = forecast_person.nil? ? 0 : forecast_person.id
+    studio_id = forecast_person_studio_id(forecast_person)
+    hourly_cost = forecast_person_hourly_cost(forecast_person, forecast_project)
+    needs_review = needs_review?(forecast_person, studio_id, hourly_cost)
+
+    {
+      forecast_assignment_id: forecast_assignment.id,
+      forecast_person_id: person_id,
+      forecast_project_id: forecast_project.id,
+      hourly_cost: hourly_cost,
+      hours: hours,
+      studio_id: studio_id,
+      effective_date: @effective_date,
+      needs_review: needs_review,
+      created_at: DateTime.now,
+      updated_at: DateTime.now
+    }
+  end
+
+  def forecast_person_studio_id(forecast_person)
+    return 0 if forecast_person.nil?
+
+    @studios.each do |studio|
+      if forecast_person.roles.include?(studio.name)
+        return studio.id
+      end
+    end
+
+    return 0
+  end
+
+  def forecast_person_hourly_cost(forecast_person, forecast_project)
+    return 0 if forecast_person.nil?
+
+    if forecast_person.admin_user.present?
+      employee_hourly_cost(forecast_person, forecast_project)
+    else
+      subcontractor_hourly_cost(forecast_person, forecast_project)
+    end
+  end
+
+  def employee_hourly_cost(forecast_person, forecast_project)
+    admin_user = forecast_person.admin_user
+    cost = admin_user.approximate_cost_per_sellable_hour_before_studio_expenses_on_date(@effective_date)
+
+    if cost.nil?
+      return 0
+    end
+
+    cost.round(2)
+  end
+
+  def subcontractor_hourly_cost(forecast_person, forecast_project)
+    if forecast_project.notes.nil?
+      return 0
+    end
+
+    # It's possible to record overrides to a particular individual's
+    # (or contractor's) hourly rates in Harvest Forecast by adding a note
+    # to the Forecast project in the form:
+    # "contractor-name@contractor-domain.com:150p/h"
+    regexp = /^([^:]+):\$?([0-9\.]+)p\/h/
+    matches = forecast_project.notes.scan(regexp)
+
+    match = matches.find do |match|
+      match[0] == forecast_person.email
+    end
+
+    if match.present?
+      match[1].to_f
+    else
+      0
+    end
+  end
+
+  def needs_review?(forecast_person, studio_id, hourly_cost)
+    if forecast_person.admin_user.present?
+      if studio_id == 0
+        return true
+      end
+    end
+
+    hourly_cost == 0
+  end
+end

--- a/lib/tasks/stacks.rake
+++ b/lib/tasks/stacks.rake
@@ -104,6 +104,7 @@ namespace :stacks do
       Parallel.map(Studio.client_services, in_threads: 2) { |s| s.generate_snapshot! }
       # Now, generate project snapshots
       Parallel.map(ProjectTracker.all, in_threads: 10) { |pt| pt.generate_snapshot! }
+      Stacks::DailyFinancialSnapshotter.snapshot_all!
 
       puts "~~~> DOING MISC"
       ProfitSharePass.ensure_exists!

--- a/test/lib/stacks/cost_of_services_rendered_calculator_test.rb
+++ b/test/lib/stacks/cost_of_services_rendered_calculator_test.rb
@@ -1,0 +1,314 @@
+require "test_helper"
+
+class Stacks::CostOfServicesRenderedCalculatorTest < ActiveSupport::TestCase
+  test "#calculate returns the expected data for a two-person project" do
+    start_date = Date.new(2024, 1, 1)
+    end_date = Date.new(2024, 1, 10)
+
+    studio = Studio.create!({
+      name: "Sanctuary Computer",
+      accounting_prefix: "Development",
+      mini_name: "sc"
+    })
+
+    forecast_client = ForecastClient.create!
+
+    forecast_project = ForecastProject.create!({
+      id: 1,
+      name: "Test project",
+      forecast_client: forecast_client,
+      code: "ABCD-1",
+    })
+
+    user_one = AdminUser.create!({
+      email: "josh@sanctuary.computer",
+      password: "password",
+    })
+
+    user_two = AdminUser.create!({
+      email: "antijosh@sanctuary.computer",
+      password: "password",
+    })
+
+    person_one = ForecastPerson.create!({
+      forecast_id: 123,
+      roles: [studio.name],
+      email: user_one.email
+    })
+
+    person_two = ForecastPerson.create!({
+      forecast_id: 456,
+      roles: [studio.name],
+      email: user_two.email
+    })
+
+    FullTimePeriod.create!({
+      admin_user: user_one,
+      started_at: Date.new(2020, 1, 1),
+      ended_at: nil,
+      contributor_type: :five_day,
+      expected_utilization: 0.8
+    })
+
+    FullTimePeriod.create!({
+      admin_user: user_two,
+      started_at: Date.new(2020, 1, 1),
+      ended_at: nil,
+      contributor_type: :five_day,
+      expected_utilization: 0.8
+    })
+
+    assignment_one = ForecastAssignment.create!({
+      forecast_id: 111,
+      start_date: start_date,
+      end_date: start_date + 4.days,
+      forecast_person: person_one,
+      forecast_project: forecast_project
+    })
+
+    assignment_two = ForecastAssignment.create!({
+      forecast_id: 222,
+      start_date: start_date,
+      end_date: start_date + 4.days,
+      forecast_person: person_two,
+      forecast_project: forecast_project
+    })
+
+    assignment_three = ForecastAssignment.create!({
+      forecast_id: 333,
+      start_date: start_date + 1.week,
+      end_date: start_date + 1.week + 2.days,
+      forecast_person: person_one,
+      forecast_project: forecast_project
+    })
+
+    assignment_four = ForecastAssignment.create!({
+      forecast_id: 444,
+      start_date: start_date + 1.week,
+      end_date: start_date + 1.week + 2.days,
+      forecast_person: person_two,
+      forecast_project: forecast_project
+    })
+
+    current_date = start_date
+
+    while current_date <= end_date
+      first_week = current_date < start_date + 5.days
+
+      ForecastAssignmentDailyFinancialSnapshot.create!({
+        forecast_assignment: first_week ? assignment_one : assignment_three,
+        forecast_person_id: person_one.id,
+        forecast_project_id: forecast_project.id,
+        effective_date: current_date,
+        studio_id: studio.id,
+        hourly_cost: first_week ? 33 : 44,
+        hours: first_week ? 7 : 6,
+        needs_review: false
+      })
+
+      ForecastAssignmentDailyFinancialSnapshot.create!({
+        forecast_assignment: first_week ? assignment_two : assignment_four,
+        forecast_person_id: person_two.id,
+        forecast_project_id: forecast_project.id,
+        effective_date: current_date,
+        studio_id: studio.id,
+        hourly_cost: first_week ? 44 : 55,
+        hours: first_week ? 6 : 5,
+        needs_review: false
+      })
+
+      current_date = current_date + 1.day
+    end
+
+    calculator = Stacks::CostOfServicesRenderedCalculator.new(
+      start_date: start_date,
+      end_date: end_date,
+      forecast_project_ids: [forecast_project.id]
+    )
+
+    cosr = calculator.calculate
+
+    assert_equal({
+      start_date => {
+        studio.id => {
+          total_hours: 13,
+          total_cost: 495,
+          assignment_costs: [
+            {
+              forecast_assignment_id: assignment_one.id,
+              hours: 7,
+              hourly_cost: 33
+            },
+            {
+              forecast_assignment_id: assignment_two.id,
+              hours: 6,
+              hourly_cost: 44
+            }
+          ]
+        }
+      },
+      start_date + 1.day => {
+        studio.id => {
+          total_hours: 13,
+          total_cost: 495,
+          assignment_costs: [
+            {
+              forecast_assignment_id: assignment_one.id,
+              hours: 7,
+              hourly_cost: 33
+            },
+            {
+              forecast_assignment_id: assignment_two.id,
+              hours: 6,
+              hourly_cost: 44
+            }
+          ]
+        }
+      },
+      start_date + 2.days => {
+        studio.id => {
+          total_hours: 13,
+          total_cost: 495,
+          assignment_costs: [
+            {
+              forecast_assignment_id: assignment_one.id,
+              hours: 7,
+              hourly_cost: 33
+            },
+            {
+              forecast_assignment_id: assignment_two.id,
+              hours: 6,
+              hourly_cost: 44
+            }
+          ]
+        }
+      },
+      start_date + 3.days => {
+        studio.id => {
+          total_hours: 13,
+          total_cost: 495,
+          assignment_costs: [
+            {
+              forecast_assignment_id: assignment_one.id,
+              hours: 7,
+              hourly_cost: 33
+            },
+            {
+              forecast_assignment_id: assignment_two.id,
+              hours: 6,
+              hourly_cost: 44
+            }
+          ]
+        }
+      },
+      start_date + 4.days => {
+        studio.id => {
+          total_hours: 13,
+          total_cost: 495,
+          assignment_costs: [
+            {
+              forecast_assignment_id: assignment_one.id,
+              hours: 7,
+              hourly_cost: 33
+            },
+            {
+              forecast_assignment_id: assignment_two.id,
+              hours: 6,
+              hourly_cost: 44
+            }
+          ]
+        }
+      },
+      start_date + 5.days => {
+        studio.id => {
+          total_hours: 11,
+          total_cost: 539,
+          assignment_costs: [
+            {
+              forecast_assignment_id: assignment_three.id,
+              hours: 6,
+              hourly_cost: 44
+            },
+            {
+              forecast_assignment_id: assignment_four.id,
+              hours: 5,
+              hourly_cost: 55
+            }
+          ]
+        }
+      },
+      start_date + 6.days => {
+        studio.id => {
+          total_hours: 11,
+          total_cost: 539,
+          assignment_costs: [
+            {
+              forecast_assignment_id: assignment_three.id,
+              hours: 6,
+              hourly_cost: 44
+            },
+            {
+              forecast_assignment_id: assignment_four.id,
+              hours: 5,
+              hourly_cost: 55
+            }
+          ]
+        }
+      },
+      start_date + 7.days => {
+        studio.id => {
+          total_hours: 11,
+          total_cost: 539,
+          assignment_costs: [
+            {
+              forecast_assignment_id: assignment_three.id,
+              hours: 6,
+              hourly_cost: 44
+            },
+            {
+              forecast_assignment_id: assignment_four.id,
+              hours: 5,
+              hourly_cost: 55
+            }
+          ]
+        }
+      },
+      start_date + 8.days => {
+        studio.id => {
+          total_hours: 11,
+          total_cost: 539,
+          assignment_costs: [
+            {
+              forecast_assignment_id: assignment_three.id,
+              hours: 6,
+              hourly_cost: 44
+            },
+            {
+              forecast_assignment_id: assignment_four.id,
+              hours: 5,
+              hourly_cost: 55
+            }
+          ]
+        }
+      },
+      start_date + 9.days => {
+        studio.id => {
+          total_hours: 11,
+          total_cost: 539,
+          assignment_costs: [
+            {
+              forecast_assignment_id: assignment_three.id,
+              hours: 6,
+              hourly_cost: 44
+            },
+            {
+              forecast_assignment_id: assignment_four.id,
+              hours: 5,
+              hourly_cost: 55
+            }
+          ]
+        }
+      }
+    }, cosr)
+  end
+end

--- a/test/lib/stacks/daily_financial_snapshotter_test.rb
+++ b/test/lib/stacks/daily_financial_snapshotter_test.rb
@@ -1,0 +1,826 @@
+require "test_helper"
+
+class Stacks::DailyFinancialSnapshotterTest < ActiveSupport::TestCase
+  test "#snapshot! builds the expected daily snapshots for an employee contributor" do
+    start_date = Date.new(2024, 1, 1)
+    end_date = Date.new(2024, 1, 10)
+
+    studio = Studio.create!({
+      name: "Sanctuary Computer",
+      accounting_prefix: "Development",
+      mini_name: "sc"
+    })
+
+    forecast_client = ForecastClient.create!
+
+    forecast_project = ForecastProject.create!({
+      id: 1,
+      name: "Test project",
+      forecast_client: forecast_client,
+      code: "ABCD-1",
+      start_date: start_date
+    })
+
+    user = AdminUser.create!({
+      email: "josh@sanctuary.computer",
+      password: "password",
+      old_skill_tree_level: :senior_3
+    })
+
+    forecast_person = ForecastPerson.create!({
+      forecast_id: 123,
+      roles: [studio.name],
+      email: user.email
+    })
+
+    FullTimePeriod.create!({
+      admin_user: user,
+      started_at: Date.new(2020, 1, 1),
+      ended_at: nil,
+      contributor_type: :five_day,
+      expected_utilization: 0.8
+    })
+
+    ForecastAssignment.create!({
+      forecast_id: 111,
+      start_date: start_date,
+      end_date: end_date,
+      forecast_person: forecast_person,
+      forecast_project: forecast_project
+    })
+
+    snapshotter = Stacks::DailyFinancialSnapshotter.new(start_date)
+    snapshotter.snapshot!
+
+    assert_snapshot_attributes([
+      {
+        forecast_person_id: forecast_person.id,
+        forecast_project_id: forecast_project.id,
+        effective_date: start_date,
+        studio_id: studio.id,
+        hourly_cost: 85.31,
+        hours: 8,
+        needs_review: false
+      }
+    ])
+  end
+
+  test "#snapshot! builds the expected daily snapshots for a contractor using the notes specified on the Forecast project" do
+    start_date = Date.new(2024, 1, 1)
+    end_date = Date.new(2024, 1, 10)
+
+    studio = Studio.create!({
+      name: "Sanctuary Computer",
+      accounting_prefix: "Development",
+      mini_name: "sc"
+    })
+
+    forecast_client = ForecastClient.create!
+
+    forecast_project = ForecastProject.create!({
+      id: 1,
+      name: "Test project",
+      forecast_client: forecast_client,
+      code: "ABCD-1",
+      notes: "subcontractor-1@some-other-agency.com:99.55p/h\nsubcontractor-2@some-other-agency.com:123p/h",
+      start_date: start_date
+    })
+
+    forecast_person = ForecastPerson.create!({
+      forecast_id: 123,
+      roles: ["Subcontractor", "Sanctuary Computer"],
+      email: "subcontractor-2@some-other-agency.com"
+    })
+
+    ForecastAssignment.create!({
+      forecast_id: 111,
+      start_date: start_date,
+      end_date: end_date,
+      forecast_person: forecast_person,
+      forecast_project: forecast_project
+    })
+
+    snapshotter = Stacks::DailyFinancialSnapshotter.new(start_date)
+    snapshotter.snapshot!
+
+    assert_snapshot_attributes([
+      {
+        forecast_person_id: forecast_person.id,
+        forecast_project_id: forecast_project.id,
+        effective_date: start_date,
+        studio_id: studio.id,
+        hourly_cost: 123,
+        hours: 8,
+        needs_review: false
+      }
+    ])
+  end
+
+  test "#snapshot! deletes old snapshot records for the target day before inserting new ones" do
+    start_date = Date.new(2024, 1, 1)
+    end_date = Date.new(2024, 1, 10)
+
+    studio = Studio.create!({
+      name: "Sanctuary Computer",
+      accounting_prefix: "Development",
+      mini_name: "sc"
+    })
+
+    forecast_client = ForecastClient.create!
+
+    forecast_project = ForecastProject.create!({
+      id: 1,
+      name: "Test project",
+      forecast_client: forecast_client,
+      code: "ABCD-1",
+      start_date: start_date
+    })
+
+    user = AdminUser.create!({
+      email: "josh@sanctuary.computer",
+      password: "password"
+    })
+
+    forecast_person = ForecastPerson.create!({
+      forecast_id: 123,
+      roles: [studio.name],
+      email: user.email
+    })
+
+    FullTimePeriod.create!({
+      admin_user: user,
+      started_at: Date.new(2020, 1, 1),
+      ended_at: nil,
+      contributor_type: :five_day,
+      expected_utilization: 0.8
+    })
+
+    forecast_assignment = ForecastAssignment.create!({
+      forecast_id: 111,
+      start_date: start_date,
+      end_date: end_date,
+      forecast_person: forecast_person,
+      forecast_project: forecast_project
+    })
+
+    ForecastAssignmentDailyFinancialSnapshot.create!({
+      forecast_assignment: forecast_assignment,
+      forecast_person_id: forecast_person.id,
+      forecast_project_id: forecast_project.id,
+      effective_date: start_date,
+      studio_id: studio.id,
+      hourly_cost: 70.61,
+      hours: 8,
+      needs_review: false
+    })
+
+    snapshotter = Stacks::DailyFinancialSnapshotter.new(start_date)
+    snapshotter.snapshot!
+
+    assert_snapshot_attributes([
+      {
+        forecast_person_id: forecast_person.id,
+        forecast_project_id: forecast_project.id,
+        effective_date: start_date,
+        studio_id: studio.id,
+        hourly_cost: 70.61,
+        hours: 8,
+        needs_review: false
+      }
+    ])
+  end
+
+  test "#snapshot! flags new snapshot records for review if their hourly cost could not be determined" do
+    start_date = Date.new(2024, 1, 1)
+    end_date = Date.new(2024, 1, 10)
+
+    studio = Studio.create!({
+      name: "Sanctuary Computer",
+      accounting_prefix: "Development",
+      mini_name: "sc"
+    })
+
+    forecast_client = ForecastClient.create!
+
+    forecast_project = ForecastProject.create!({
+      id: 1,
+      name: "Test project",
+      forecast_client: forecast_client,
+      code: "ABCD-1",
+      # Notice: no cost overrides specified in notes field
+      start_date: start_date
+    })
+
+    forecast_person = ForecastPerson.create!({
+      forecast_id: 123,
+      roles: ["Subcontractor", "Sanctuary Computer"],
+      email: "subcontractor@some-other-agency.com"
+    })
+
+    ForecastAssignment.create!({
+      forecast_id: 111,
+      start_date: start_date,
+      end_date: end_date,
+      forecast_person: forecast_person,
+      forecast_project: forecast_project
+    })
+
+    snapshotter = Stacks::DailyFinancialSnapshotter.new(start_date)
+    snapshotter.snapshot!
+
+    assert_snapshot_attributes([
+      {
+        forecast_person_id: forecast_person.id,
+        forecast_project_id: forecast_project.id,
+        effective_date: start_date,
+        studio_id: studio.id,
+        hourly_cost: 0,
+        hours: 8,
+        needs_review: true
+      }
+    ])
+  end
+
+  test "#snapshot! flags new snapshot records for review for employees without a studio" do
+    start_date = Date.new(2024, 1, 1)
+    end_date = Date.new(2024, 1, 10)
+
+    forecast_client = ForecastClient.create!
+
+    forecast_project = ForecastProject.create!({
+      id: 1,
+      name: "Test project",
+      forecast_client: forecast_client,
+      code: "ABCD-1",
+      start_date: start_date
+    })
+
+    user = AdminUser.create!({
+      email: "josh@sanctuary.computer",
+      password: "password"
+    })
+
+    forecast_person = ForecastPerson.create!({
+      forecast_id: 123,
+      roles: [],
+      email: user.email
+    })
+
+    FullTimePeriod.create!({
+      admin_user: user,
+      started_at: Date.new(2020, 1, 1),
+      ended_at: nil,
+      contributor_type: :five_day,
+      expected_utilization: 0.8
+    })
+
+    ForecastAssignment.create!({
+      forecast_id: 111,
+      start_date: start_date,
+      end_date: end_date,
+      forecast_person: forecast_person,
+      forecast_project: forecast_project
+    })
+
+    snapshotter = Stacks::DailyFinancialSnapshotter.new(start_date, [])
+    snapshotter.snapshot!
+
+    assert_snapshot_attributes([
+      {
+        forecast_person_id: forecast_person.id,
+        forecast_project_id: forecast_project.id,
+        effective_date: start_date,
+        studio_id: 0,
+        hourly_cost: 70.61,
+        hours: 8,
+        needs_review: true
+      }
+    ])
+  end
+
+  test "#snapshot! does not flag new snapshot records for review for subcontractors without a studio" do
+    start_date = Date.new(2024, 1, 1)
+    end_date = Date.new(2024, 1, 10)
+
+    studio = Studio.create!({
+      name: "Sanctuary Computer",
+      accounting_prefix: "Development",
+      mini_name: "sc"
+    })
+
+    forecast_client = ForecastClient.create!
+
+    forecast_project = ForecastProject.create!({
+      id: 1,
+      name: "Test project",
+      forecast_client: forecast_client,
+      code: "ABCD-1",
+      notes: "subcontractor@some-other-agency.com:99.55p/h",
+      start_date: start_date
+    })
+
+    forecast_person = ForecastPerson.create!({
+      forecast_id: 123,
+      roles: ["Subcontractor", "Some non-identifiable studio"],
+      email: "subcontractor@some-other-agency.com"
+    })
+
+    ForecastAssignment.create!({
+      forecast_id: 111,
+      start_date: start_date,
+      end_date: end_date,
+      forecast_person: forecast_person,
+      forecast_project: forecast_project
+    })
+
+    snapshotter = Stacks::DailyFinancialSnapshotter.new(start_date, [studio])
+    snapshotter.snapshot!
+
+    assert_snapshot_attributes([
+      {
+        forecast_person_id: forecast_person.id,
+        forecast_project_id: forecast_project.id,
+        effective_date: start_date,
+        studio_id: 0,
+        hourly_cost: 99.55,
+        hours: 8,
+        needs_review: false
+      }
+    ])
+  end
+
+  test "#snapshot! does not create snapshot records for assignment days without hours" do
+    start_date = Date.new(2024, 1, 1)
+    end_date = Date.new(2024, 1, 10)
+
+    studio = Studio.create!({
+      name: "Sanctuary Computer",
+      accounting_prefix: "Development",
+      mini_name: "sc"
+    })
+
+    forecast_client = ForecastClient.create!
+
+    forecast_project = ForecastProject.create!({
+      id: 1,
+      name: "Test project",
+      forecast_client: forecast_client,
+      code: "ABCD-1",
+      start_date: start_date
+    })
+
+    user = AdminUser.create!({
+      email: "josh@sanctuary.computer",
+      password: "password"
+    })
+
+    forecast_person = ForecastPerson.create!({
+      forecast_id: 123,
+      roles: [studio.name],
+      email: user.email
+    })
+
+    FullTimePeriod.create!({
+      admin_user: user,
+      started_at: Date.new(2020, 1, 1),
+      ended_at: nil,
+      contributor_type: :five_day,
+      expected_utilization: 0.8
+    })
+
+    ForecastAssignment.create!({
+      forecast_id: 111,
+      start_date: start_date,
+      end_date: end_date,
+      forecast_person: forecast_person,
+      forecast_project: forecast_project,
+      allocation: 0
+    })
+
+    snapshotter = Stacks::DailyFinancialSnapshotter.new(start_date)
+    snapshotter.snapshot!
+
+    assert_snapshot_attributes([])
+  end
+
+  test "#snapshot! uses the current date as the effective date if no explicit date is supplied" do
+    start_date = Date.today - 1.day
+    end_date = Date.today + 1.day
+
+    studio = Studio.create!({
+      name: "Sanctuary Computer",
+      accounting_prefix: "Development",
+      mini_name: "sc"
+    })
+
+    forecast_client = ForecastClient.create!
+
+    forecast_project = ForecastProject.create!({
+      id: 1,
+      name: "Test project",
+      forecast_client: forecast_client,
+      code: "ABCD-1",
+      start_date: start_date
+    })
+
+    user = AdminUser.create!({
+      email: "josh@sanctuary.computer",
+      password: "password"
+    })
+
+    forecast_person = ForecastPerson.create!({
+      forecast_id: 123,
+      roles: [studio.name],
+      email: user.email
+    })
+
+    FullTimePeriod.create!({
+      admin_user: user,
+      started_at: Date.new(2020, 1, 1),
+      ended_at: nil,
+      contributor_type: :five_day,
+      expected_utilization: 0.8
+    })
+
+    ForecastAssignment.create!({
+      forecast_id: 111,
+      start_date: start_date,
+      end_date: end_date,
+      forecast_person: forecast_person,
+      forecast_project: forecast_project
+    })
+
+    snapshotter = Stacks::DailyFinancialSnapshotter.new
+    snapshotter.snapshot!
+
+    assert_snapshot_attributes([
+      {
+        forecast_person_id: forecast_person.id,
+        forecast_project_id: forecast_project.id,
+        effective_date: Date.today,
+        studio_id: studio.id,
+        hourly_cost: 70.61,
+        hours: 8,
+        needs_review: false
+      }
+    ])
+  end
+
+  test "#snapshot! with more complicated case, using multiple people and projects" do
+    start_date = Date.today - 1.day
+    end_date = Date.today + 1.day
+
+    studio_one = Studio.create!({
+      name: "Sanctuary Computer",
+      accounting_prefix: "Development",
+      mini_name: "sc"
+    })
+
+    studio_two = Studio.create!({
+      name: "XXIX",
+      accounting_prefix: "Design",
+      mini_name: "xxix"
+    })
+
+    forecast_client = ForecastClient.create!
+
+    past_project = ForecastProject.create!({
+      id: 1,
+      name: "Test project",
+      forecast_client: forecast_client,
+      code: "ABCD-1",
+      start_date: start_date - 2.days,
+      end_date: start_date - 2.days
+    })
+
+    current_project_one = ForecastProject.create!({
+      id: 2,
+      name: "Test project",
+      forecast_client: forecast_client,
+      code: "ABCD-1",
+      start_date: start_date,
+      end_date: end_date
+    })
+
+    current_project_two = ForecastProject.create!({
+      id: 3,
+      name: "Test project",
+      forecast_client: forecast_client,
+      code: "ABCD-1",
+      start_date: start_date,
+      end_date: end_date
+    })
+
+    future_project = ForecastProject.create!({
+      id: 4,
+      name: "Test project",
+      forecast_client: forecast_client,
+      code: "ABCD-1",
+      start_date: end_date + 2.days,
+      end_date: end_date + 2.days
+    })
+
+    user_one = AdminUser.create!({
+      email: "josh@sanctuary.computer",
+      password: "password"
+    })
+
+    user_two = AdminUser.create!({
+      email: "gandalf@sanctuary.computer",
+      password: "password"
+    })
+
+    person_one = ForecastPerson.create!({
+      forecast_id: 123,
+      roles: [studio_one.name],
+      email: user_one.email
+    })
+
+    person_two = ForecastPerson.create!({
+      forecast_id: 456,
+      roles: [studio_two.name],
+      email: user_two.email
+    })
+
+    FullTimePeriod.create!({
+      admin_user: user_one,
+      started_at: Date.new(2020, 1, 1),
+      ended_at: nil,
+      contributor_type: :five_day,
+      expected_utilization: 0.8
+    })
+
+    FullTimePeriod.create!({
+      admin_user: user_two,
+      started_at: Date.new(2020, 1, 1),
+      ended_at: nil,
+      contributor_type: :five_day,
+      expected_utilization: 0.8
+    })
+
+    [
+      past_project,
+      current_project_one,
+      current_project_two,
+      future_project
+    ].each_with_index do |project, index|
+      ForecastAssignment.create!({
+        forecast_id: (index * 2) + 1,
+        start_date: project.start_date,
+        end_date: project.end_date,
+        forecast_person: person_one,
+        forecast_project: project,
+        allocation: 4 * 60 * 60
+      })
+
+      ForecastAssignment.create!({
+        forecast_id: (index * 2) + 2,
+        start_date: project.start_date,
+        end_date: project.end_date,
+        forecast_person: person_two,
+        forecast_project: project,
+        allocation: 4 * 60 * 60
+      })
+    end
+
+    snapshotter = Stacks::DailyFinancialSnapshotter.new
+    snapshotter.snapshot!
+
+    assert_snapshot_attributes([
+      {
+        forecast_person_id: person_one.id,
+        forecast_project_id: current_project_one.id,
+        effective_date: Date.today,
+        studio_id: studio_one.id,
+        hourly_cost: 70.61,
+        hours: 4,
+        needs_review: false
+      },
+      {
+        forecast_person_id: person_two.id,
+        forecast_project_id: current_project_one.id,
+        effective_date: Date.today,
+        studio_id: studio_two.id,
+        hourly_cost: 70.61,
+        hours: 4,
+        needs_review: false
+      },
+      {
+        forecast_person_id: person_one.id,
+        forecast_project_id: current_project_two.id,
+        effective_date: Date.today,
+        studio_id: studio_one.id,
+        hourly_cost: 70.61,
+        hours: 4,
+        needs_review: false
+      },
+      {
+        forecast_person_id: person_two.id,
+        forecast_project_id: current_project_two.id,
+        effective_date: Date.today,
+        studio_id: studio_two.id,
+        hourly_cost: 70.61,
+        hours: 4,
+        needs_review: false
+      }
+    ])
+  end
+
+  test "#snapshot_all! creates snapshot records for all historical projects" do
+    ForecastAssignment.delete_all
+
+    today = Date.today
+
+    studio_one = Studio.create!({
+      name: "Sanctuary Computer",
+      accounting_prefix: "Development",
+      mini_name: "sc"
+    })
+
+    studio_two = Studio.create!({
+      name: "XXIX",
+      accounting_prefix: "Design",
+      mini_name: "xxix"
+    })
+
+    forecast_client = ForecastClient.create!
+
+    past_project = ForecastProject.create!({
+      id: 1,
+      name: "Test project",
+      forecast_client: forecast_client,
+      code: "ABCD-1",
+      start_date: today - 2.days,
+      end_date: today - 2.days
+    })
+
+    current_project_one = ForecastProject.create!({
+      id: 2,
+      name: "Test project",
+      forecast_client: forecast_client,
+      code: "ABCD-1",
+      start_date: today,
+      end_date: today
+    })
+
+    current_project_two = ForecastProject.create!({
+      id: 3,
+      name: "Test project",
+      forecast_client: forecast_client,
+      code: "ABCD-1",
+      start_date: today,
+      end_date: today
+    })
+
+    future_project = ForecastProject.create!({
+      id: 4,
+      name: "Test project",
+      forecast_client: forecast_client,
+      code: "ABCD-1",
+      start_date: today + 2.days,
+      end_date: today + 2.days
+    })
+
+    user_one = AdminUser.create!({
+      email: "josh@sanctuary.computer",
+      password: "password"
+    })
+
+    user_two = AdminUser.create!({
+      email: "gandalf@sanctuary.computer",
+      password: "password"
+    })
+
+    person_one = ForecastPerson.create!({
+      forecast_id: 123,
+      roles: [studio_one.name],
+      email: user_one.email
+    })
+
+    person_two = ForecastPerson.create!({
+      forecast_id: 456,
+      roles: [studio_two.name],
+      email: user_two.email
+    })
+
+    FullTimePeriod.create!({
+      admin_user: user_one,
+      started_at: Date.new(2020, 1, 1),
+      ended_at: nil,
+      contributor_type: :five_day,
+      expected_utilization: 0.8
+    })
+
+    FullTimePeriod.create!({
+      admin_user: user_two,
+      started_at: Date.new(2020, 1, 1),
+      ended_at: nil,
+      contributor_type: :five_day,
+      expected_utilization: 0.8
+    })
+
+    [
+      past_project,
+      current_project_one,
+      current_project_two,
+      future_project
+    ].each_with_index do |project, index|
+      ForecastAssignment.create!({
+        forecast_id: (index * 2) + 1,
+        start_date: project.start_date,
+        end_date: project.end_date,
+        forecast_person: person_one,
+        forecast_project: project,
+        allocation: 4 * 60 * 60
+      })
+
+      ForecastAssignment.create!({
+        forecast_id: (index * 2) + 2,
+        start_date: project.start_date,
+        end_date: project.end_date,
+        forecast_person: person_two,
+        forecast_project: project,
+        allocation: 4 * 60 * 60
+      })
+    end
+
+    Stacks::DailyFinancialSnapshotter.snapshot_all!
+
+    assert_snapshot_attributes([
+      {
+        forecast_person_id: person_one.id,
+        forecast_project_id: past_project.id,
+        effective_date: past_project.start_date,
+        studio_id: studio_one.id,
+        hourly_cost: 70.61,
+        hours: 4,
+        needs_review: false
+      },
+      {
+        forecast_person_id: person_two.id,
+        forecast_project_id: past_project.id,
+        effective_date: past_project.start_date,
+        studio_id: studio_two.id,
+        hourly_cost: 70.61,
+        hours: 4,
+        needs_review: false
+      },
+      {
+        forecast_person_id: person_one.id,
+        forecast_project_id: current_project_one.id,
+        effective_date: current_project_one.start_date,
+        studio_id: studio_one.id,
+        hourly_cost: 70.61,
+        hours: 4,
+        needs_review: false
+      },
+      {
+        forecast_person_id: person_two.id,
+        forecast_project_id: current_project_one.id,
+        effective_date: current_project_one.start_date,
+        studio_id: studio_two.id,
+        hourly_cost: 70.61,
+        hours: 4,
+        needs_review: false
+      },
+      {
+        forecast_person_id: person_one.id,
+        forecast_project_id: current_project_two.id,
+        effective_date: current_project_two.start_date,
+        studio_id: studio_one.id,
+        hourly_cost: 70.61,
+        hours: 4,
+        needs_review: false
+      },
+      {
+        forecast_person_id: person_two.id,
+        forecast_project_id: current_project_two.id,
+        effective_date: current_project_two.start_date,
+        studio_id: studio_two.id,
+        hourly_cost: 70.61,
+        hours: 4,
+        needs_review: false
+      }
+    ])
+  end
+
+  private
+
+  def assert_snapshot_attributes(expected_attributes)
+    fields = [
+      :forecast_person_id,
+      :forecast_project_id,
+      :effective_date,
+      :studio_id,
+      :hourly_cost,
+      :hours,
+      :needs_review
+    ]
+
+    actual_attributes = ForecastAssignmentDailyFinancialSnapshot
+      .pluck(*fields)
+      .map { |row| fields.zip(row).to_h }
+
+    assert_equal(expected_attributes, actual_attributes)
+  end
+end

--- a/test/models/project_tracker_test.rb
+++ b/test/models/project_tracker_test.rb
@@ -1,0 +1,285 @@
+require "test_helper"
+
+class ProjectTrackerTest < ActiveSupport::TestCase
+  test "#generate_snapshot! records the expected snapshot data" do
+    start_date = Date.new(2024, 1, 1) # January 1st was a Monday.
+    end_date = Date.new(2024, 1, 10)
+
+    studio = Studio.create!({
+      name: "Sanctuary Computer",
+      accounting_prefix: "Development",
+      mini_name: "sc",
+      snapshot: {
+        "month" => [
+          {
+            "label" => "January, 2024",
+            "cash" => {
+              "datapoints" => {
+                "cost_per_sellable_hour" => {
+                  "value" => 123
+                },
+                "actual_cost_per_hour_sold" => {
+                  "value" => 100
+                }
+              }
+            },
+            "accrual" => {
+              "datapoints" => {
+                "cost_per_sellable_hour" => {
+                  "value" => 111
+                },
+                "actual_cost_per_hour_sold" => {
+                  "value" => 90
+                }
+              }
+            }
+          }
+        ]
+      }
+    })
+
+    forecast_client = ForecastClient.create!
+
+    forecast_project = ForecastProject.create!({
+      id: 1,
+      name: "Test project",
+      forecast_client: forecast_client,
+      code: "ABCD-1",
+    })
+
+    user_one = AdminUser.create!({
+      email: "josh@sanctuary.computer",
+      password: "password",
+    })
+
+    user_two = AdminUser.create!({
+      email: "antijosh@sanctuary.computer",
+      password: "password",
+    })
+
+    person_one = ForecastPerson.create!({
+      forecast_id: 123,
+      roles: [studio.name],
+      email: user_one.email
+    })
+
+    person_two = ForecastPerson.create!({
+      forecast_id: 456,
+      roles: [studio.name],
+      email: user_two.email
+    })
+
+    FullTimePeriod.create!({
+      admin_user: user_one,
+      started_at: Date.new(2020, 1, 1),
+      ended_at: nil,
+      contributor_type: :five_day,
+      expected_utilization: 0.8
+    })
+
+    FullTimePeriod.create!({
+      admin_user: user_two,
+      started_at: Date.new(2020, 1, 1),
+      ended_at: nil,
+      contributor_type: :five_day,
+      expected_utilization: 0.8
+    })
+
+    assignment_one = ForecastAssignment.create!({
+      forecast_id: 111,
+      start_date: start_date,
+      end_date: start_date + 4.days,
+      forecast_person: person_one,
+      forecast_project: forecast_project
+    })
+
+    assignment_two = ForecastAssignment.create!({
+      forecast_id: 222,
+      start_date: start_date,
+      end_date: start_date + 4.days,
+      forecast_person: person_two,
+      forecast_project: forecast_project
+    })
+
+    assignment_three = ForecastAssignment.create!({
+      forecast_id: 333,
+      start_date: start_date + 1.week,
+      end_date: start_date + 1.week + 2.days,
+      forecast_person: person_one,
+      forecast_project: forecast_project
+    })
+
+    assignment_four = ForecastAssignment.create!({
+      forecast_id: 444,
+      start_date: start_date + 1.week,
+      end_date: start_date + 1.week + 2.days,
+      forecast_person: person_two,
+      forecast_project: forecast_project
+    })
+
+    current_date = start_date
+
+    while current_date <= end_date
+      if current_date.saturday? || current_date.sunday?
+        current_date = current_date + 1.day
+        next
+      end
+
+      ForecastAssignmentDailyFinancialSnapshot.create!({
+        forecast_assignment: (
+          assignment_one.end_date >= current_date ?
+          assignment_one :
+          assignment_three
+        ),
+        forecast_person_id: person_one.id,
+        forecast_project_id: forecast_project.id,
+        effective_date: current_date,
+        studio_id: studio.id,
+        hourly_cost: 55,
+        hours: 6,
+        needs_review: false
+      })
+
+      ForecastAssignmentDailyFinancialSnapshot.create!({
+        forecast_assignment: (
+          assignment_two.end_date >= current_date ?
+          assignment_two :
+          assignment_four
+        ),
+        forecast_person_id: person_two.id,
+        forecast_project_id: forecast_project.id,
+        effective_date: current_date,
+        studio_id: studio.id,
+        hourly_cost: 44,
+        hours: 7,
+        needs_review: false
+      })
+
+      current_date = current_date + 1.day
+    end
+
+    project_tracker_links = [
+      ProjectTrackerLink.new({
+        name: "SOW link",
+        url: "https://example.com",
+        link_type: "sow"
+      }),
+      ProjectTrackerLink.new({
+        name: "MSA link",
+        url: "https://example.com",
+        link_type: "msa"
+      })
+    ]
+
+    tracker = ProjectTracker.create!({
+      name: "Test project 1",
+      forecast_projects: [forecast_project],
+      project_tracker_links: project_tracker_links
+    })
+
+    tracker.generate_snapshot!
+    current_timestamp = DateTime.now.iso8601
+
+    assert_equal({
+      "generated_at"=> current_timestamp,
+      "hours" => [
+        {"x" => "2024-01-01", "y" => 16},
+        {"x" => "2024-01-02", "y" => 32},
+        {"x" => "2024-01-03", "y" => 48},
+        {"x" => "2024-01-04", "y" => 64},
+        {"x" => "2024-01-05", "y" => 80},
+        {"x" => "2024-01-06", "y" => 80},
+        {"x" => "2024-01-07", "y" => 80},
+        {"x" => "2024-01-08", "y" => 96},
+        {"x" => "2024-01-09", "y" => 112},
+        {"x" => "2024-01-10", "y" => 128}
+      ],
+      "hours_new"=> [
+        {"x" => "2024-01-01", "y" => 13},
+        {"x" => "2024-01-02", "y" => 26},
+        {"x" => "2024-01-03", "y" => 39},
+        {"x" => "2024-01-04", "y" => 52},
+        {"x" => "2024-01-05", "y" => 65},
+        {"x" => "2024-01-06", "y" => 65},
+        {"x" => "2024-01-07", "y" => 65},
+        {"x" => "2024-01-08", "y" => 78},
+        {"x" => "2024-01-09", "y" => 91},
+        {"x" => "2024-01-10", "y" => 104}
+      ],
+      "spend"=> [
+        {"x" => "2024-01-01", "y" => 2800},
+        {"x" => "2024-01-02", "y" => 5600},
+        {"x" => "2024-01-03", "y" => 8400},
+        {"x" => "2024-01-04", "y" => 11200},
+        {"x" => "2024-01-05", "y" => 14000},
+        {"x" => "2024-01-06", "y" => 14000},
+        {"x" => "2024-01-07", "y" => 14000},
+        {"x" => "2024-01-08", "y" => 16800},
+        {"x" => "2024-01-09", "y" => 19600},
+        {"x" => "2024-01-10", "y" => 22400}
+      ],
+      "hours_total" => 128,
+      "hours_total_new" => 104,
+      "spend_total" => 22400,
+      "cash"=> {
+        "cosr"=> [
+          {"x" => "2024-01-01", "y" => 1600},
+          {"x" => "2024-01-02", "y" => 3200},
+          {"x" => "2024-01-03", "y" => 4800},
+          {"x" => "2024-01-04", "y" => 6400},
+          {"x" => "2024-01-05", "y" => 8000},
+          {"x" => "2024-01-06", "y" => 8000},
+          {"x" => "2024-01-07", "y" => 8000},
+          {"x" => "2024-01-08", "y" => 9600},
+          {"x" => "2024-01-09", "y" => 11200},
+          {"x" => "2024-01-10", "y" => 12800}
+        ],
+        "cosr_new"=> [
+          {"x" => "2024-01-01", "y" => 638},
+          {"x" => "2024-01-02", "y" => 1276},
+          {"x" => "2024-01-03", "y" => 1914},
+          {"x" => "2024-01-04", "y" => 2552},
+          {"x" => "2024-01-05", "y" => 3190},
+          {"x" => "2024-01-06", "y" => 3190},
+          {"x" => "2024-01-07", "y" => 3190},
+          {"x" => "2024-01-08", "y" => 3828},
+          {"x" => "2024-01-09", "y" => 4466},
+          {"x" => "2024-01-10", "y" => 5104}
+        ],
+        "cosr_total" => 12800,
+        "cosr_total_new" => 5104
+      },
+      "accrual"=> {
+        "cosr"=> [
+          {"x" => "2024-01-01", "y" => 1440},
+          {"x" => "2024-01-02", "y" => 2880},
+          {"x" => "2024-01-03", "y" => 4320},
+          {"x" => "2024-01-04", "y" => 5760},
+          {"x" => "2024-01-05", "y" => 7200},
+          {"x" => "2024-01-06", "y" => 7200},
+          {"x" => "2024-01-07", "y" => 7200},
+          {"x" => "2024-01-08", "y" => 8640},
+          {"x" => "2024-01-09", "y" => 10080},
+          {"x" => "2024-01-10", "y" => 11520}
+        ],
+        "cosr_new"=> [
+          {"x" => "2024-01-01", "y" => 638},
+          {"x" => "2024-01-02", "y" => 1276},
+          {"x" => "2024-01-03", "y" => 1914},
+          {"x" => "2024-01-04", "y" => 2552},
+          {"x" => "2024-01-05", "y" => 3190},
+          {"x" => "2024-01-06", "y" => 3190},
+          {"x" => "2024-01-07", "y" => 3190},
+          {"x" => "2024-01-08", "y" => 3828},
+          {"x" => "2024-01-09", "y" => 4466},
+          {"x" => "2024-01-10", "y" => 5104}
+        ],
+        "cosr_total" => 11520,
+        # ($44 * 7hrs * 8days) + ($55 * 6hrs * 8days) = $5104
+        "cosr_total_new" => 5104
+      }
+    }, tracker.snapshot.merge({
+      "generated_at" => current_timestamp
+    }))
+  end
+end


### PR DESCRIPTION
## Overview
**This PR:**
- Adds a new `forecast_assignment_daily_financial_snapshots` table for storing daily cost information for each Forecast assignment
- Adds a new `Snapshotter` utility that can be used to (re)create these snapshot records for all projects active on a given day
- Uses the `Snapshotter` to rcreate all daily snapshots during the daily maintenance task
- Adds a new `CostOfServicesRenderedCalculator` that reads these snapshots from the database and builds the expected COSR data
- Adds the new COSR data to the `ProjectTracker` daily snapshot


Happy to break this up into separate PR's if that's easier.

**This PR _does not_:**
- Render the new COSR numbers in the UI.
- Send system notifications to admins warning of snapshots needing review.

I'll put up separate followup PR's for each of these.



## Some notes on naming
Hugh suggested in Twist that we call this either `daily_finances` or `forecast_person_project_tracker_daily_finances`. I'd be fine with either of these for the table name but it gets a little weird when we get into the singular form for ActiveRecord (`DailyFinance.where(...)` feels weird). We could use inflectors but meh. So I thought maybe we could use `daily_financial_snapshots` instead.

And then for the prefix, I went with `forecast_assignment` because that's what each of these snapshot records are most closely associated with. (The `forecast_person_id` and `forecast_project_id` fields on the table are just denormalized for querying purposes, not because they imply a direct AR relation.)