### PR TITLE
[FEAT] Add new COSR metrics to project tracker budget burnup chart

### DIFF
--- a/app/admin/project_trackers.rb
+++ b/app/admin/project_trackers.rb
@@ -331,6 +331,16 @@ ActiveAdmin.register ProjectTracker do
       })
     end
 
+    if resource.snapshot[accounting_method].try(:dig, "cosr_new")
+      burnup_data[:data][:datasets].push({
+        borderColor: Stacks::Utils::COLORS[9], # color of dots
+        backgroundColor: Stacks::Utils::COLORS[9], # color of line
+        label: "Cost of Services Rendered (COSR - NEW)",
+        data: resource.snapshot[accounting_method].try(:dig, "cosr_new"),
+        pointRadius: 1
+      })
+    end
+
     render(partial: 'show', locals: {
       burnup_data: burnup_data
     })


### PR DESCRIPTION
This uses the new COSR data added to project snapshots via https://github.com/sanctuarycomputer/stacks/pull/49 to render more accurate per-person cost data on the project tracker burnup chart.

![new_cosr_graph](https://github.com/sanctuarycomputer/stacks/assets/34255985/144cdc8f-2ccc-449e-bd09-02b313d3cca0)