### PR TITLE
[FEAT] Use updated COSR numbers for COSR Explorer

### DIFF
--- a/app/admin/project_cosr_explorer.rb
+++ b/app/admin/project_cosr_explorer.rb
@@ -2,20 +2,27 @@ ActiveAdmin.register_page "Project COSR Explorer" do
   belongs_to :project_tracker
 
   content title: proc { I18n.t("active_admin.project_cosr_explorer") } do
-    accounting_method = session[:accounting_method] || "cash"
-    all_gradations = ["month", "project_to_date"]
-    default_gradation = "month"
-    current_gradation = params["gradation"] || default_gradation
-
     project_tracker = ProjectTracker.find(params[:project_tracker_id])
-    cosr = project_tracker.cost_of_services_rendered(current_gradation)
+    cosr = project_tracker.cost_of_services_rendered_new
+
+    monthly_studio_rollups, forecast_person_ids, studio_ids = build_monthly_rollup(cosr)
+    forecast_people = ForecastPerson.find(forecast_person_ids)
+    studios = Studio.find(studio_ids)
+
+    forecast_people_hash = forecast_people.reduce({}) do |acc, forecast_person|
+      acc[forecast_person.id] = forecast_person
+      acc
+    end
+
+    studios_hash = studios.reduce({}) do |acc, studio|
+      acc[studio.id] = studio
+      acc
+    end
 
     render(partial: "project_cosr_explorer", locals: {
-      all_gradations: all_gradations,
-      default_gradation: all_gradations.first,
-      current_gradation: current_gradation,
-      cosr: cosr,
-      accounting_method: accounting_method,
+      monthly_studio_rollups: monthly_studio_rollups,
+      studios: studios_hash,
+      forecast_people: forecast_people_hash
     })
   end
 end

--- a/app/helpers/cosr_explorer_helper.rb
+++ b/app/helpers/cosr_explorer_helper.rb
@@ -1,0 +1,70 @@
+module CosrExplorerHelper
+  # Takes the COSR data format emitted from ProjectTracker.cost_of_services_rendered,
+  # and transforms it into the format necessary for use in the COSR Explorer template.
+  def build_monthly_rollup(cosr_data)
+    forecast_person_ids = []
+    studio_ids = []
+
+    monthly_studio_rollups = cosr_data.reduce({}) do |acc, tuple|
+      date, studio_datas = tuple
+      month_start = date.beginning_of_month
+      acc[month_start] ||= {}
+
+      studio_datas.each do |studio_id, studio_data|
+        studio_rollup = acc[month_start][studio_id] ||= {
+          total_cost: 0,
+          assignment_rollups: {}
+        }
+
+        studio_rollup[:total_cost] += studio_data[:total_cost]
+        studio_ids << studio_id
+
+        studio_data[:assignment_costs].each do |assignment_cost|
+          person_id, hourly_cost, hours, effective_date = assignment_cost.fetch_values(
+            :forecast_person_id,
+            :hourly_cost,
+            :hours,
+            :effective_date
+          )
+
+          forecast_person_ids << person_id
+          composite_key = "#{person_id}-#{hourly_cost}"
+
+          assignment_rollup = studio_rollup[:assignment_rollups][composite_key] ||= {
+            forecast_person_id: person_id,
+            hours: 0,
+            hourly_cost: hourly_cost,
+            total_cost: 0,
+            start_date: effective_date,
+            end_date: effective_date
+          }
+
+          assignment_rollup[:hours] += hours
+          assignment_rollup[:total_cost] += hourly_cost * hours
+          assignment_rollup[:start_date] = [assignment_rollup[:start_date], date].min
+          assignment_rollup[:end_date] = [assignment_rollup[:end_date], date].max
+        end
+      end
+
+      acc
+    end
+
+    [monthly_studio_rollups, forecast_person_ids.uniq, studio_ids.uniq]
+  end
+
+  def format_date_range(assignment_rollup)
+    start_date, end_date = assignment_rollup.fetch_values(:start_date, :end_date)
+
+    if start_date == end_date
+      format_date(start_date)
+    else
+      "#{format_date(start_date)} to #{format_date(end_date)}"
+    end
+  end
+
+  private
+
+  def format_date(date)
+    date.strftime("%-m/%-d")
+  end
+end

--- a/app/views/admin/project_cosr_explorer/_project_cosr_explorer.html.erb
+++ b/app/views/admin/project_cosr_explorer/_project_cosr_explorer.html.erb
@@ -1,20 +1,21 @@
-<% cosr.reverse_each do |p| %>
-  <% period, by_studio = p %>
+<% monthly_studio_rollups.reverse_each do |p| %>
+  <% month_start, studio_rollups = p %>
 
   <div class="title_bar" id="title_bar" style="padding: 80px 0px 20px 0px;">
     <div id="titlebar_left">
       <h2 id="page_title">
-        <%= period.label %>
+        <%= month_start.strftime("%B %Y") %>
       </h2>
     </div>
     <div id="titlebar_right">
       <h2>
-        <%= number_to_currency by_studio.reduce(0){|acc, d| acc += d[1][:total_studio_hours] * d[1][accounting_method.to_sym][:actual_cost_per_hour_sold]; acc} %>
+        <%= number_to_currency studio_rollups.values.map{ |rollup| rollup[:total_cost] }.sum %>
       </h2>
     </div>
   </div>
 
-  <% by_studio.keys.each do |studio| %>
+  <% studio_rollups.each do |studio_id, studio_rollup| %>
+    <% studio = studios.fetch(studio_id) %>
     <table border="0" cellspacing="0" cellpadding="0" class="index_table index" style="margin-bottom:20px;table-layout:fixed;">
       <thead>
         <tr>
@@ -22,32 +23,39 @@
             <%= link_to "#{studio.name} ↗", admin_studio_path(studio) %>
           </th>
           <th class="col">
+            Date(s)
+          </th>
+          <th class="col">
             Hours
           </th>
           <th class="col">
-            @ Cost per Sellable Hour <%= number_to_currency by_studio[studio][accounting_method.to_sym][:cost_per_sellable_hour] %>
+            Hourly rate
           </th>
           <th class="col text-right">
-            @ Actual Cost per Hour Sold <%= number_to_currency by_studio[studio][accounting_method.to_sym][:actual_cost_per_hour_sold] %>
+            Total cost
           </th>
         </tr>
       </thead>
 
       <tbody>
-        <% by_studio[studio][:forecast_people].each_with_index do |tuple, index| %>
-          <% person, data = tuple %>
+        <% studio_rollup.fetch(:assignment_rollups).each_with_index do |tuple, index| %>
+          <% _key, assignment_rollup = tuple %>
+          <% person = forecast_people.fetch(assignment_rollup[:forecast_person_id]) %>
           <tr class="<%= index.even? ? "even" : "odd" %>">
             <td class="col">
               <%= person.email %>
             </td>
             <td class="col">
-              <%= data[:hours] %>
+              <%= format_date_range(assignment_rollup) %>
             </td>
             <td class="col">
-              <%= number_to_currency data[:hours] * by_studio[studio][accounting_method.to_sym][:cost_per_sellable_hour] %>
+              <%= assignment_rollup.fetch(:hours) %>
+            </td>
+            <td class="col">
+              <%= number_to_currency assignment_rollup.fetch(:hourly_cost) %>
             </td>
             <td class="col text-right">
-              <%= number_to_currency data[:hours] * by_studio[studio][accounting_method.to_sym][:actual_cost_per_hour_sold] %>
+              <%= number_to_currency assignment_rollup.fetch(:total_cost) %>
             </td>
           </tr>
         <% end %>
@@ -57,13 +65,14 @@
           </td>
           <td></td>
           <td></td>
+          <td></td>
           <td class="col text-right">
-            <%= number_to_currency by_studio[studio][:total_studio_hours] * by_studio[studio][accounting_method.to_sym][:actual_cost_per_hour_sold] %>
+            <%= number_to_currency studio_rollup.fetch(:total_cost) %>
           </td>
         </tr>
       </tbody>
     </table>
   <% end %>
-  
+
 
 <% end %>

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -397,3 +397,7 @@ ActiveAdmin::Views::Pages::Index.class_eval do
     end
   end
 end
+
+module ActiveAdmin::ViewHelpers
+  include CosrExplorerHelper
+end

--- a/lib/stacks/cost_of_services_rendered_calculator.rb
+++ b/lib/stacks/cost_of_services_rendered_calculator.rb
@@ -15,6 +15,7 @@ class Stacks::CostOfServicesRenderedCalculator
         @end_date
       )
       .pluck(
+        :forecast_person_id,
         :forecast_assignment_id,
         :effective_date,
         :hours,
@@ -27,6 +28,7 @@ class Stacks::CostOfServicesRenderedCalculator
 
       while daily_snapshots.length > 0
         (
+          forecast_person_id,
           forecast_assignment_id,
           effective_date,
           hours,
@@ -48,7 +50,9 @@ class Stacks::CostOfServicesRenderedCalculator
         acc[date][studio_id][:total_cost] += (hours * hourly_cost).to_f
 
         acc[date][studio_id][:assignment_costs] << {
+          forecast_person_id: forecast_person_id,
           forecast_assignment_id: forecast_assignment_id,
+          effective_date: date,
           hours: hours,
           hourly_cost: hourly_cost
         }

--- a/test/helpers/cosr_explorer_helper_test.rb
+++ b/test/helpers/cosr_explorer_helper_test.rb
@@ -1,0 +1,157 @@
+require "test_helper"
+
+class CosrExplorerHelperTest < ActiveSupport::TestCase
+  include CosrExplorerHelper
+
+  test "#build_monthly_rollup returns expected data for use in the template" do
+    studio_id = 3
+
+    monthly_studio_rollups, forecast_person_ids, studio_ids = build_monthly_rollup({
+      Date.new(2024, 3, 13) => {
+        studio_id => {
+          total_hours: 4,
+          total_cost: 311.16,
+          assignment_costs: [
+            {
+              forecast_person_id: 79984011,
+              forecast_assignment_id: 401479,
+              hours: 4,
+              hourly_cost: 77.79,
+              effective_date: Date.new(2024, 3, 13)
+            }
+          ]
+        }
+      },
+      Date.new(2024, 3, 14) => {
+        studio_id => {
+          total_hours: 3,
+          total_cost: 226.19,
+          assignment_costs: [
+            {
+              forecast_person_id: 79942931,
+              forecast_assignment_id: 994567,
+              hours: 1,
+              hourly_cost: 70.61,
+              effective_date: Date.new(2024, 3, 14)
+            },
+            {
+              forecast_person_id: 79983971,
+              forecast_assignment_id: 401479,
+              hours: 2,
+              hourly_cost: 77.79,
+              effective_date: Date.new(2024, 3, 14)
+            }
+          ]
+        }
+      },
+      Date.new(2024, 3, 15) => {
+        studio_id => {
+          total_hours: 3,
+          total_cost: 233.37,
+          assignment_costs: [
+            {
+              forecast_person_id: 79983787,
+              forecast_assignment_id: 401479,
+              hours: 3,
+              hourly_cost: 77.79,
+              effective_date: Date.new(2024, 3, 15)
+            }
+          ]
+        }
+      },
+      Date.new(2024, 3, 16) => {},
+      Date.new(2024, 3, 17) => {},
+      Date.new(2024, 3, 18) => {},
+      Date.new(2024, 3, 19) => {
+        studio_id => {
+          total_hours: 4,
+          total_cost: 311.16,
+          assignment_costs: [
+            {
+              forecast_person_id: 79983767,
+              forecast_assignment_id: 401479,
+              hours: 4,
+              hourly_cost: 77.79,
+              effective_date: Date.new(2024, 3, 19)
+            }
+          ]
+        }
+      }
+    })
+
+    assert_equal({
+      Date.new(2024, 3, 1) => {
+				studio_id => {
+          total_cost: 1081.88,
+          assignment_rollups: {
+            "79984011-77.79" => {
+              forecast_person_id: 79984011,
+              hours: 4,
+              hourly_cost: 77.79,
+              total_cost: 311.16,
+              start_date: Date.new(2024, 3, 13),
+              end_date: Date.new(2024, 3, 13)
+            },
+            "79942931-70.61" => {
+              forecast_person_id: 79942931,
+              hours: 1,
+              hourly_cost: 70.61,
+              total_cost: 70.61,
+              start_date: Date.new(2024, 3, 14),
+              end_date: Date.new(2024, 3, 14)
+            },
+            "79983971-77.79" => {
+              forecast_person_id: 79983971,
+              hours: 2,
+              hourly_cost: 77.79,
+              total_cost: 155.58,
+              start_date: Date.new(2024, 3, 14),
+              end_date: Date.new(2024, 3, 14)
+            },
+            "79983787-77.79" => {
+              forecast_person_id: 79983787,
+              hours: 3,
+              hourly_cost: 77.79,
+              total_cost: 233.37,
+              start_date: Date.new(2024, 3, 15),
+              end_date: Date.new(2024, 3, 15)
+            },
+            "79983767-77.79" => {
+              forecast_person_id: 79983767,
+              hours: 4,
+              hourly_cost: 77.79,
+              total_cost: 311.16,
+              start_date: Date.new(2024, 3, 19),
+              end_date: Date.new(2024, 3, 19)
+            }
+          }
+        }
+      }
+    }, monthly_studio_rollups)
+
+    assert_equal([studio_id], studio_ids)
+
+    assert_equal(
+      [79984011, 79942931, 79983971, 79983787, 79983767],
+      forecast_person_ids
+    )
+  end
+
+  test "#format_date_range returns the expected string when the specified start and end dates are different" do
+    formatted_date = format_date_range({
+      start_date: Date.new(2024, 3, 1),
+      end_date: Date.new(2024, 3, 15)
+    })
+
+    assert_equal(formatted_date, "3/1 to 3/15")
+  end
+
+  test "#format_date_range returns the expected string when the specified start and end dates are the same" do
+    formatted_date = format_date_range({
+      start_date: Date.new(2024, 3, 1),
+      end_date: Date.new(2024, 3, 1)
+    })
+
+    assert_equal(formatted_date, "3/1")
+  end
+end

--- a/test/lib/stacks/cost_of_services_rendered_calculator_test.rb
+++ b/test/lib/stacks/cost_of_services_rendered_calculator_test.rb
@@ -135,14 +135,18 @@ class Stacks::CostOfServicesRenderedCalculatorTest < ActiveSupport::TestCase
           total_cost: 495,
           assignment_costs: [
             {
+              forecast_person_id: person_one.id,
               forecast_assignment_id: assignment_one.id,
               hours: 7,
-              hourly_cost: 33
+              hourly_cost: 33,
+              effective_date: start_date
             },
             {
+              forecast_person_id: person_two.id,
               forecast_assignment_id: assignment_two.id,
               hours: 6,
-              hourly_cost: 44
+              hourly_cost: 44,
+              effective_date: start_date
             }
           ]
         }
@@ -153,14 +157,18 @@ class Stacks::CostOfServicesRenderedCalculatorTest < ActiveSupport::TestCase
           total_cost: 495,
           assignment_costs: [
             {
+              forecast_person_id: person_one.id,
               forecast_assignment_id: assignment_one.id,
               hours: 7,
-              hourly_cost: 33
+              hourly_cost: 33,
+              effective_date: start_date + 1.day
             },
             {
+              forecast_person_id: person_two.id,
               forecast_assignment_id: assignment_two.id,
               hours: 6,
-              hourly_cost: 44
+              hourly_cost: 44,
+              effective_date: start_date + 1.day
             }
           ]
         }
@@ -171,14 +179,18 @@ class Stacks::CostOfServicesRenderedCalculatorTest < ActiveSupport::TestCase
           total_cost: 495,
           assignment_costs: [
             {
+              forecast_person_id: person_one.id,
               forecast_assignment_id: assignment_one.id,
               hours: 7,
-              hourly_cost: 33
+              hourly_cost: 33,
+              effective_date: start_date + 2.days
             },
             {
+              forecast_person_id: person_two.id,
               forecast_assignment_id: assignment_two.id,
               hours: 6,
-              hourly_cost: 44
+              hourly_cost: 44,
+              effective_date: start_date + 2.days
             }
           ]
         }
@@ -189,14 +201,18 @@ class Stacks::CostOfServicesRenderedCalculatorTest < ActiveSupport::TestCase
           total_cost: 495,
           assignment_costs: [
             {
+              forecast_person_id: person_one.id,
               forecast_assignment_id: assignment_one.id,
               hours: 7,
-              hourly_cost: 33
+              hourly_cost: 33,
+              effective_date: start_date + 3.days
             },
             {
+              forecast_person_id: person_two.id,
               forecast_assignment_id: assignment_two.id,
               hours: 6,
-              hourly_cost: 44
+              hourly_cost: 44,
+              effective_date: start_date + 3.days
             }
           ]
         }
@@ -207,14 +223,18 @@ class Stacks::CostOfServicesRenderedCalculatorTest < ActiveSupport::TestCase
           total_cost: 495,
           assignment_costs: [
             {
+              forecast_person_id: person_one.id,
               forecast_assignment_id: assignment_one.id,
               hours: 7,
-              hourly_cost: 33
+              hourly_cost: 33,
+              effective_date: start_date + 4.days
             },
             {
+              forecast_person_id: person_two.id,
               forecast_assignment_id: assignment_two.id,
               hours: 6,
-              hourly_cost: 44
+              hourly_cost: 44,
+              effective_date: start_date + 4.days
             }
           ]
         }
@@ -225,14 +245,18 @@ class Stacks::CostOfServicesRenderedCalculatorTest < ActiveSupport::TestCase
           total_cost: 539,
           assignment_costs: [
             {
+              forecast_person_id: person_one.id,
               forecast_assignment_id: assignment_three.id,
               hours: 6,
-              hourly_cost: 44
+              hourly_cost: 44,
+              effective_date: start_date + 5.days
             },
             {
+              forecast_person_id: person_two.id,
               forecast_assignment_id: assignment_four.id,
               hours: 5,
-              hourly_cost: 55
+              hourly_cost: 55,
+              effective_date: start_date + 5.days
             }
           ]
         }
@@ -243,14 +267,18 @@ class Stacks::CostOfServicesRenderedCalculatorTest < ActiveSupport::TestCase
           total_cost: 539,
           assignment_costs: [
             {
+              forecast_person_id: person_one.id,
               forecast_assignment_id: assignment_three.id,
               hours: 6,
-              hourly_cost: 44
+              hourly_cost: 44,
+              effective_date: start_date + 6.days
             },
             {
+              forecast_person_id: person_two.id,
               forecast_assignment_id: assignment_four.id,
               hours: 5,
-              hourly_cost: 55
+              hourly_cost: 55,
+              effective_date: start_date + 6.days
             }
           ]
         }
@@ -261,14 +289,18 @@ class Stacks::CostOfServicesRenderedCalculatorTest < ActiveSupport::TestCase
           total_cost: 539,
           assignment_costs: [
             {
+              forecast_person_id: person_one.id,
               forecast_assignment_id: assignment_three.id,
               hours: 6,
-              hourly_cost: 44
+              hourly_cost: 44,
+              effective_date: start_date + 7.days
             },
             {
+              forecast_person_id: person_two.id,
               forecast_assignment_id: assignment_four.id,
               hours: 5,
-              hourly_cost: 55
+              hourly_cost: 55,
+              effective_date: start_date + 7.days
             }
           ]
         }
@@ -279,14 +311,18 @@ class Stacks::CostOfServicesRenderedCalculatorTest < ActiveSupport::TestCase
           total_cost: 539,
           assignment_costs: [
             {
+              forecast_person_id: person_one.id,
               forecast_assignment_id: assignment_three.id,
               hours: 6,
-              hourly_cost: 44
+              hourly_cost: 44,
+              effective_date: start_date + 8.days
             },
             {
+              forecast_person_id: person_two.id,
               forecast_assignment_id: assignment_four.id,
               hours: 5,
-              hourly_cost: 55
+              hourly_cost: 55,
+              effective_date: start_date + 8.days
             }
           ]
         }
@@ -297,14 +333,18 @@ class Stacks::CostOfServicesRenderedCalculatorTest < ActiveSupport::TestCase
           total_cost: 539,
           assignment_costs: [
             {
+              forecast_person_id: person_one.id,
               forecast_assignment_id: assignment_three.id,
               hours: 6,
-              hourly_cost: 44
+              hourly_cost: 44,
+              effective_date: start_date + 9.days
             },
             {
+              forecast_person_id: person_two.id,
               forecast_assignment_id: assignment_four.id,
               hours: 5,
-              hourly_cost: 55
+              hourly_cost: 55,
+              effective_date: start_date + 9.days
             }
           ]
         }


### PR DESCRIPTION
Now that we have updated logic for calculating more accurate COSR numbers for project trackers, we can start showing those numbers in the COSR explorer page.

This requires a few changes from how the page is currently rendered:
- We need to potentially show different line items for team members based on their hourly rate. If they have different hourly rates during a monthly period (eg, if their salary changes midway through the month), we need to render two different line items for each rate, and indicate the effective dates.
- We should no longer render the average costs per studio at the top of each section, since these are no longer used.

![updated_cosr](https://github.com/sanctuarycomputer/stacks/assets/34255985/a4433e25-055a-4a72-8637-5ac74033598e)
