### PR TITLE
Adds Stale Task Reminders

### DIFF
--- a/app/admin/stale_tasks.rb
+++ b/app/admin/stale_tasks.rb
@@ -2,7 +2,7 @@ ActiveAdmin.register_page "Stale Tasks" do
   menu parent: "Notion Pages"
 
   content title: "Stale Tasks" do
-    table_for(NotionPage.stale_tasks, class: 'index_table') do
+    table_for(Stacks::Notion::Task.stale, class: 'index_table') do
       column "Task", :task do |task|
         task.notion_page
       end

--- a/app/admin/stale_tasks.rb
+++ b/app/admin/stale_tasks.rb
@@ -1,0 +1,29 @@
+ActiveAdmin.register_page "Stale Tasks" do
+  menu parent: "Notion Pages"
+
+  content title: "Stale Tasks" do
+    table_for(NotionPage.stale_tasks, class: 'index_table') do
+      column "Task", :task do |task|
+        task
+      end
+      column "Steward", :steward do |task|
+        key = task.data.dig("properties").keys.find{|k| k.downcase.include?("steward")}
+        people = task.data.dig("properties", key)
+        people.dig("people").map{|p| p.dig("person", "email")}
+      end
+      column "Assignees", :assignees do |task|
+        key = task.data.dig("properties").keys.find{|k| k.downcase.include?("assignees")}
+        people = task.data.dig("properties", key)
+        people.dig("people").map{|p| p.dig("person", "email")}
+      end
+      column "Due Date", :time_in_days_since_role_last_held do |task|
+        due_date = task.data.dig("properties", "✳️ Due Date 🗓", "date", "end") || task.data.dig("properties", "✳️ Due Date 🗓", "date", "start")
+        Date.parse(due_date).strftime("%B %d, %Y")
+      end
+      column "Open in Notion", :open_in_notion do |task|
+        a "View in Notion ↗", href: task.notion_link, target: "_blank"
+      end
+    end
+
+  end
+end

--- a/app/admin/stale_tasks.rb
+++ b/app/admin/stale_tasks.rb
@@ -4,26 +4,20 @@ ActiveAdmin.register_page "Stale Tasks" do
   content title: "Stale Tasks" do
     table_for(NotionPage.stale_tasks, class: 'index_table') do
       column "Task", :task do |task|
-        task
+        task.notion_page
       end
       column "Steward", :steward do |task|
-        key = task.data.dig("properties").keys.find{|k| k.downcase.include?("steward")}
-        people = task.data.dig("properties", key)
-        people.dig("people").map{|p| p.dig("person", "email")}
+        task.stewards.map{|p| p.dig("person", "email")}
       end
       column "Assignees", :assignees do |task|
-        key = task.data.dig("properties").keys.find{|k| k.downcase.include?("assignees")}
-        people = task.data.dig("properties", key)
-        people.dig("people").map{|p| p.dig("person", "email")}
+        task.assignees.map{|p| p.dig("person", "email")}
       end
       column "Due Date", :time_in_days_since_role_last_held do |task|
-        due_date = task.data.dig("properties", "✳️ Due Date 🗓", "date", "end") || task.data.dig("properties", "✳️ Due Date 🗓", "date", "start")
-        Date.parse(due_date).strftime("%B %d, %Y")
+        task.due_date
       end
       column "Open in Notion", :open_in_notion do |task|
         a "View in Notion ↗", href: task.notion_link, target: "_blank"
       end
     end
-
   end
 end

--- a/app/models/notion_page.rb
+++ b/app/models/notion_page.rb
@@ -21,8 +21,7 @@ class NotionPage < ApplicationRecord
       notion_parent_type: "database_id",
       notion_parent_id: Stacks::Utils.dashify_uuid(Stacks::Notion::DATABASE_IDS[:TASKS])
     ).all.map(&:as_task).select do |task|
-      next false unless task.in_flight?
-      task.overdue?
+      task.in_flight? && task.overdue?
     end.sort_by do |task|
       task.due_date
     end

--- a/app/models/notion_page.rb
+++ b/app/models/notion_page.rb
@@ -12,7 +12,7 @@ class NotionPage < ApplicationRecord
     milestones.where("page_title LIKE ?", "In 2024,%")
   }
 
-  def stale_tasks
+  def self.stale_tasks
     where(
       notion_parent_type: "database_id",
       notion_parent_id: Stacks::Utils.dashify_uuid(Stacks::Notion::DATABASE_IDS[:TASKS])
@@ -22,7 +22,14 @@ class NotionPage < ApplicationRecord
       due_date = task.data.dig("properties", "✳️ Due Date 🗓", "date", "end") || task.data.dig("properties", "✳️ Due Date 🗓", "date", "start")
       next false if due_date.nil?
       Date.parse(due_date) < Date.today
+    end.sort_by do |task|
+      due_date = task.data.dig("properties", "✳️ Due Date 🗓", "date", "end") || task.data.dig("properties", "✳️ Due Date 🗓", "date", "start")
+      Date.parse(due_date)
     end
+  end
+
+  def notion_link
+    "https://www.notion.so/garden3d/#{notion_id.gsub('-', '')}"
   end
 
   # For active admin to set the title on the show page

--- a/app/models/notion_page.rb
+++ b/app/models/notion_page.rb
@@ -16,17 +16,6 @@ class NotionPage < ApplicationRecord
     Stacks::Notion::Task.new(self)
   end
 
-  def self.stale_tasks
-    where(
-      notion_parent_type: "database_id",
-      notion_parent_id: Stacks::Utils.dashify_uuid(Stacks::Notion::DATABASE_IDS[:TASKS])
-    ).all.map(&:as_task).select do |task|
-      task.in_flight? && task.overdue?
-    end.sort_by do |task|
-      task.due_date
-    end
-  end
-
   def notion_link
     "https://www.notion.so/garden3d/#{notion_id.gsub('-', '')}"
   end

--- a/app/notifications/stale_tasks_notification.rb
+++ b/app/notifications/stale_tasks_notification.rb
@@ -1,0 +1,34 @@
+class StaleTasksNotification < Noticed::Base
+  deliver_by :database
+  deliver_by :twist, class: "DeliveryMethods::Twist"
+  param :digest, :include_admins
+
+  def topic
+    "Stale Tasks Reminder (#{record.created_at.to_date.strftime("%B %d, %Y")})"
+  end
+
+  def body
+    stewardship_body = record.params[:digest][:tasks_stewarding].reduce("# Stewarding\n") do |acc, task|
+      due_date = task.data.dig("properties", "✳️ Due Date 🗓", "date", "end") || task.data.dig("properties", "✳️ Due Date 🗓", "date", "start")
+      acc + "- **[#{task.page_title}](#{task.notion_link})**: Due #{ApplicationController.helpers.time_ago_in_words(Date.parse(due_date))} ago\n"
+    end
+
+    assignment_body = record.params[:digest][:tasks_assigned].reduce("# Assigned\n") do |acc, task|
+      due_date = task.data.dig("properties", "✳️ Due Date 🗓", "date", "end") || task.data.dig("properties", "✳️ Due Date 🗓", "date", "start")
+      acc + "- **[#{task.page_title}](#{task.notion_link})**: Due #{ApplicationController.helpers.time_ago_in_words(Date.parse(due_date))} ago\n"
+    end
+
+    <<~HEREDOC
+      👋 Hi #{(recipient.info || {}).dig("first_name")}!
+
+      You're either a steward or assignee on the following Notion tasks that are now overdue. A company is an enormous tree of cascading due dates, and the best companies rarely miss the deadlines they commit to.
+
+      Can you please update the due date for the following to something super realistic? It's better to pad the due date than to miss it!
+
+      #{stewardship_body}
+      #{assignment_body}
+
+      Thank you!
+    HEREDOC
+  end
+end

--- a/app/notifications/stale_tasks_notification.rb
+++ b/app/notifications/stale_tasks_notification.rb
@@ -8,14 +8,12 @@ class StaleTasksNotification < Noticed::Base
   end
 
   def body
-    stewardship_body = record.params[:digest][:tasks_stewarding].reduce("# Stewarding\n") do |acc, task|
-      due_date = task.data.dig("properties", "✳️ Due Date 🗓", "date", "end") || task.data.dig("properties", "✳️ Due Date 🗓", "date", "start")
-      acc + "- **[#{task.page_title}](#{task.notion_link})**: Due #{ApplicationController.helpers.time_ago_in_words(Date.parse(due_date))} ago\n"
+    stewardship_body = record.params[:digest][:tasks_stewarding].map(&:as_task).reduce("# Stewarding\n") do |acc, task|
+      acc + "- **[#{task.page_title}](#{task.notion_link})**: Due #{ApplicationController.helpers.time_ago_in_words(task.due_date)} ago\n"
     end
 
-    assignment_body = record.params[:digest][:tasks_assigned].reduce("# Assigned\n") do |acc, task|
-      due_date = task.data.dig("properties", "✳️ Due Date 🗓", "date", "end") || task.data.dig("properties", "✳️ Due Date 🗓", "date", "start")
-      acc + "- **[#{task.page_title}](#{task.notion_link})**: Due #{ApplicationController.helpers.time_ago_in_words(Date.parse(due_date))} ago\n"
+    assignment_body = record.params[:digest][:tasks_assigned].map(&:as_task).reduce("# Assigned\n") do |acc, task|
+      acc + "- **[#{task.page_title}](#{task.notion_link})**: Due #{ApplicationController.helpers.time_ago_in_words(task.due_date)} ago\n"
     end
 
     <<~HEREDOC

--- a/app/views/admin/notion_pages/_milestones_show.html.erb
+++ b/app/views/admin/notion_pages/_milestones_show.html.erb
@@ -1,4 +1,4 @@
-<a href="https://www.notion.so/garden3d/<%= milestone.notion_id.gsub('-', '') %>" target="_blank" style="margin-right: 6px">
+<a href="<%= milestone.notion_link %>" target="_blank" style="margin-right: 6px">
   <p class="nag" style="margin-bottom: 20px;margin-right: 6px;">
     Open in Notion ↗
   </p>

--- a/lib/stacks/automator.rb
+++ b/lib/stacks/automator.rb
@@ -11,7 +11,7 @@ class Stacks::Automator
     end
 
     def send_stale_task_digests_every_thursday
-      #return unless Time.now.thursday?
+      return unless Time.now.thursday?
 
       raw_digest =
         NotionPage.stale_tasks.reduce({}) do |acc, task|

--- a/lib/stacks/automator.rb
+++ b/lib/stacks/automator.rb
@@ -14,7 +14,7 @@ class Stacks::Automator
       return unless Time.now.thursday?
 
       raw_digest =
-        NotionPage.stale_tasks.reduce({}) do |acc, task|
+        Stacks::Notion::Task.stale.reduce({}) do |acc, task|
           stewards_emails = task.stewards.map{|p| p.dig("person", "email")}
           stewards_emails.compact.each do |e|
             acc[e] = acc[e] || { tasks_stewarding: [], tasks_assigned: [] }

--- a/lib/stacks/automator.rb
+++ b/lib/stacks/automator.rb
@@ -10,7 +10,9 @@ class Stacks::Automator
       @_twist ||= Stacks::Twist.new
     end
 
-    def send_people_of_stale_tasks_digest
+    def send_stale_task_digests_every_wednesday
+      return unless Time.now.wednesday?
+
       raw_digest =
         NotionPage.stale_tasks.reduce({}) do |acc, task|
           key = task.data.dig("properties").keys.find{|k| k.downcase.include?("steward")}
@@ -35,6 +37,7 @@ class Stacks::Automator
         end
 
       raw_digest.each do |k, v|
+        # TODO: Remove this email check when we're ready to open these emails up to everyone!
         if k == "hugh@sanctuary.computer"
           a = AdminUser.find_by(email: k)
           StaleTasksNotification.with(

--- a/lib/stacks/automator.rb
+++ b/lib/stacks/automator.rb
@@ -10,8 +10,8 @@ class Stacks::Automator
       @_twist ||= Stacks::Twist.new
     end
 
-    def send_stale_task_digests_every_wednesday
-      return unless Time.now.wednesday?
+    def send_stale_task_digests_every_thursday
+      return unless Time.now.thursday?
 
       raw_digest =
         NotionPage.stale_tasks.reduce({}) do |acc, task|
@@ -37,14 +37,11 @@ class Stacks::Automator
         end
 
       raw_digest.each do |k, v|
-        # TODO: Remove this email check when we're ready to open these emails up to everyone!
-        if k == "hugh@sanctuary.computer"
-          a = AdminUser.find_by(email: k)
-          StaleTasksNotification.with(
-            digest: v,
-            include_admins: false,
-          ).deliver(a) if a.present?
-        end
+        a = AdminUser.find_by(email: k)
+        StaleTasksNotification.with(
+          digest: v,
+          include_admins: false,
+        ).deliver(a) if a.present?
       end
     end
 

--- a/lib/stacks/notion/base.rb
+++ b/lib/stacks/notion/base.rb
@@ -1,0 +1,20 @@
+class Stacks::Notion::Base
+  attr_accessor :notion_page
+
+  def initialize(notion_page)
+    @notion_page = notion_page
+  end
+
+  def method_missing(method, *args)
+    @notion_page.send method, *args
+  end
+
+  def get_prop_value(fuzzy_key)
+    key = @notion_page.data.dig("properties").keys.find{|k| k.downcase.include?(fuzzy_key)}
+    return {} if key.nil?
+
+    bearer = @notion_page.data.dig("properties", key)
+    bearer.dig(bearer.dig("type"))
+  end
+end
+

--- a/lib/stacks/notion/task.rb
+++ b/lib/stacks/notion/task.rb
@@ -1,0 +1,37 @@
+class Stacks::Notion::Task < Stacks::Notion::Base
+  def stewards
+    get_prop_value("steward")
+  end
+
+  def assignees
+    get_prop_value("assignees")
+  end
+
+  def status
+    get_prop_value("status").dig("name")
+  end
+
+  def done?
+    status.downcase.include?("done")
+  end
+
+  def let_go?
+    status.downcase.include?("let go")
+  end
+
+  def in_flight?
+    !done? && !let_go?
+  end
+
+  def overdue?
+    due_date && due_date < Date.today
+  end
+
+  def due_date
+    @_due_date ||= (
+      raw_due_date = get_prop_value("due date").dig("end") || get_prop_value("due date").dig("start")
+      raw_due_date ? Date.parse(raw_due_date) : nil
+    )
+  end
+end
+

--- a/lib/stacks/notion/task.rb
+++ b/lib/stacks/notion/task.rb
@@ -1,4 +1,21 @@
 class Stacks::Notion::Task < Stacks::Notion::Base
+  class << self
+    def all
+      NotionPage.where(
+        notion_parent_type: "database_id",
+        notion_parent_id: Stacks::Utils.dashify_uuid(Stacks::Notion::DATABASE_IDS[:TASKS])
+      ).map(&:as_task)
+    end
+
+    def stale
+      Stacks::Notion::Task.all.select do |task|
+        task.in_flight? && task.overdue?
+      end.sort_by do |task|
+        task.due_date
+      end
+    end
+  end
+
   def stewards
     get_prop_value("steward")
   end

--- a/lib/tasks/stacks.rake
+++ b/lib/tasks/stacks.rake
@@ -68,7 +68,7 @@ namespace :stacks do
       Parallel.map(Stacks::Notion::DATABASE_IDS.values, in_threads: 3) do |db_id|
         notion.sync_database(db_id)
       end
-      Stacks::Automator.send_stale_task_digests_every_wednesday
+      Stacks::Automator.send_stale_task_digests_every_thursday
     rescue => e
       Sentry.capture_exception(e)
     end

--- a/lib/tasks/stacks.rake
+++ b/lib/tasks/stacks.rake
@@ -68,6 +68,7 @@ namespace :stacks do
       Parallel.map(Stacks::Notion::DATABASE_IDS.values, in_threads: 3) do |db_id|
         notion.sync_database(db_id)
       end
+      Stacks::Automator.send_stale_task_digests_every_wednesday
     rescue => e
       Sentry.capture_exception(e)
     end


### PR DESCRIPTION
This is a simple Stacks notification, run every wednesday directly after freshening the Notion Tasks. Looks like this via Twist.

<img width="744" alt="image" src="https://github.com/sanctuarycomputer/stacks/assets/2865404/e3535fb9-0467-4666-bb01-b38229188e18">

Also adds a screen to see these Stale Tasks (albeit this could be a Notion filter on the Taskboard):
<img width="1840" alt="image" src="https://github.com/sanctuarycomputer/stacks/assets/2865404/e9a5ce04-8386-4c8b-9523-79fd6d810679">

