### PR TITLE
[FEAT] Create system notifications for any Forecast daily financial snapshots that are flagged as needing review

### DIFF
--- a/app/models/forecast_assignment_daily_financial_snapshot.rb
+++ b/app/models/forecast_assignment_daily_financial_snapshot.rb
@@ -1,3 +1,7 @@
 class ForecastAssignmentDailyFinancialSnapshot < ApplicationRecord
   belongs_to :forecast_assignment
+
+  scope :needs_review, -> {
+    where(needs_review: true)
+  }
 end

--- a/app/views/admin/systems/_show.html.erb
+++ b/app/views/admin/systems/_show.html.erb
@@ -125,6 +125,8 @@
                 <strong><%= n.params[:subject].display_name %></strong> has multiple hourly rates (the first will be used).
               <% when :no_explicit_hourly_rate %>
                 <strong><%= n.params[:subject].display_name %></strong> does not have an explicit hourly rate (the Stacks default will be used).
+              <% when :person_missing_hourly_rate %>
+                <strong><%= n.params[:subject].forecast_person.email %></strong> does not have an hourly rate set for the project <strong><%= n.params[:subject].forecast_project.name %></strong>. Add an hourly rate for this user to the notes for the project in Forecast, eg: <em>"john.doe@example.com: $123.45"</em>
               <% else %>
                 Unknown Forecast Project Error
               <% end %>

--- a/lib/stacks/notifications.rb
+++ b/lib/stacks/notifications.rb
@@ -195,6 +195,16 @@ class Stacks::Notifications
         } if fp.has_no_explicit_hourly_rate?
       end
 
+			ForecastAssignmentDailyFinancialSnapshot.needs_review.each do |snapshot|
+        notifications << {
+          subject: snapshot.forecast_assignment,
+          type: :forecast_project,
+          link: snapshot.forecast_assignment.forecast_project.edit_link,
+          error: :person_missing_hourly_rate,
+          priority: 1
+        }
+      end
+
       forecast_clients.each do |fc|
         notifications << {
           subject: fc,

--- a/test/lib/stacks/notifications_test.rb
+++ b/test/lib/stacks/notifications_test.rb
@@ -1,0 +1,97 @@
+require "test_helper"
+
+class ProjectTrackertTest < ActiveSupport::TestCase
+  test "#make_notifications! creates notifications for cost windows needing review" do
+    Stacks::Quickbooks.stubs(:fetch_all_customers).returns([])
+    Stacks::Team.stubs(:fetch_from_google_workspace).returns([])
+    Stacks::Forecast.any_instance.stubs(:people).returns({
+      "people" => []
+    })
+
+    Stacks::Notion.any_instance.stubs(:get_users).returns([])
+    Stacks::Availability.stubs(:load_allocations_from_notion).returns([[], []])
+
+    Stacks::Twist.any_instance.stubs(:get_workspace_users).returns(
+      Struct.new(:parsed_response).new([])
+    )
+
+    studio = Studio.create!({
+      name: "Sanctuary Computer",
+      accounting_prefix: "Development",
+      mini_name: "sc"
+    })
+
+    forecast_client = ForecastClient.create!
+
+    forecast_project = ForecastProject.create!({
+      id: 55,
+      name: "Test project",
+      forecast_client: forecast_client,
+      code: "ABCD-1",
+    })
+
+    person_one = ForecastPerson.create!({
+      forecast_id: "123",
+      roles: ["Subcontractor", studio.name],
+      email: "subcontractor-1@some-other-company.com"
+    })
+
+    person_two = ForecastPerson.create!({
+      forecast_id: "456",
+      roles: ["Subcontractor", studio.name],
+      email: "subcontractor-2@some-other-company.com"
+    })
+
+		assignment_one = ForecastAssignment.create!({
+      forecast_id: 111,
+      start_date: Date.today,
+      end_date: Date.today + 5.days,
+      forecast_person: person_one,
+      forecast_project: forecast_project
+    })
+
+		assignment_two = ForecastAssignment.create!({
+      forecast_id: 222,
+      start_date: Date.today,
+      end_date: Date.today + 5.days,
+      forecast_person: person_two,
+      forecast_project: forecast_project
+    })
+
+		ForecastAssignmentDailyFinancialSnapshot.create!({
+      forecast_assignment: assignment_one,
+      forecast_person_id: person_one.id,
+      forecast_project_id: forecast_project.id,
+      effective_date: Date.today,
+      studio_id: studio.id,
+      hourly_cost: 123,
+      hours: 8,
+      needs_review: false
+    })
+
+    ForecastAssignmentDailyFinancialSnapshot.create!({
+      forecast_assignment: assignment_two,
+      forecast_person_id: person_two.id,
+      forecast_project_id: forecast_project.id,
+      effective_date: Date.today,
+      studio_id: studio.id,
+      hourly_cost: 0,
+      hours: 8,
+      needs_review: true
+    })
+
+    Stacks::Notifications.make_notifications!
+
+    notification = Notification.all.find do |notification|
+      notification.params[:error] == :person_missing_hourly_rate
+    end
+
+    refute_nil(notification, "Expected notification not found")
+
+    assert_equal(notification.params[:type], :forecast_project)
+    assert_equal(notification.params[:subject].forecast_id, assignment_two.forecast_id)
+    assert_equal(notification.params[:priority], 1)
+    assert(notification.params[:link].end_with?("/projects/55/edit"))
+  end
+end
+


### PR DESCRIPTION
This PR adds a query to the daily system notification creation cron to fetch all of the `needs_review` financial snapshots and generate system notifications for them.

Exact same approach as this earlier PR: https://github.com/sanctuarycomputer/stacks/pull/39 but for the updated snapshot model instead of cost windows.