### PR TITLE
Remove duplicate COSR metric from project budget burnup graph

### DIFF
--- a/app/admin/project_trackers.rb
+++ b/app/admin/project_trackers.rb
@@ -331,16 +331,6 @@ ActiveAdmin.register ProjectTracker do
       })
     end
 
-    if resource.snapshot[accounting_method].try(:dig, "cosr_new")
-      burnup_data[:data][:datasets].push({
-        borderColor: Stacks::Utils::COLORS[9], # color of dots
-        backgroundColor: Stacks::Utils::COLORS[9], # color of line
-        label: "Cost of Services Rendered (COSR - NEW)",
-        data: resource.snapshot[accounting_method].try(:dig, "cosr_new"),
-        pointRadius: 1
-      })
-    end
-
     render(partial: 'show', locals: {
       burnup_data: burnup_data
     })


### PR DESCRIPTION
I forgot to remove the duplicate line from the budget burnup graph when I removed the old COSR metrics in https://github.com/sanctuarycomputer/stacks/pull/56.