### PR TITLE
Don't inflate hourly cost as a factor of employee utilization percentage

### DIFF
--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -83,11 +83,7 @@ class AdminUser < ApplicationRecord
   end
 
   def approximate_cost_per_sellable_hour_before_studio_expenses
-    approximate_cost_per_sellable_hour_before_studio_expenses_on_date(Date.today)
-  end
-
-  def approximate_cost_per_sellable_hour_before_studio_expenses_on_date(date)
-    date = date.beginning_of_week
+    date = Date.today.beginning_of_week
     data = sellable_hours_for_date(date)
     return nil unless data.present?
     return nil if data[:sellable] == 0

--- a/lib/stacks/daily_financial_snapshotter.rb
+++ b/lib/stacks/daily_financial_snapshotter.rb
@@ -93,13 +93,10 @@ class Stacks::DailyFinancialSnapshotter
 
   def employee_hourly_cost(forecast_person, forecast_project)
     admin_user = forecast_person.admin_user
-    cost = admin_user.approximate_cost_per_sellable_hour_before_studio_expenses_on_date(@effective_date)
+    daily_cost = admin_user.cost_of_employment_on_date(@effective_date)
+    hours_per_day = 8
 
-    if cost.nil?
-      return 0
-    end
-
-    cost.round(2)
+    (daily_cost / hours_per_day).round(2)
   end
 
   def subcontractor_hourly_cost(forecast_person, forecast_project)

--- a/test/lib/stacks/daily_financial_snapshotter_test.rb
+++ b/test/lib/stacks/daily_financial_snapshotter_test.rb
@@ -58,7 +58,7 @@ class Stacks::DailyFinancialSnapshotterTest < ActiveSupport::TestCase
         forecast_project_id: forecast_project.id,
         effective_date: start_date,
         studio_id: studio.id,
-        hourly_cost: 85.31,
+        hourly_cost: 68.25,
         hours: 8,
         needs_review: false
       }
@@ -169,7 +169,7 @@ class Stacks::DailyFinancialSnapshotterTest < ActiveSupport::TestCase
       forecast_project_id: forecast_project.id,
       effective_date: start_date,
       studio_id: studio.id,
-      hourly_cost: 70.61,
+      hourly_cost: 56.49,
       hours: 8,
       needs_review: false
     })
@@ -183,7 +183,7 @@ class Stacks::DailyFinancialSnapshotterTest < ActiveSupport::TestCase
         forecast_project_id: forecast_project.id,
         effective_date: start_date,
         studio_id: studio.id,
-        hourly_cost: 70.61,
+        hourly_cost: 56.49,
         hours: 8,
         needs_review: false
       }
@@ -291,7 +291,7 @@ class Stacks::DailyFinancialSnapshotterTest < ActiveSupport::TestCase
         forecast_project_id: forecast_project.id,
         effective_date: start_date,
         studio_id: 0,
-        hourly_cost: 70.61,
+        hourly_cost: 56.49,
         hours: 8,
         needs_review: true
       }
@@ -459,7 +459,7 @@ class Stacks::DailyFinancialSnapshotterTest < ActiveSupport::TestCase
         forecast_project_id: forecast_project.id,
         effective_date: Date.today,
         studio_id: studio.id,
-        hourly_cost: 70.61,
+        hourly_cost: 56.49,
         hours: 8,
         needs_review: false
       }
@@ -592,7 +592,7 @@ class Stacks::DailyFinancialSnapshotterTest < ActiveSupport::TestCase
         forecast_project_id: current_project_one.id,
         effective_date: Date.today,
         studio_id: studio_one.id,
-        hourly_cost: 70.61,
+        hourly_cost: 56.49,
         hours: 4,
         needs_review: false
       },
@@ -601,7 +601,7 @@ class Stacks::DailyFinancialSnapshotterTest < ActiveSupport::TestCase
         forecast_project_id: current_project_one.id,
         effective_date: Date.today,
         studio_id: studio_two.id,
-        hourly_cost: 70.61,
+        hourly_cost: 56.49,
         hours: 4,
         needs_review: false
       },
@@ -610,7 +610,7 @@ class Stacks::DailyFinancialSnapshotterTest < ActiveSupport::TestCase
         forecast_project_id: current_project_two.id,
         effective_date: Date.today,
         studio_id: studio_one.id,
-        hourly_cost: 70.61,
+        hourly_cost: 56.49,
         hours: 4,
         needs_review: false
       },
@@ -619,7 +619,7 @@ class Stacks::DailyFinancialSnapshotterTest < ActiveSupport::TestCase
         forecast_project_id: current_project_two.id,
         effective_date: Date.today,
         studio_id: studio_two.id,
-        hourly_cost: 70.61,
+        hourly_cost: 56.49,
         hours: 4,
         needs_review: false
       }
@@ -752,7 +752,7 @@ class Stacks::DailyFinancialSnapshotterTest < ActiveSupport::TestCase
         forecast_project_id: past_project.id,
         effective_date: past_project.start_date,
         studio_id: studio_one.id,
-        hourly_cost: 70.61,
+        hourly_cost: 56.49,
         hours: 4,
         needs_review: false
       },
@@ -761,7 +761,7 @@ class Stacks::DailyFinancialSnapshotterTest < ActiveSupport::TestCase
         forecast_project_id: past_project.id,
         effective_date: past_project.start_date,
         studio_id: studio_two.id,
-        hourly_cost: 70.61,
+        hourly_cost: 56.49,
         hours: 4,
         needs_review: false
       },
@@ -770,7 +770,7 @@ class Stacks::DailyFinancialSnapshotterTest < ActiveSupport::TestCase
         forecast_project_id: current_project_one.id,
         effective_date: current_project_one.start_date,
         studio_id: studio_one.id,
-        hourly_cost: 70.61,
+        hourly_cost: 56.49,
         hours: 4,
         needs_review: false
       },
@@ -779,7 +779,7 @@ class Stacks::DailyFinancialSnapshotterTest < ActiveSupport::TestCase
         forecast_project_id: current_project_one.id,
         effective_date: current_project_one.start_date,
         studio_id: studio_two.id,
-        hourly_cost: 70.61,
+        hourly_cost: 56.49,
         hours: 4,
         needs_review: false
       },
@@ -788,7 +788,7 @@ class Stacks::DailyFinancialSnapshotterTest < ActiveSupport::TestCase
         forecast_project_id: current_project_two.id,
         effective_date: current_project_two.start_date,
         studio_id: studio_one.id,
-        hourly_cost: 70.61,
+        hourly_cost: 56.49,
         hours: 4,
         needs_review: false
       },
@@ -797,7 +797,7 @@ class Stacks::DailyFinancialSnapshotterTest < ActiveSupport::TestCase
         forecast_project_id: current_project_two.id,
         effective_date: current_project_two.start_date,
         studio_id: studio_two.id,
-        hourly_cost: 70.61,
+        hourly_cost: 56.49,
         hours: 4,
         needs_review: false
       }


### PR DESCRIPTION
I was using the cost per *sellable* hour to determine hourly project costs, which is not correct. We need to determine the daily cost for each employee and divide that by the total hours in the day instead. Within the context of recorded hours for a particular project, we don't care about people's target utilization -- they worked the hours they worked.

This inaccuracy was especially apparent in the case of team members with low utilization targets, like myself (0% target utilization) and Jacob (20%).