### PR TITLE
Update contractor rate override format in notification for missing contractor rate

### DIFF
--- a/app/views/admin/systems/_show.html.erb
+++ b/app/views/admin/systems/_show.html.erb
@@ -126,7 +126,7 @@
               <% when :no_explicit_hourly_rate %>
                 <strong><%= n.params[:subject].display_name %></strong> does not have an explicit hourly rate (the Stacks default will be used).
               <% when :person_missing_hourly_rate %>
-                <strong><%= n.params[:subject].forecast_person.email %></strong> does not have an hourly rate set for the project <strong><%= n.params[:subject].forecast_project.name %></strong>. Add an hourly rate for this user to the notes for the project in Forecast, eg: <em>"john.doe@example.com: $123.45"</em>
+                <strong><%= n.params[:subject].forecast_person.email %></strong> does not have an hourly rate set for the project <strong><%= n.params[:subject].forecast_project.name %></strong>. Add an hourly rate for this user to the notes for the project in Forecast, eg: <em>"contractor-name@contractor-domain.com:150p/h"</em>
               <% else %>
                 Unknown Forecast Project Error
               <% end %>


### PR DESCRIPTION
@hhff noticed that I listed the wrong example for the rate override in the system notification for when a contractor is missing a hardcoded hourly rate in Forecast. This updates the message in the notification to use the correct format.