### PR TITLE
[FIX] Deduplicate system notifications for daily financial snapshots needing review

### DIFF
--- a/app/views/admin/systems/_show.html.erb
+++ b/app/views/admin/systems/_show.html.erb
@@ -126,7 +126,7 @@
               <% when :no_explicit_hourly_rate %>
                 <strong><%= n.params[:subject].display_name %></strong> does not have an explicit hourly rate (the Stacks default will be used).
               <% when :person_missing_hourly_rate %>
-                <strong><%= n.params[:subject].forecast_person.email %></strong> does not have an hourly rate set for the project <strong><%= n.params[:subject].forecast_project.name %></strong>. Add an hourly rate for this user to the notes for the project in Forecast, eg: <em>"contractor-name@contractor-domain.com:150p/h"</em>
+                <strong><%= n.params[:forecast_person_email] %></strong> does not have an hourly rate set for the project <strong><%= n.params[:subject].display_name %></strong>. Add an hourly rate for this user to the notes for the project in Forecast, eg: <em>"contractor-name@contractor-domain.com:150p/h"</em>
               <% else %>
                 Unknown Forecast Project Error
               <% end %>

--- a/lib/stacks/notifications.rb
+++ b/lib/stacks/notifications.rb
@@ -197,8 +197,9 @@ class Stacks::Notifications
 
 			ForecastAssignmentDailyFinancialSnapshot.needs_review.each do |snapshot|
         notifications << {
-          subject: snapshot.forecast_assignment,
+          subject: snapshot.forecast_assignment.forecast_project,
           type: :forecast_project,
+          forecast_person_email: snapshot.forecast_assignment.forecast_person.email,
           link: snapshot.forecast_assignment.forecast_project.edit_link,
           error: :person_missing_hourly_rate,
           priority: 1

--- a/test/lib/stacks/notifications_test.rb
+++ b/test/lib/stacks/notifications_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class ProjectTrackertTest < ActiveSupport::TestCase
+class NotificationstTest < ActiveSupport::TestCase
   test "#make_notifications! creates notifications for cost windows needing review" do
     Stacks::Quickbooks.stubs(:fetch_all_customers).returns([])
     Stacks::Team.stubs(:fetch_from_google_workspace).returns([])
@@ -89,8 +89,9 @@ class ProjectTrackertTest < ActiveSupport::TestCase
     refute_nil(notification, "Expected notification not found")
 
     assert_equal(notification.params[:type], :forecast_project)
-    assert_equal(notification.params[:subject].forecast_id, assignment_two.forecast_id)
+    assert_equal(notification.params[:subject].forecast_id, forecast_project.forecast_id)
     assert_equal(notification.params[:priority], 1)
+    assert_equal(notification.params[:forecast_person_email], person_two.email)
     assert(notification.params[:link].end_with?("/projects/55/edit"))
   end
 end


### PR DESCRIPTION
We currently generate system notifications for daily financial snapshots needing review (read: where the `hourly_cost` could not be determined). However, @hhff pointed out that the current approach creates a bunch of duplicate notifications. This is because I was using `ForecastAssignment` for the notification subject, and there are a lot of individual instances of those for the same project + person, so the deduplication code for notifications treated them all as distinct sets of parameters.

I'm updating this to use the `ForecastProject` as the notification subject, and adding a new parameter to the params hash for the person's email so that we can render it in the notification message.