### PR TITLE
[FIX] Use enum module for contributor type constants

### DIFF
--- a/app/models/full_time_period.rb
+++ b/app/models/full_time_period.rb
@@ -12,13 +12,22 @@ class FullTimePeriod < ApplicationRecord
     variable_hours: 2
   }
 
+  def four_day?
+    contributor_type == Enum::ContributorType::FOUR_DAY
+  end
+
+  def five_day?
+    contributor_type == Enum::ContributorType::FIVE_DAY
+  end
+
   def psu_earn_rate
-    if contributor_type == "five_day"
-      return 1
-    elsif contributor_type == "four_day"
-      return 0.8
+    if five_day?
+      1
+    elsif four_day?
+      0.8
+    else
+      0
     end
-    0
   end
 
   def overlaps?(other)

--- a/app/views/admin/admin_users/_show.html.erb
+++ b/app/views/admin/admin_users/_show.html.erb
@@ -154,9 +154,11 @@
     </div>
   </div>
 
+  <% ftp = ftp_log[:ftp] %>
+
   <p class="nag" style="margin-right: 6px">
     <strong>
-      <% if ["five_day", "four_day"].include?(ftp_log[:ftp].contributor_type) %>
+      <% if ftp.four_day? || ftp.five_day? %>
         <%= ftp_log[:ftp].expected_utilization * 100 %>% Expected Utilization
       <% else %>
         Does not effect Expected Utilization
@@ -170,9 +172,9 @@
   </p>
   <p class="nag">
     <strong>
-      <% if ftp_log[:ftp].contributor_type == "five_day" %>
+      <% if ftp.five_day? %>
         1 PSU p/month
-      <% elsif ftp_log[:ftp].contributor_type == "four_day" %>
+      <% elsif ftp.four_day? %>
         0.8 PSU p/month
       <% else %>
         Does not accrue PSU

--- a/db/migrate/20221214193722_add_contributor_type_to_full_time_periods.rb
+++ b/db/migrate/20221214193722_add_contributor_type_to_full_time_periods.rb
@@ -7,7 +7,11 @@ class AddContributorTypeToFullTimePeriods < ActiveRecord::Migration[6.0]
     AdminUser.all.each do |a|
       if a.full_time_periods.empty?
         if ["core", "satellite"].include?(a.contributor_type)
-          FullTimePeriod.create!(admin_user: a, started_at: Date.today, contributor_type: :variable_hours)
+          FullTimePeriod.create!({
+            admin_user: a,
+            started_at: Date.today,
+            contributor_type: Enum::ContributorType::VARIABLE_HOURS
+          })
         end
       end
     end
@@ -23,21 +27,27 @@ class AddContributorTypeToFullTimePeriods < ActiveRecord::Migration[6.0]
         if a.contributor_type == "core"
           if ftp.multiplier == 0.8
             # 4 day worker
-            next ftp.update!(contributor_type: :four_day)
+            next ftp.update!(contributor_type: Enum::ContributorType::FOUR_DAY)
           elsif ftp.multiplier == 1
             # 5 Day worker
-            next ftp.update!(contributor_type: :five_day)
+            next ftp.update!(contributor_type: Enum::ContributorType::FIVE_DAY)
           elsif ftp.multiplier
             # ??? Give a "0" multiplier, probably should be variable_hours
-            next ftp.update!(contributor_type: :variable_hours, expected_utilization: 0)
-          end 
+            next ftp.update!({
+              contributor_type: Enum::ContributorType::VARIABLE_HOURS,
+              expected_utilization: 0
+            })
+          end
         end
-  
+
         if a.contributor_type == "satellite"
           # Move to variable_hours
-          next ftp.update!(contributor_type: :variable_hours, expected_utilization: 0)
+          next ftp.update!({
+            contributor_type: Enum::ContributorType::VARIABLE_HOURS,
+            expected_utilization: 0
+          })
         end
-  
+
         if a.contributor_type == "bot"
           # ??? Why does a bot have a FTP
           next ftp.destroy!

--- a/lib/enum/contributor_type.rb
+++ b/lib/enum/contributor_type.rb
@@ -1,0 +1,5 @@
+module Enum::ContributorType
+  FOUR_DAY = "four_day"
+  FIVE_DAY = "five_day"
+  VARIABLE_HOURS = "variable_hours"
+end

--- a/lib/stacks/admin_user_salary_window_syncer.rb
+++ b/lib/stacks/admin_user_salary_window_syncer.rb
@@ -66,6 +66,6 @@ class Stacks::AdminUserSalaryWindowSyncer
       return 1
     end
 
-    ftp.contributor_type == "four_day" ? 0.8 : 1
+    ftp.four_day? ? 0.8 : 1
   end
 end

--- a/lib/stacks/automator.rb
+++ b/lib/stacks/automator.rb
@@ -105,7 +105,7 @@ class Stacks::Automator
       end_of_last_week = (Date.today - 1.week).end_of_week
       ForecastPerson.includes(:admin_user).all.reject(&:archived).each do |fp|
         next unless fp.admin_user.present?
-        next if fp.admin_user.contributor_type == "variable_hours"
+        next if fp.admin_user.contributor_type == Enum::ContributorType::VARIABLE_HOURS
 
         missing_hours = fp.missing_allocation_during_range_in_hours(
           Date.today.beginning_of_month, end_of_last_week

--- a/lib/stacks/notifications.rb
+++ b/lib/stacks/notifications.rb
@@ -79,11 +79,23 @@ class Stacks::Notifications
       end
 
       active_users = users.select(&:active?)
+
       users_without_dei_response = active_users.select do |u|
-        ["five_day", "four_day"].include?(u.current_contributor_type) && u.should_nag_for_dei_data?
+        next false unless [
+          Enum::ContributorType::FOUR_DAY,
+          Enum::ContributorType::FIVE_DAY
+        ].include?(u.current_contributor_type)
+
+        u.should_nag_for_dei_data?
       end
+
       users_with_unknown_salary = active_users.select do |u|
-        ["five_day", "four_day"].include?(u.current_contributor_type) && u.skill_tree_level_without_salary == "No Reviews Yet"
+        next false unless [
+          Enum::ContributorType::FOUR_DAY,
+          Enum::ContributorType::FIVE_DAY
+        ].include?(u.current_contributor_type)
+
+        u.skill_tree_level_without_salary == "No Reviews Yet"
       end
 
       active_project_trackers = ProjectTracker

--- a/test/lib/stacks/admin_user_cost_window_syncer_test.rb
+++ b/test/lib/stacks/admin_user_cost_window_syncer_test.rb
@@ -117,12 +117,12 @@ class Stacks::AdminUserCostWindowSyncerTest < ActiveSupport::TestCase
     user.full_time_periods.create!({
       started_at: Date.today - 1.year,
       ended_at: Date.today - 6.months - 1.day,
-      contributor_type: :five_day
+      contributor_type: Enum::ContributorType::FIVE_DAY
     })
 
     user.full_time_periods.create!({
       started_at: Date.today - 6.months,
-      contributor_type: :four_day
+      contributor_type: Enum::ContributorType::FOUR_DAY
     })
 
     syncer = Stacks::AdminUserSalaryWindowSyncer.new(user)

--- a/test/lib/stacks/cost_of_services_rendered_calculator_test.rb
+++ b/test/lib/stacks/cost_of_services_rendered_calculator_test.rb
@@ -46,7 +46,7 @@ class Stacks::CostOfServicesRenderedCalculatorTest < ActiveSupport::TestCase
       admin_user: user_one,
       started_at: Date.new(2020, 1, 1),
       ended_at: nil,
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.8
     })
 
@@ -54,7 +54,7 @@ class Stacks::CostOfServicesRenderedCalculatorTest < ActiveSupport::TestCase
       admin_user: user_two,
       started_at: Date.new(2020, 1, 1),
       ended_at: nil,
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.8
     })
 

--- a/test/lib/stacks/daily_financial_snapshotter_test.rb
+++ b/test/lib/stacks/daily_financial_snapshotter_test.rb
@@ -37,7 +37,7 @@ class Stacks::DailyFinancialSnapshotterTest < ActiveSupport::TestCase
       admin_user: user,
       started_at: Date.new(2020, 1, 1),
       ended_at: nil,
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.8
     })
 
@@ -151,7 +151,7 @@ class Stacks::DailyFinancialSnapshotterTest < ActiveSupport::TestCase
       admin_user: user,
       started_at: Date.new(2020, 1, 1),
       ended_at: nil,
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.8
     })
 
@@ -270,7 +270,7 @@ class Stacks::DailyFinancialSnapshotterTest < ActiveSupport::TestCase
       admin_user: user,
       started_at: Date.new(2020, 1, 1),
       ended_at: nil,
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.8
     })
 
@@ -384,7 +384,7 @@ class Stacks::DailyFinancialSnapshotterTest < ActiveSupport::TestCase
       admin_user: user,
       started_at: Date.new(2020, 1, 1),
       ended_at: nil,
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.8
     })
 
@@ -438,7 +438,7 @@ class Stacks::DailyFinancialSnapshotterTest < ActiveSupport::TestCase
       admin_user: user,
       started_at: Date.new(2020, 1, 1),
       ended_at: nil,
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.8
     })
 
@@ -546,7 +546,7 @@ class Stacks::DailyFinancialSnapshotterTest < ActiveSupport::TestCase
       admin_user: user_one,
       started_at: Date.new(2020, 1, 1),
       ended_at: nil,
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.8
     })
 
@@ -554,7 +554,7 @@ class Stacks::DailyFinancialSnapshotterTest < ActiveSupport::TestCase
       admin_user: user_two,
       started_at: Date.new(2020, 1, 1),
       ended_at: nil,
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.8
     })
 
@@ -707,7 +707,7 @@ class Stacks::DailyFinancialSnapshotterTest < ActiveSupport::TestCase
       admin_user: user_one,
       started_at: Date.new(2020, 1, 1),
       ended_at: nil,
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.8
     })
 
@@ -715,7 +715,7 @@ class Stacks::DailyFinancialSnapshotterTest < ActiveSupport::TestCase
       admin_user: user_two,
       started_at: Date.new(2020, 1, 1),
       ended_at: nil,
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.8
     })
 

--- a/test/lib/stacks/team_test.rb
+++ b/test/lib/stacks/team_test.rb
@@ -8,7 +8,7 @@ class Stacks::TeamTest < ActiveSupport::TestCase
         email: "fulltime1@sanctuary.computer",
         password: "password",
       }),
-      contributor_type: FullTimePeriod.contributor_types["five_day"]
+      contributor_type: Enum::ContributorType::FIVE_DAY
     })
 
     FullTimePeriod.create!({
@@ -17,7 +17,7 @@ class Stacks::TeamTest < ActiveSupport::TestCase
         email: "fulltime2@sanctuary.computer",
         password: "password",
       }),
-      contributor_type: FullTimePeriod.contributor_types["four_day"]
+      contributor_type: Enum::ContributorType::FOUR_DAY
     })
 
     FullTimePeriod.create!({
@@ -26,7 +26,7 @@ class Stacks::TeamTest < ActiveSupport::TestCase
         email: "not_fulltime@sanctuary.computer",
         password: "password",
       }),
-      contributor_type: FullTimePeriod.contributor_types["variable_hours"]
+      contributor_type: Enum::ContributorType::VARIABLE_HOURS
     })
 
     assert Stacks::Team.admin_users_sorted_by_tenure_in_days.length == 2
@@ -40,7 +40,7 @@ class Stacks::TeamTest < ActiveSupport::TestCase
         email: "fulltime1@sanctuary.computer",
         password: "password",
       }),
-      contributor_type: FullTimePeriod.contributor_types["five_day"]
+      contributor_type: Enum::ContributorType::FIVE_DAY
     })
 
     FullTimePeriod.create!({
@@ -49,7 +49,7 @@ class Stacks::TeamTest < ActiveSupport::TestCase
         email: "fulltime2@sanctuary.computer",
         password: "password",
       }),
-      contributor_type: FullTimePeriod.contributor_types["four_day"]
+      contributor_type: Enum::ContributorType::FOUR_DAY
     })
 
     FullTimePeriod.create!({
@@ -58,7 +58,7 @@ class Stacks::TeamTest < ActiveSupport::TestCase
         email: "not_fulltime@sanctuary.computer",
         password: "password",
       }),
-      contributor_type: FullTimePeriod.contributor_types["four_day"],
+      contributor_type: Enum::ContributorType::FOUR_DAY,
       considered_temporary: true
     })
 

--- a/test/models/admin_user_test.rb
+++ b/test/models/admin_user_test.rb
@@ -10,7 +10,7 @@ class AdminUserTest < ActiveSupport::TestCase
       admin_user: admin_user,
       started_at: Date.new(2020, 1, 1),
       ended_at: nil,
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.8
     })
     admin_user.full_time_periods.reload
@@ -41,14 +41,14 @@ class AdminUserTest < ActiveSupport::TestCase
       admin_user: admin_user,
       started_at: Date.new(2020, 1, 1),
       ended_at: Date.new(2020, 12, 31),
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.8
     })
     FullTimePeriod.create!({
       admin_user: admin_user,
       started_at: Date.new(2021, 6, 5),
       ended_at: nil,
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.8
     })
     admin_user.full_time_periods.reload
@@ -80,14 +80,14 @@ class AdminUserTest < ActiveSupport::TestCase
       admin_user: admin_user,
       started_at: Date.new(2020, 1, 1),
       ended_at: Date.new(2020, 12, 31),
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.8
     })
     FullTimePeriod.create!({
       admin_user: admin_user,
       started_at: Date.new(2021, 1, 1),
       ended_at: nil,
-      contributor_type: :four_day,
+      contributor_type: Enum::ContributorType::FOUR_DAY,
       expected_utilization: 0.8
     })
     admin_user.full_time_periods.reload
@@ -106,14 +106,14 @@ class AdminUserTest < ActiveSupport::TestCase
       admin_user: admin_user,
       started_at: Date.new(2020, 1, 1),
       ended_at: Date.new(2020, 12, 15),
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.8
     })
     FullTimePeriod.create!({
       admin_user: admin_user,
       started_at: Date.new(2020, 12, 16),
       ended_at: nil,
-      contributor_type: :four_day,
+      contributor_type: Enum::ContributorType::FOUR_DAY,
       expected_utilization: 0.8
     })
     admin_user.full_time_periods.reload
@@ -134,14 +134,14 @@ class AdminUserTest < ActiveSupport::TestCase
       admin_user: admin_user,
       started_at: Date.new(2020, 1, 1),
       ended_at: Date.new(2020, 12, 15),
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.8
     })
     FullTimePeriod.create!({
       admin_user: admin_user,
       started_at: Date.new(2020, 12, 16),
       ended_at: nil,
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.2 # Utilization is the only thing that changed on the 16th of December
     })
     admin_user.full_time_periods.reload
@@ -221,7 +221,7 @@ class AdminUserTest < ActiveSupport::TestCase
       admin_user: user,
       started_at: start_date,
       ended_at: nil,
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.8
     })
 
@@ -245,7 +245,7 @@ class AdminUserTest < ActiveSupport::TestCase
       admin_user: user,
       started_at: start_date,
       ended_at: nil,
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.8
     })
 

--- a/test/models/full_time_period_test.rb
+++ b/test/models/full_time_period_test.rb
@@ -35,4 +35,60 @@ class FullTimePeriodTest < ActiveSupport::TestCase
 
     assert period.include?(Date.today)
   end
+
+  test "#four_day? returns true for four-day contributor type" do
+    period = FullTimePeriod.new({
+      contributor_type: Enum::ContributorType::FOUR_DAY
+    })
+
+    assert period.four_day?
+  end
+
+  test "#four_day? returns false for other contributor types" do
+    period = FullTimePeriod.new({
+      contributor_type: Enum::ContributorType::FIVE_DAY
+    })
+
+    refute period.four_day?
+  end
+
+  test "#five_day? returns true for five-day contributor type" do
+    period = FullTimePeriod.new({
+      contributor_type: Enum::ContributorType::FIVE_DAY
+    })
+
+    assert period.five_day?
+  end
+
+  test "#five_day? returns false for other contributor types" do
+    period = FullTimePeriod.new({
+      contributor_type: Enum::ContributorType::FOUR_DAY
+    })
+
+    refute period.five_day?
+  end
+
+  test "#psu_earn_rate returns expected rate for 4-day workers" do
+    period = FullTimePeriod.new({
+      contributor_type: Enum::ContributorType::FOUR_DAY
+    })
+
+    assert_equal(0.8, period.psu_earn_rate)
+  end
+
+  test "#psu_earn_rate returns expected rate for 5-day workers" do
+    period = FullTimePeriod.new({
+      contributor_type: Enum::ContributorType::FIVE_DAY
+    })
+
+    assert_equal(1, period.psu_earn_rate)
+  end
+
+  test "#psu_earn_rate returns expected rate for variable hours workers" do
+    period = FullTimePeriod.new({
+      contributor_type: Enum::ContributorType::VARIABLE_HOURS
+    })
+
+    assert_equal(0, period.psu_earn_rate)
+  end
 end

--- a/test/models/project_tracker_test.rb
+++ b/test/models/project_tracker_test.rb
@@ -73,7 +73,7 @@ class ProjectTrackerTest < ActiveSupport::TestCase
       admin_user: user_one,
       started_at: Date.new(2020, 1, 1),
       ended_at: nil,
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.8
     })
 
@@ -81,7 +81,7 @@ class ProjectTrackerTest < ActiveSupport::TestCase
       admin_user: user_two,
       started_at: Date.new(2020, 1, 1),
       ended_at: nil,
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.8
     })
 

--- a/test/models/studio_test.rb
+++ b/test/models/studio_test.rb
@@ -28,7 +28,7 @@ class StudioTest < ActiveSupport::TestCase
       admin_user: admin_user,
       started_at: Date.new(2021, 1, 1),
       ended_at: Date.new(2021, 12, 31),
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.8
     })
     admin_user.full_time_periods.reload
@@ -66,7 +66,7 @@ class StudioTest < ActiveSupport::TestCase
       admin_user: admin_user,
       started_at: Date.new(2021, 1, 1),
       ended_at: Date.new(2021, 12, 31),
-      contributor_type: :four_day,
+      contributor_type: Enum::ContributorType::FOUR_DAY,
       expected_utilization: 0.6
     })
     admin_user.full_time_periods.reload
@@ -104,7 +104,7 @@ class StudioTest < ActiveSupport::TestCase
       admin_user: admin_user,
       started_at: Date.new(2021, 1, 1),
       ended_at: Date.new(2021, 12, 31),
-      contributor_type: :variable_hours,
+      contributor_type: Enum::ContributorType::VARIABLE_HOURS,
       expected_utilization: 0.6
     })
     admin_user.full_time_periods.reload
@@ -151,7 +151,7 @@ class StudioTest < ActiveSupport::TestCase
       admin_user: user_one,
       started_at: Date.yesterday,
       ended_at: nil,
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.8
     })
 
@@ -159,7 +159,7 @@ class StudioTest < ActiveSupport::TestCase
       admin_user: user_two,
       started_at: Date.yesterday,
       ended_at: nil,
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.8
     })
 
@@ -167,7 +167,7 @@ class StudioTest < ActiveSupport::TestCase
       admin_user: user_three,
       started_at: Date.yesterday,
       ended_at: nil,
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.8
     })
 
@@ -175,7 +175,7 @@ class StudioTest < ActiveSupport::TestCase
       admin_user: user_four,
       started_at: Date.yesterday,
       ended_at: nil,
-      contributor_type: :five_day,
+      contributor_type: Enum::ContributorType::FIVE_DAY,
       expected_utilization: 0.8
     })
 


### PR DESCRIPTION
I wanted to do a lightweight experiment to see how it would feel replacing some hardcoded literals with constant references. I picked `FullTimePeriod.contributor_type` as a good candidate for this.

- I added a new `Enum::ContributorType` module with constants defined for each supported contributor type.
- I also added `four_day?` and `five_day?` convenience methods to `FullTimePeriod`.

## Why should we use constant references instead of string/symbol literals?

- It's easier to determine all of the supported values at a glance. Arguably in this case someone could just look at the enum mapping on the AR model, but that's less intuitive for RoR newcomers. Having these values in a standalone module is more self-descriptive. And there are other string/symbol literals used in Stacks that don't have a corresponding enum definition on an AR model, so we shouldn't rely on that as a general approach.
- It makes it less likely that someone will add a typo/runtime error by trying to refer to one of these values as a string or symbol literal, eg `"five-day"` instead of `"five_day"`.