### PR TITLE
Use correct number of business days when calculating daily cost for four-day workers

### DIFF
--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -369,8 +369,12 @@ class AdminUser < ApplicationRecord
     # project out PSU by the EOY)
     if date > Date.today
       latest = latest_full_time_period
-      return latest if latest.ended_at.nil?
+
+      if latest.present? && latest.ended_at.nil?
+        return latest
+      end
     end
+
     full_time_periods.find do |ftp|
       ftp.started_at <= date && ftp.period_ended_at >= date
     end
@@ -544,8 +548,15 @@ class AdminUser < ApplicationRecord
       salary_window.salary
     end
 
+    ftp = full_time_period_at(date)
+
     business_days =
       Stacks::Utils.business_days_between(date.beginning_of_year, date.end_of_year)
+
+    # TODO: Actually calculate the number of non-Friday business days.
+    if ftp.present? && ftp.four_day?
+      business_days *= 0.8
+    end
 
     (yearly_cost / business_days) * 1.1 # employment taxes & healthcare
   end


### PR DESCRIPTION
@hhff had a good catch for the Chewie project tracker, where he noticed that he was listed at a lower hourly cost than expected. This was because, when calculating the effective cost per day for an employee, we are currently dividing by the number of business days in the year -- even for four-day employees. But four-day employees have a different number of expected business days each year (roughly 80% of the business days of a 5-day employee).

I'm choosing to correct the numbers by using `business_days * 0.8` as the denominator for calculating an employee's estimated daily cost to the company. Long-term we should probably update the logic for tallying business days to actually calculate the correct number rather than just estimating it.