### PR TITLE
Use consistent logic for employee hourly rates

### DIFF
--- a/app/admin/admin_users.rb
+++ b/app/admin/admin_users.rb
@@ -111,8 +111,8 @@ ActiveAdmin.register AdminUser do
       column :expected_utilization do |resource|
         "#{(resource.expected_utilization * 100)}%"
       end
-      column :approximate_cost_per_sellable_hour_before_studio_expenses do |resource|
-        number_to_currency(resource.approximate_cost_per_sellable_hour_before_studio_expenses)
+      column :approximate_cost_per_hour_before_studio_expenses do |resource|
+        number_to_currency(resource.approximate_cost_per_hour_before_studio_expenses)
       end
     end
     actions

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -82,12 +82,10 @@ class AdminUser < ApplicationRecord
     )
   end
 
-  def approximate_cost_per_sellable_hour_before_studio_expenses
+  def approximate_cost_per_hour_before_studio_expenses
     date = Date.today.beginning_of_week
-    data = sellable_hours_for_date(date)
-    return nil unless data.present?
-    return nil if data[:sellable] == 0
-    cost_of_employment_on_date(date) / data[:sellable]
+    hours_per_day = 8
+    cost_of_employment_on_date(date) / hours_per_day
   end
 
   def sellable_hours_for_date(date)

--- a/test/models/admin_user_test.rb
+++ b/test/models/admin_user_test.rb
@@ -647,4 +647,17 @@ class AdminUserTest < ActiveSupport::TestCase
 
     assert_nil(period)
   end
+
+  test "#approximate_cost_per_hour_before_studio_expenses returns the expected value" do
+    user = AdminUser.create!({
+      email: "josh@sanctuary.computer",
+      password: "password",
+      old_skill_tree_level: :senior_2
+    })
+
+    actual_cost = user.approximate_cost_per_hour_before_studio_expenses
+    expected_cost = 62.2306
+
+    assert_in_delta(expected_cost, actual_cost, 0.0001)
+  end
 end


### PR DESCRIPTION
As part of the larger COSR changes in Stacks, we need to update the Approximate Cost Per Sellable Hour metric that we assign for each team member. Right now this number is often higher than the actual hourly costs recorded in project COSR data. This is because we're taking someone's daily cost and dividing that only by the number of sellable hours available. To make this consistent with the COSR hourly costs, we should divide by 8 hours, and ignore the team member's utilization rate.

In other words, someone shouldn't appear as more expensive *to an individual project* as a function of how many hours they bill.