### PR TITLE
Rename rate header to cost in COSR explorer

### DIFF
--- a/app/views/admin/project_cosr_explorer/_project_cosr_explorer.html.erb
+++ b/app/views/admin/project_cosr_explorer/_project_cosr_explorer.html.erb
@@ -29,7 +29,7 @@
             Hours
           </th>
           <th class="col">
-            Hourly rate
+            Hourly cost
           </th>
           <th class="col text-right">
             Total cost


### PR DESCRIPTION
It is more accurate to use the term "cost" than "rate for the hourly costs that we incur for each team member on a given project. I'm updating the table header on the COSR Explorer page to use "cost" instead.