### PR TITLE
[FIX] Use QBO line item descriptions as fallback for matching against projects

### DIFF
--- a/app/models/invoice_tracker.rb
+++ b/app/models/invoice_tracker.rb
@@ -78,12 +78,12 @@ class InvoiceTracker < ApplicationRecord
     }
     forecast_project_ids = forecast_projects.map(&:id)
     forecast_project_codes = forecast_projects.map{|fp| fp.code}.compact.uniq
-    
+
     ((qbo_invoice.try(:line_items) || []).select do |qbo_li|
       corresponding_base_line_item = (base["lines"].values.find{|l| l["id"] == qbo_li["id"]} || {})
-      
-      if corresponding_base_line_item.present?
-        next forecast_project_ids.include?(corresponding_base_line_item["forecast_project"])
+
+      if corresponding_base_line_item&.dig("forecast_project").present?
+        forecast_project_ids.include?(corresponding_base_line_item["forecast_project"])
       else
         forecast_project_codes.any?{|code| (qbo_li["description"] || "").include?(code)}
       end

--- a/test/models/invoice_tracker_test.rb
+++ b/test/models/invoice_tracker_test.rb
@@ -1,0 +1,86 @@
+require 'test_helper'
+
+class InvoiceTrackerTest < ActiveSupport::TestCase
+  test "#qbo_line_items_relating_to_forecast_projects returns any line items without a corresponding base line item if their description matches the current project code" do
+    qbo_invoice = QboInvoice.new
+
+    qbo_invoice.expects(:line_items).returns([
+      {
+        "id" => 1
+      },
+      {
+        "id" => 2
+      }
+    ])
+
+    forecast_project = ForecastProject.new({
+      id: 123,
+      code: "ABCD-1"
+    })
+
+    invoice_tracker = InvoiceTracker.new({
+      qbo_invoice: qbo_invoice
+    })
+
+    invoice_tracker.expects(:blueprint_diff).returns({
+      "generated_at" => DateTime.now.to_s,
+      "lines" => {
+        "1" => {
+          "id" => 2,
+          "forecast_project" => forecast_project.id
+        }
+      }
+    })
+
+    line_items = invoice_tracker.qbo_line_items_relating_to_forecast_projects([
+      forecast_project
+    ])
+
+    assert_equal([
+      {
+        "id" => 2
+      }
+    ], line_items)
+
+  end
+
+  test "#qbo_line_items_relating_to_forecast_projects returns any line items with a corresponding base line item sans forecast project if their description matches the current project code" do
+    qbo_invoice = QboInvoice.new
+
+    qbo_invoice.expects(:line_items).returns([
+      {
+        "id" => 1,
+        "description" => "ABCD-1 Some info here"
+      },
+      {
+        "id" => 2,
+        "description" => "EFGH-2 Some other info here"
+      }
+    ])
+
+    forecast_project = ForecastProject.new({
+      id: 123,
+      code: "ABCD-1"
+    })
+
+    invoice_tracker = InvoiceTracker.new({
+      qbo_invoice: qbo_invoice
+    })
+
+    invoice_tracker.expects(:blueprint_diff).returns({
+      "generated_at" => DateTime.now.to_s,
+      "lines" => {}
+    })
+
+    line_items = invoice_tracker.qbo_line_items_relating_to_forecast_projects([
+      forecast_project
+    ])
+
+    assert_equal([
+      {
+        "id" => 1,
+        "description" => "ABCD-1 Some info here"
+      }
+    ], line_items)
+  end
+end


### PR DESCRIPTION
Sam noticed an issue with a recent invoice where certain QBO line items are not being included in the total tally on the Project Tracker show page. This is due to a previously voided invoice for April, where the line items from the voided invoice got folded into the updated invoice for May:

![invoice_trackers](https://github.com/sanctuarycomputer/stacks/assets/34255985/b6a70b19-aab5-4682-9113-c9f908219bae)

Note the difference between the amount in the invoice description ($23,025) vs the `Total (for this Project Tracker)` column ($20,987.50).

The problem is that the matching logic for which QBO invoice line items (from the invoice tracker) to include in this tally presupposes that the base line item it's checking against has a matching forecast project. However, in the case of the base line items from the voided invoice, they no longer have a `forecast_project` field set.

To address this, I'm falling back to checking for the existence of a matching project code in the `description` field of the new line items if the base line item's `forecast_project` is missing (so essentially the same logic we do if the base line item doesn't exist at all).