### PR TITLE
[WIP][FIX] Add missing dates to ProjectLeadPeriod, and don't check assignments as fallback

### DIFF
--- a/app/models/project_lead_period.rb
+++ b/app/models/project_lead_period.rb
@@ -5,14 +5,6 @@ class ProjectLeadPeriod < ApplicationRecord
   belongs_to :admin_user
   belongs_to :studio
 
-  def period_started_at
-    started_at || project_tracker.first_recorded_assignment&.start_date || Date.today
-  end
-
-  def period_ended_at
-    ended_at || project_tracker.last_recorded_assignment&.end_date || Date.today
-  end
-
   def current?
     period_ended_at >= Date.today - 14.days
   end

--- a/app/models/project_tracker.rb
+++ b/app/models/project_tracker.rb
@@ -57,23 +57,27 @@ class ProjectTracker < ApplicationRecord
     end
   end
 
+  def work_complete?
+    work_status == :complete
+  end
+
   def considered_successful?
-    return nil if work_status != :complete
+    return nil unless work_complete?
     return client_satisfied? && target_profit_margin_satisfied? && target_free_hours_ratio_satisfied?
   end
 
   def client_satisfied?
-    return nil if work_status != :complete
+    return nil unless work_complete?
     project_capsule.client_satisfaction_status == "satisfied"
   end
 
   def target_profit_margin_satisfied?
-    return nil if work_status != :complete
+    return nil unless work_complete?
     profit_margin >= target_profit_margin
   end
 
   def target_free_hours_ratio_satisfied?
-    return nil if work_status != :complete
+    return nil unless work_complete?
     (free_hours_ratio * 100) <= target_free_hours_percent
   end
 

--- a/db/migrate/20240621013049_standardize_project_lead_period_dates.rb
+++ b/db/migrate/20240621013049_standardize_project_lead_period_dates.rb
@@ -1,0 +1,39 @@
+class StandardizeProjectLeadPeriodDates < ActiveRecord::Migration[6.0]
+  def update_started_at!(lead_period)
+    return unless lead_period.started_at.nil?
+
+    started_at = if project_tracker.first_recorded_assignment.present?
+      project_tracker.first_recorded_assignment.start_date
+    else
+      project_tracker.created_at
+    end
+
+    lead_period.update!({
+      started_at: started_at
+    })
+  end
+
+  def update_ended_at!(lead_period)
+    return unless lead_period.ended_at.nil?
+    return unless project_tracker.work_complete?
+
+    ended_at = if project_tracker.last_recorded_assignment.present?
+      project_tracker.last_recorded_assignment.end_date
+    else
+      project_tracker.work_completed_at
+    end
+
+    lead_period.update!({
+      ended_at: ended_at
+    })
+  end
+
+  def change
+    ProjectLeadPeriod.all.each do |lead_period|
+      update_started_at!(lead_period)
+      update_ended_at!(lead_period)
+    end
+
+    change_column_null :project_lead_periods, :started_at, false
+  end
+end


### PR DESCRIPTION
Annie noticed an issue where we are showing incorrect times in the Roles Explorer for the `Time in days since role last held` metric:
- some team members are showing that they haven't held a lead role in several days, even though they currently are in that role
- some team members have a negative number of days since their last time holding this role

These problems stem from checking the `forecast_assignments` for the current project tracker as a fallback when the start or end dates of the lead period are not explicitly set. This results in inaccurate numbers, because team members can either:
- Be overdue in adding their recent hours to Harvest Forecast (if they're the last assignee on a project, this will show that they haven't been a project lead since the day of their last recorded assignment, even if the project is still underway)
- Have already added future hours to Forecast (in which case their project lead period will have an effective end date in the future, resulting in a negative number of days)

To fix these issues, I think we should just outright stop reading from the assignments table as a fallback at runtime. Instead, I think we should run a migration to correct entries in the `project_lead_periods` table where we're missing either the start date, or the end date in the case that the associated project is complete. We should also make the start date column non-nullable (once we've manually ensured that no more null values are present).

Then, at runtime, we can simply use the default `ActsAsPeriod` behavior for the start and end dates.

## Problems with this approach?
One problem with this approach is that it requires that we close out project lead periods when projects are marked complete. Otherwise, project members in lead roles will continue to be treated as current leads indefinitely. I don't have that implemented yet in this PR, though.