### PR TITLE
Bugfix: Adding in table names for ambiguous columns

### DIFF
--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -141,10 +141,10 @@ class AdminUser < ApplicationRecord
   }
 
   scope :active, -> {
-    joins(:full_time_periods).where("started_at <= ? AND coalesce(ended_at, 'infinity') >= ?", Date.today, Date.today)
+    joins(:full_time_periods).where("full_time_periods.started_at <= ? AND coalesce(full_time_periods.ended_at, 'infinity') >= ?", Date.today, Date.today)
   }
   scope :associates, -> {
-    joins(:associates_award_agreement).where("started_at <= ?", Date.today)
+    joins(:associates_award_agreement).where("associates_award_agreements.started_at <= ?", Date.today)
   }
   scope :inactive, -> {
     where.not(id: active)


### PR DESCRIPTION
This is a fix for the [Teams](https://stacks.garden3d.net/admin/admin_users) page. When applying a filter by studio, the page would fail due to an ambiguous SQL query. Adding in the table names for the filter columns has fixed this and the page loads as expected.

More details can be found here: https://www.notion.so/garden3d/Stacks-Team-Filter-bugfix-0262276503444d128d820ca897105555?pvs=4