### PR TITLE
Fix Date::Error on /admin/enterprises when snapshot is empty

### DIFF
--- a/app/admin/enterprises.rb
+++ b/app/admin/enterprises.rb
@@ -27,7 +27,12 @@ ActiveAdmin.register Enterprise do
   index download_links: false do
     column :name
     column :last_generated do |resource|
-      "#{time_ago_in_words(DateTime.iso8601(resource.snapshot["generated_at"]))} ago"
+      generated_at = resource.snapshot.is_a?(Hash) ? resource.snapshot["generated_at"] : nil
+      if generated_at.present?
+        "#{time_ago_in_words(DateTime.iso8601(generated_at))} ago"
+      else
+        "Never"
+      end
     end
     actions
   end


### PR DESCRIPTION
## Summary

`/admin/enterprises` was crashing with `Date::Error: invalid date` after the multi-enterprise PR introduced new enterprises (Garden3D LLC, Index Space LLC, USB Club LLC). Their `generate_snapshot!` has never run, so `snapshot["generated_at"]` is `nil`, and `DateTime.iso8601(nil)` raises.

Render `"Never"` instead when the snapshot is empty / missing `generated_at`. Also guard against `snapshot` not being a Hash (defensive).

## Test plan
- [x] `bin/rails test` — still green
- [ ] After deploy, hit `/admin/enterprises` — page loads; new enterprises show "Never" in Last generated column; Sanctuary still shows the real timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)