### PR TITLE
Skip QBO bill sync for ContributorAdjustments with non-positive amounts

### DIFF
--- a/app/models/concerns/syncs_as_qbo_bill.rb
+++ b/app/models/concerns/syncs_as_qbo_bill.rb
@@ -67,6 +67,13 @@ module SyncsAsQboBill
 
   def sync_qbo_bill!
     return unless contributor.qbo_vendor.present?
+    # QBO Bills reject amounts <= 0 ("Enter a transaction amount that is 0 or
+    # greater"). ContributorAdjustment rows folded from the old MiscPayment
+    # table carry negative amounts (representing deductions from the
+    # contributor's ledger balance) and shouldn't manifest as QBO bills.
+    # PayStubs / CPs / Trueups / ProfitShares are always positive, so this
+    # guard is a no-op for them.
+    return if amount.to_f <= 0
 
     bill = load_qbo_bill! || Quickbooks::Model::Bill.new
     bill.txn_date = bill_txn_date


### PR DESCRIPTION
## Summary

`sync_contributor_qbo_bills` started failing on 300+ rows in prod with `Business Validation Error: Enter a transaction amount that is 0 or greater`. Those are the folded `MiscPayment` rows from the multi-enterprise PR — they live as `ContributorAdjustment`s with **negative amounts** (preserving the original deducts-from-balance semantic). QBO Bills reject amount <= 0.

Add a guard in `SyncsAsQboBill#sync_qbo_bill!` to early-return when `amount.to_f <= 0`. `ContributorAdjustment` supports negative amounts intentionally; the other `SyncsAsQboBill` hosts (`ContributorPayout`, `Trueup`, `ProfitShare`) are always positive so this is a no-op for them.

## Test plan
- [x] `bin/rails test` — green
- [ ] After deploy, manually re-run `sync_contributor_qbo_bills` and confirm the 300+ failures are gone (negative-amount CAs silently skip; positive CAs continue syncing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)