### PR TITLE
Fix .includes(contributor:) on ledger-item models (3 callsites)

### DIFF
--- a/app/models/invoice_tracker.rb
+++ b/app/models/invoice_tracker.rb
@@ -238,7 +238,10 @@ class InvoiceTracker < ApplicationRecord
   end
 
   def surplus_chunks
-    contributor_payouts.includes(contributor: :forecast_person).map(&:calculate_surplus).flatten
+    # ContributorPayout's `:contributor` is delegated through `:ledger` (via
+    # the LedgerItem concern), not a direct AR association — `.includes(contributor:)`
+    # would raise AssociationNotFoundError. Eager-load through the actual chain.
+    contributor_payouts.includes(ledger: { contributor: :forecast_person }).map(&:calculate_surplus).flatten
   end
 
   def commission_deductions_for_line(project_tracker, qbo_line_item, blueprint_line)
@@ -251,7 +254,9 @@ class InvoiceTracker < ApplicationRecord
   end
 
   def commission_total_for_line(line_item_id)
-    contributor_payouts.includes(:contributor).sum do |cp|
+    # Same delegation gotcha as surplus_chunks — :contributor is a method
+    # on CP, not an association. Eager-load via :ledger.
+    contributor_payouts.includes(ledger: :contributor).sum do |cp|
       (cp.blueprint["Commission"] || []).sum do |entry|
         entry.dig("blueprint_metadata", "id").to_s == line_item_id.to_s ? entry["amount"].to_f : 0
       end

--- a/app/models/periodic_report.rb
+++ b/app/models/periodic_report.rb
@@ -142,7 +142,9 @@ class PeriodicReport < ApplicationRecord
   end
 
   def profit_shares_for_studio(studio)
-    rel = profit_shares.includes(contributor: :forecast_person)
+    # ProfitShare's :contributor is delegated via LedgerItem; eager-load through
+    # the actual :ledger association (matches the fix in invoice_tracker.rb).
+    rel = profit_shares.includes(ledger: { contributor: :forecast_person })
     return rel.to_a if studio.nil? || studio.is_garden3d?
     allowed = studio.forecast_people(Studio.all).map(&:forecast_id).to_set
     rel.to_a.select { |ps| allowed.include?(ps.contributor.forecast_person_id) }


### PR DESCRIPTION
## Summary

Production was 500ing on `/admin/invoice_passes/:id` with:

> ActiveRecord::AssociationNotFoundError in Admin::InvoicePasses#index
> Association named 'contributor' was not found on ContributorPayout

After the multi-enterprise PR routed ledger items (CP / Trueup / ContributorAdjustment / ProfitShare / PayStub) through the \`LedgerItem\` concern, their \`:contributor\` is a **delegated Ruby method**, not an AR association. Any \`.includes(:contributor)\` or \`.includes(contributor: ...)\` raises \`AssociationNotFoundError\`.

Three callsites had this bug — fixed all three to eager-load through \`:ledger\` instead:

| File | Method |
|---|---|
| \`app/models/invoice_tracker.rb:241\` | \`surplus_chunks\` |
| \`app/models/invoice_tracker.rb:254\` | \`commission_total_for_line\` |
| \`app/models/periodic_report.rb:145\` | \`profit_shares_for_studio\` |

All now use \`.includes(ledger: { contributor: :forecast_person })\`.

## Test plan
- [x] \`bin/rails test\` — green
- [ ] After deploy, reload \`/admin/invoice_passes/:id\` and confirm it renders
- [ ] Spot-check \`/admin/periodic_reports/:id\` (profit_shares_for_studio caller) to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)