### PR TITLE
Admin::Enterprises#show: render placeholder when QBO not connected

### DIFF
--- a/app/admin/enterprises.rb
+++ b/app/admin/enterprises.rb
@@ -154,6 +154,18 @@ ActiveAdmin.register Enterprise do
   end
 
   show do
+    # The entire dashboard below is QBO-backed (accounts, P&L reports,
+    # snapshot). For an enterprise that hasn't authorized QBO yet, render a
+    # placeholder + the (QBO-independent) pay cycles section instead of
+    # crashing on a nil access token.
+    if resource.qbo_account.blank? || resource.qbo_account.qbo_token.blank?
+      panel "QuickBooks not connected" do
+        para "This enterprise isn't connected to QuickBooks yet. Edit the enterprise to fill in the QBO Account credentials and authorize an OAuth token — financial dashboards will appear here once that's done."
+      end
+      render(partial: "admin/enterprises/pay_cycles_section", locals: { enterprise: resource })
+      next
+    end
+
     COLORS = Stacks::Utils::COLORS
     accounting_method = session[:accounting_method] || "cash"
 


### PR DESCRIPTION
## Summary
- `Admin::Enterprises#show` crashed with `NoMethodError: undefined method 'client' for nil:NilClass` for any enterprise without a `qbo_token` — `QboAccount#make_and_refresh_qbo_access_token` returns `nil` when the token is missing, and the quickbooks-ruby gem then explodes on `service.access_token = nil`.
- The entire show dashboard is QBO-backed (`discover_verticals`, `fetch_all_accounts`, P&L reports, snapshot), so there's no meaningful dashboard to render before QBO is connected.
- Early-return from the `show do` block with a "QuickBooks not connected" panel + the QBO-independent pay cycles partial. Connected enterprises render exactly as before.

## Test plan
- [ ] Visit `/admin/enterprises/:id` for an enterprise with no `qbo_account` → page renders the placeholder panel (and pay cycles if cadence is set), no 500.
- [ ] Visit `/admin/enterprises/:id` for an enterprise with a `qbo_account` but no `qbo_token` → same placeholder render, no 500.
- [ ] Visit `/admin/enterprises/:id` for a fully connected enterprise (e.g. Sanctuary) → dashboards render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)