### PR TITLE
Forecast sync: stop delete_all'ing clients/people/projects

### DIFF
--- a/lib/stacks/forecast.rb
+++ b/lib/stacks/forecast.rb
@@ -12,14 +12,14 @@ class Stacks::Forecast
 
   def sync_all!
     ActiveRecord::Base.transaction do
+      # Assignments are genuinely deletable on Forecast (bookings get removed),
+      # so we still nuke-and-pave them to catch upstream deletions. Clients,
+      # people, and projects only get archived in Forecast — they never
+      # disappear from the API — so upsert_all (keyed on forecast_id) handles
+      # both new rows and the archived flag without us needing to delete
+      # anything first. The old delete_all on those three was also colliding
+      # with the new FK on enterprise_forecast_clients.
       ForecastAssignment.delete_all
-      ForecastProject.delete_all
-      ForecastPerson.delete_all
-      # Skip forecast clients that admins have mapped to an Enterprise — that
-      # mapping is curated state, and the FK on enterprise_forecast_clients
-      # would block a blanket delete_all anyway. The upsert below refreshes
-      # the surviving rows and inserts anything new.
-      ForecastClient.where.not(forecast_id: EnterpriseForecastClient.select(:forecast_client_id)).delete_all
       sync_clients!
       sync_people!
       sync_projects!

--- a/lib/stacks/forecast.rb
+++ b/lib/stacks/forecast.rb
@@ -15,7 +15,11 @@ class Stacks::Forecast
       ForecastAssignment.delete_all
       ForecastProject.delete_all
       ForecastPerson.delete_all
-      ForecastClient.delete_all
+      # Skip forecast clients that admins have mapped to an Enterprise — that
+      # mapping is curated state, and the FK on enterprise_forecast_clients
+      # would block a blanket delete_all anyway. The upsert below refreshes
+      # the surviving rows and inserts anything new.
+      ForecastClient.where.not(forecast_id: EnterpriseForecastClient.select(:forecast_client_id)).delete_all
       sync_clients!
       sync_people!
       sync_projects!


### PR DESCRIPTION
## Summary
- Nightly Forecast sync crashed with \`ActiveRecord::InvalidForeignKey: forecast_id=607830 is still referenced from enterprise_forecast_clients\` at \`lib/stacks/forecast.rb:18\`. The trigger was PR #93's new FK on \`forecast_clients.forecast_id\`, but the real issue is that the \`delete_all\` was never necessary for forecast clients/people/projects in the first place.
- Forecast archives rather than hard-deletes those three — they never disappear from the API, and we even read \`c["archived"]\` into the row. \`upsert_all\` (keyed on \`forecast_id\`) is sufficient on its own to keep them in sync including the archived flag, so the nuke-and-pave was both load-bearing-of-nothing and FK-fragile.
- Assignments keep their \`delete_all\`: bookings really do get removed from Forecast, and the nuke-and-pave is how we catch upstream deletions there.

## Test plan
- [ ] Run the Forecast sync rake task against a DB where at least one forecast client is mapped to an Enterprise → completes without an InvalidForeignKey.
- [ ] After sync: mapped \`enterprise_forecast_clients\` rows untouched, archived flag on \`forecast_clients\` matches Forecast API state, new clients/people/projects show up.
- [ ] \`ForecastAssignment\` row count still matches what Forecast returns for the synced window (i.e. assignments deleted upstream are gone locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)