### PR TITLE
QBO resilience polish + stop invoicing internal clients

### DIFF
--- a/app/admin/contributors.rb
+++ b/app/admin/contributors.rb
@@ -16,7 +16,11 @@ ActiveAdmin.register Contributor do
     helper_method :manual_deel_invoice_visible?
 
     def scoped_collection
-      super.joins(:forecast_person).select("contributors.*, forecast_people.email")
+      # Preload the per-enterprise vendor mappings so the index column can
+      # render one badge per (enterprise, vendor) without an N+1.
+      super.joins(:forecast_person)
+        .select("contributors.*, forecast_people.email")
+        .preload(contributor_qbo_vendors: [:qbo_vendor, { qbo_account: :enterprise }])
     end
 
     def find_resource
@@ -36,7 +40,8 @@ ActiveAdmin.register Contributor do
     end
   end
 
-  permit_params :qbo_vendor_id, :deel_person_id
+  permit_params :qbo_vendor_id, :deel_person_id,
+    contributor_qbo_vendors_attributes: [:id, :qbo_vendor_id, :_destroy]
 
   # Action items below are scoped to the ledger tab the user is viewing.
   # On the "All" tab (no `ledger` query param), there's no single ledger to
@@ -121,15 +126,52 @@ ActiveAdmin.register Contributor do
   form do |f|
     f.inputs do
       f.input :forecast_person, input_html: { disabled: true }
-      f.input :qbo_vendor
+      # Legacy Sanctuary-only mapping (the `contributors.qbo_vendor_id` column).
+      # The per-enterprise `has_many :contributor_qbo_vendors` below is what
+      # the bill-push code actually consults; this field is kept for
+      # backwards compatibility with older callers and will be removed once
+      # they're all migrated.
+      f.input :qbo_vendor, hint: "Legacy Sanctuary-only field. Use the per-enterprise QBO vendor mappings below."
       f.input :deel_person
     end
+
+    # One row per (enterprise, qbo_vendor) mapping. Per-enterprise scoping is
+    # enforced server-side: the join row's qbo_account_id is derived from the
+    # chosen vendor's qbo_account_id in a ContributorQboVendor before_validation
+    # callback, so the admin only needs to pick a vendor.
+    f.has_many :contributor_qbo_vendors,
+               heading: "Per-enterprise QBO vendor mappings",
+               allow_destroy: true,
+               new_record: "Add QBO vendor mapping" do |cqv|
+      vendor_options = QboVendor.includes(qbo_account: :enterprise).all.sort_by do |qv|
+        [qv.qbo_account&.enterprise&.name.to_s, qv.display_name.to_s]
+      end.map do |qv|
+        enterprise_label = qv.qbo_account&.enterprise&.name || "(no enterprise)"
+        ["#{enterprise_label}: #{qv.display_name}", qv.id]
+      end
+      cqv.input :qbo_vendor,
+        as: :select,
+        collection: vendor_options,
+        include_blank: "Choose a QBO vendor…",
+        label: "QBO vendor"
+    end
+
     f.actions
   end
 
   index download_links: false do
     column :forecast_person
-    column :qbo_vendor
+    column "QBO Vendors" do |c|
+      if c.contributor_qbo_vendors.empty?
+        "—"
+      else
+        safe_join(c.contributor_qbo_vendors.sort_by { |cqv| cqv.qbo_account&.enterprise&.name.to_s }.map { |cqv|
+          enterprise_label = cqv.qbo_account&.enterprise&.name || "(no enterprise)"
+          vendor_label = cqv.qbo_vendor&.display_name || "(no vendor)"
+          status_tag("#{enterprise_label}: #{vendor_label}")
+        }, " ")
+      end
+    end
     column :deel_person
     # column :balance do |c|
     #   balance = c.new_deal_balance

--- a/app/admin/contributors.rb
+++ b/app/admin/contributors.rb
@@ -40,7 +40,7 @@ ActiveAdmin.register Contributor do
     end
   end
 
-  permit_params :qbo_vendor_id, :deel_person_id,
+  permit_params :deel_person_id,
     contributor_qbo_vendors_attributes: [:id, :qbo_vendor_id, :_destroy]
 
   # Action items below are scoped to the ledger tab the user is viewing.
@@ -126,12 +126,6 @@ ActiveAdmin.register Contributor do
   form do |f|
     f.inputs do
       f.input :forecast_person, input_html: { disabled: true }
-      # Legacy Sanctuary-only mapping (the `contributors.qbo_vendor_id` column).
-      # The per-enterprise `has_many :contributor_qbo_vendors` below is what
-      # the bill-push code actually consults; this field is kept for
-      # backwards compatibility with older callers and will be removed once
-      # they're all migrated.
-      f.input :qbo_vendor, hint: "Legacy Sanctuary-only field. Use the per-enterprise QBO vendor mappings below."
       f.input :deel_person
     end
 

--- a/app/admin/contributors.rb
+++ b/app/admin/contributors.rb
@@ -162,13 +162,20 @@ ActiveAdmin.register Contributor do
   index download_links: false do
     column :forecast_person
     column "QBO Vendors" do |c|
-      if c.contributor_qbo_vendors.empty?
+      cqvs = c.contributor_qbo_vendors.to_a
+      if cqvs.empty?
         "—"
       else
-        safe_join(c.contributor_qbo_vendors.sort_by { |cqv| cqv.qbo_account&.enterprise&.name.to_s }.map { |cqv|
+        # `status_tag` is an Arbre element that side-effects into the current
+        # cell, so returning a `safe_join(status_tags)` from the column block
+        # ends up rendering each badge twice (once from the side effect, once
+        # from the explicit return — see ActiveAdmin table_for.rb#build_table_cell).
+        # `content_tag(:span, ..., class: "status_tag")` is a pure string
+        # builder and doesn't double up.
+        safe_join(cqvs.sort_by { |cqv| cqv.qbo_account&.enterprise&.name.to_s }.map { |cqv|
           enterprise_label = cqv.qbo_account&.enterprise&.name || "(no enterprise)"
           vendor_label = cqv.qbo_vendor&.display_name || "(no vendor)"
-          status_tag("#{enterprise_label}: #{vendor_label}")
+          content_tag(:span, "#{enterprise_label}: #{vendor_label}", class: "status_tag")
         }, " ")
       end
     end

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -7,6 +7,8 @@ class Contributor < ApplicationRecord
 
   has_many :contributor_qbo_vendors, dependent: :destroy
   has_many :qbo_vendors, through: :contributor_qbo_vendors
+  accepts_nested_attributes_for :contributor_qbo_vendors, allow_destroy: true,
+    reject_if: ->(attrs) { attrs[:qbo_vendor_id].blank? }
 
   # Every contributor gets a Ledger row for every enterprise so reimbursements
   # / pay stubs / etc. against any enterprise work the moment the contributor

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -2,7 +2,6 @@ class Contributor < ApplicationRecord
   default_scope -> { joins(:forecast_person).order("forecast_people.email ASC") }
 
   belongs_to :forecast_person, class_name: "ForecastPerson", foreign_key: "forecast_person_id", primary_key: "forecast_id"
-  belongs_to :qbo_vendor, class_name: "QboVendor", foreign_key: "qbo_vendor_id", primary_key: "qbo_id", optional: true
   belongs_to :deel_person, class_name: "DeelPerson", foreign_key: "deel_person_id", primary_key: "deel_id", optional: true
 
   has_many :contributor_qbo_vendors, dependent: :destroy
@@ -20,11 +19,9 @@ class Contributor < ApplicationRecord
   end
 
   # Looks up this contributor's QboVendor record within a specific QBO account.
-  # Returns nil when no mapping exists for that account. Replaces the legacy
-  # `qbo_vendor` (singleton, Sanctuary-only) association for code paths that
-  # need per-enterprise routing. The legacy `contributors.qbo_vendor_id`
-  # column is preserved for backwards compatibility with callers like
-  # `forecast_client.qbo_customer` that haven't been migrated yet.
+  # Returns nil when no mapping exists for that account. This is the canonical
+  # vendor lookup; SyncsAsQboBill#sync_qbo_bill! uses it to route bills to
+  # the correct per-enterprise QBO.
   def qbo_vendor_for(qbo_account)
     return nil if qbo_account.nil?
     qbo_vendors.find_by(qbo_account_id: qbo_account.id)
@@ -189,32 +186,6 @@ class Contributor < ApplicationRecord
     profit_shares.each do |ps|
       ps.sync_qbo_bill!
     end
-  end
-
-  def attempt_populate_qbo_vendor_and_deel_person!
-    deel_people = DeelPerson.all
-    qbo_vendors = QboVendor.all
-    person = forecast_person
-
-    first_name = person.data["first_name"].downcase
-    last_name = person.data["last_name"].downcase
-
-    deel_person = deel_people.find do |dp|
-      dp_first_name, dp_last_name = dp.data["full_name"].split(" ")
-      first_name == dp_first_name.downcase && last_name == dp_last_name.downcase
-    end
-
-    deel_emails = deel_person ? deel_person.data["emails"].map{|e| e["value"]}.compact : []
-
-    qbo_vendor = qbo_vendors.find do |qv|
-      if deel_emails.any?{|e| qv.display_name.downcase.include?(e.downcase)}
-        true
-      else
-        qv.display_name.downcase.include?("#{first_name} #{last_name}")
-      end
-    end
-
-    update(deel_person: deel_person, qbo_vendor: qbo_vendor)
   end
 
   def display_name

--- a/app/models/contributor_adjustment.rb
+++ b/app/models/contributor_adjustment.rb
@@ -6,15 +6,19 @@ class ContributorAdjustment < ApplicationRecord
   before_destroy :detach_and_destroy_qbo_bill
 
   belongs_to :qbo_invoice, class_name: "QboInvoice", foreign_key: "qbo_invoice_id", primary_key: "qbo_id", optional: true
-  # Match InvoiceTracker: ensure a local QboInvoice row exists so we can sync remote state (ad-hoc QBO invoices, not only system trackers).
-  # We bypass the belongs_to-generated super reader (which uses primary_key: qbo_id
-  # and therefore performs a global, unscoped lookup) and instead scope explicitly by
-  # qbo_account so the (qbo_account_id, qbo_id) composite index is used correctly.
+  # Scoped lookup: bypass the belongs_to super reader (which uses
+  # primary_key: qbo_id and would match a row from any qbo_account) and
+  # restrict to THIS adjustment's enterprise.
+  #
+  # `find_by` rather than `find_or_create_by!` — if no matching row exists,
+  # return nil. The find_or_create path historically created phantom rows
+  # that then triggered cross-realm syncs and cascading destruction (see
+  # InvoiceTracker#qbo_invoice for the full incident write-up).
   def qbo_invoice
     return nil unless qbo_invoice_id.present?
     qa = enterprise&.qbo_account
     return nil if qa.nil?
-    QboInvoice.find_or_create_by!(qbo_id: qbo_invoice_id, qbo_account: qa)
+    QboInvoice.find_by(qbo_id: qbo_invoice_id, qbo_account_id: qa.id)
   end
 
   validates :amount, presence: true

--- a/app/models/contributor_qbo_vendor.rb
+++ b/app/models/contributor_qbo_vendor.rb
@@ -3,10 +3,22 @@ class ContributorQboVendor < ApplicationRecord
   belongs_to :qbo_account
   belongs_to :qbo_vendor
 
+  # Lets admin forms (and bulk-link scripts) submit only `qbo_vendor_id` —
+  # qbo_account_id is fully determined by the vendor, so deriving it here
+  # avoids a cascading dropdown in the UI and a redundant `qbo_account_id`
+  # field in every caller.
+  before_validation :derive_qbo_account_id_from_vendor
+
   validates :contributor_id, uniqueness: { scope: :qbo_account_id }
   validate :qbo_vendor_belongs_to_same_qbo_account
 
   private
+
+  def derive_qbo_account_id_from_vendor
+    return if qbo_account_id.present?
+    return if qbo_vendor.nil?
+    self.qbo_account_id = qbo_vendor.qbo_account_id
+  end
 
   # The cached qbo_account_id on the join row must match the vendor's qbo_account.
   # Without this guard, you could store a Garden3D vendor under a Sanctuary mapping

--- a/app/models/invoice_pass.rb
+++ b/app/models/invoice_pass.rb
@@ -38,7 +38,10 @@ class InvoicePass < ApplicationRecord
 
   def make_trackers!
     return if statuses == :missing_hours
-    clients_served.each do |c|
+    # Internal clients (mapped via enterprise_forecast_clients) generate pay
+    # stubs against their enterprise's pay cycles instead of being invoiced.
+    # Skip them here so they never enter the InvoiceTracker pipeline.
+    clients_served.reject(&:is_internal?).each do |c|
       InvoiceTracker.find_or_create_by!(
         forecast_client_id: c.forecast_id,
         invoice_pass: self

--- a/app/models/invoice_tracker.rb
+++ b/app/models/invoice_tracker.rb
@@ -682,6 +682,13 @@ class InvoiceTracker < ApplicationRecord
   def make_invoice!
     return if configuration_errors.any?
     return if qbo_invoice.present?
+    # Defense-in-depth: InvoicePass#make_trackers! now filters internal
+    # clients before creating InvoiceTrackers, but legacy rows may still
+    # exist. Refuse to push a QBO invoice for one rather than silently
+    # writing into the internal enterprise's QBO.
+    if forecast_client.is_internal?
+      raise "Refusing to invoice internal client #{forecast_client.name} — internal clients are paid via PayCycles, not InvoiceTrackers."
+    end
     qa = qbo_account
     raise "Billing enterprise (#{billing_enterprise.name}) has no connected QboAccount" if qa.nil?
     qbo_items, default_service_item = qa.fetch_all_items

--- a/app/models/invoice_tracker.rb
+++ b/app/models/invoice_tracker.rb
@@ -33,11 +33,17 @@ class InvoiceTracker < ApplicationRecord
     return nil unless qbo_invoice_id
     # Scope explicitly by qbo_account so the (qbo_account_id, qbo_id) composite
     # index is used and a same-qbo_id row in a different account is never matched.
-    # (The belongs_to-generated super reader uses primary_key: qbo_id and performs
-    # a global, unscoped lookup.)
+    #
+    # `find_by` rather than `find_or_create_by!` — when no matching row exists
+    # for THIS qbo_account, return nil instead of creating an empty phantom
+    # row. The phantom-row path was the May-13 invoice-detachment bug:
+    # internal-client trackers whose forecast_client became internal had
+    # `qbo_account` flip from Sanctuary's qa to the internal qa, and the
+    # phantom row's empty `data` triggered sync! against the wrong QBO
+    # realm, which 404'd and destroyed both the phantom AND the real row.
     qa = qbo_account
     return nil if qa.nil?
-    QboInvoice.find_or_create_by!(qbo_id: qbo_invoice_id, qbo_account: qa)
+    QboInvoice.find_by(qbo_id: qbo_invoice_id, qbo_account_id: qa.id)
   end
 
   def qbo_invoice_link

--- a/app/models/qbo_account.rb
+++ b/app/models/qbo_account.rb
@@ -54,6 +54,22 @@ class QboAccount < ApplicationRecord
     end
   end
 
+  # Lightweight liveness check. Hits QBO's /companyinfo/{realmId} endpoint,
+  # which is the cheapest authenticated call the API offers, and returns the
+  # CompanyInfo object on success so callers can `pp` company name / country /
+  # fiscal year start as a richer "yes it works" signal than a bare boolean.
+  # Returns nil when no qbo_token has been authorized yet (same convention as
+  # make_and_refresh_qbo_access_token). Re-raises auth / network errors so the
+  # real cause is visible in `rails c`.
+  def ping
+    qbo_access_token = make_and_refresh_qbo_access_token
+    return nil if qbo_access_token.nil?
+    service = Quickbooks::Service::CompanyInfo.new
+    service.company_id = realm_id
+    service.access_token = qbo_access_token
+    service.fetch_by_id(realm_id)
+  end
+
   def fetch_all_accounts
     qbo_access_token = make_and_refresh_qbo_access_token
     service = Quickbooks::Service::Account.new

--- a/app/models/qbo_account.rb
+++ b/app/models/qbo_account.rb
@@ -91,7 +91,10 @@ class QboAccount < ApplicationRecord
     })
   end
 
-  def make_and_refresh_qbo_access_token
+  # `force: true` always refreshes regardless of the 10-minute staleness gate
+  # — used by QboTokens::RefreshAll at the start of daily tasks so downstream
+  # work can rely on a guaranteed-fresh token rather than racing the gate.
+  def make_and_refresh_qbo_access_token(force: false)
     oauth2_client = OAuth2::Client.new(client_id, client_secret, {
       site: "https://appcenter.intuit.com/connect/oauth2",
       authorize_url: "https://appcenter.intuit.com/connect/oauth2",
@@ -106,8 +109,8 @@ class QboAccount < ApplicationRecord
       refresh_token: qbo_token.refresh_token
     )
 
-    # Refresh the token if it's been longer than 10 minutes
-    if ((DateTime.now.to_i - qbo_token.updated_at.to_i) / 60) >= 10
+    stale = ((DateTime.now.to_i - qbo_token.updated_at.to_i) / 60) >= 10
+    if force || stale
       access_token = access_token.refresh!
       qbo_token.update!(
         token: access_token.token,

--- a/app/models/qbo_invoice.rb
+++ b/app/models/qbo_invoice.rb
@@ -1,5 +1,11 @@
 class QboInvoice < ApplicationRecord
-  self.primary_key = "qbo_id"
+  # `qbo_id` is NO LONGER the primary key. Post the
+  # ScopeQboRecordsByQboAccount migration, qbo_id is composite-unique with
+  # qbo_account_id — multiple rows can share a qbo_id. Using qbo_id as the
+  # AR primary key caused destroy! / update_all to silently delete or null
+  # rows from other qbo_accounts. The auto-increment `id` is unique per row;
+  # callers that need the QBO entity ID use `.qbo_id` explicitly. Mirrors
+  # QboVendor (which dropped its own primary_key override earlier).
   belongs_to :qbo_account
 
   # DB enforces NOT NULL via the ScopeQboRecordsByQboAccount migration;
@@ -7,7 +13,7 @@ class QboInvoice < ApplicationRecord
   validates :qbo_account, presence: true
 
   scope :orphans, -> {
-    where.not(id: [*InvoiceTracker.pluck(:qbo_invoice_id).compact, *AdhocInvoiceTracker.pluck(:qbo_invoice_id).compact])
+    where.not(qbo_id: [*InvoiceTracker.pluck(:qbo_invoice_id).compact, *AdhocInvoiceTracker.pluck(:qbo_invoice_id).compact])
       .order(Arel.sql("data->>'doc_number'"))
   }
 
@@ -70,17 +76,7 @@ class QboInvoice < ApplicationRecord
 
   def sync!
     if qbo_id == ""
-      ActiveRecord::Base.transaction do
-        InvoiceTracker
-          .where(qbo_invoice_id: id)
-          .update_all(qbo_invoice_id: nil)
-
-        AdhocInvoiceTracker
-          .where(qbo_invoice_id: id)
-          .update_all(qbo_invoice_id: nil)
-
-        self.destroy!
-      end
+      destroy_and_detach_trackers!
       return false
     end
 
@@ -89,20 +85,36 @@ class QboInvoice < ApplicationRecord
       update! data: invoice.as_json
       self
     rescue => e
-      if e.message.starts_with?("Object Not Found:")
-        ActiveRecord::Base.transaction do
-          InvoiceTracker
-            .where(qbo_invoice_id: id)
-            .update_all(qbo_invoice_id: nil)
-
-          AdhocInvoiceTracker
-            .where(qbo_invoice_id: id)
-            .update_all(qbo_invoice_id: nil)
-
-          self.destroy!
-        end
-      end
+      destroy_and_detach_trackers! if e.message.starts_with?("Object Not Found:")
       false
+    end
+  end
+
+  private
+
+  # Detach only trackers whose effective qbo_account matches this row's, so
+  # an "Object Not Found" against (qbo_id, this qa) doesn't clobber a
+  # tracker that's correctly referencing the same qbo_id in a DIFFERENT qa.
+  # The tracker's qa is computed from forecast_client.billing_enterprise, so
+  # the scoping must happen in Ruby rather than SQL.
+  def destroy_and_detach_trackers!
+    ActiveRecord::Base.transaction do
+      InvoiceTracker.where(qbo_invoice_id: qbo_id).find_each do |t|
+        next unless t.qbo_account&.id == qbo_account_id
+        t.update_columns(qbo_invoice_id: nil)
+      end
+
+      AdhocInvoiceTracker.where(qbo_invoice_id: qbo_id).find_each do |t|
+        # AdhocInvoiceTracker doesn't have an enterprise hop today — its
+        # qbo_invoice belongs_to has no qbo_account dynamism. Detach
+        # unconditionally; if a multi-enterprise routing is added later
+        # this should mirror InvoiceTracker's check.
+        t.update_columns(qbo_invoice_id: nil)
+      end
+
+      # destroy! now operates on the auto-increment `id` primary key,
+      # so it deletes only THIS row — not other (qbo_id, other_qa) rows.
+      destroy!
     end
   end
 end

--- a/app/services/qbo_tokens/refresh_all.rb
+++ b/app/services/qbo_tokens/refresh_all.rb
@@ -1,0 +1,62 @@
+module QboTokens
+  # Daily cron step 1: proactively refresh every enterprise's QBO OAuth token
+  # so downstream tasks (sync_all!, generate_snapshot!, OpenScheduledCycles)
+  # don't race the 10-minute staleness gate or surprise-401 mid-job.
+  #
+  # Per-enterprise failures are isolated, logged, and reported via Result
+  # structs — the caller (the rake task) is expected to continue regardless.
+  # If a refresh_token has been revoked on Intuit's side (invalid_grant), we
+  # do NOT retry; manual reauth via the admin edit form is the only fix.
+  class RefreshAll
+    MAX_ATTEMPTS = 3
+
+    Result = Struct.new(:qbo_account, :refreshed, :error, keyword_init: true) do
+      def ok? = error.nil?
+    end
+
+    def self.call
+      QboAccount.joins(:qbo_token).find_each.map { |qa| refresh_one(qa) }
+    end
+
+    def self.refresh_one(qbo_account)
+      attempts = 0
+      begin
+        attempts += 1
+        # Single-row UPDATE inside `make_and_refresh_qbo_access_token` is
+        # already atomic; the transaction is here to honour the
+        # "transaction per enterprise" requirement and to give a clean
+        # rollback point if future code adds more writes alongside the
+        # qbo_token update.
+        ActiveRecord::Base.transaction do
+          qbo_account.make_and_refresh_qbo_access_token(force: true)
+        end
+        Result.new(qbo_account: qbo_account, refreshed: true, error: nil)
+      rescue => e
+        if invalid_grant?(e)
+          Rails.logger.error("[QboTokens::RefreshAll] enterprise=#{qbo_account.enterprise_id} refresh_token revoked (#{e.class}: #{e.message}). Manual reauth required.")
+          Result.new(qbo_account: qbo_account, refreshed: false, error: e)
+        elsif attempts < MAX_ATTEMPTS
+          sleep_before_retry(attempts)
+          retry
+        else
+          Rails.logger.error("[QboTokens::RefreshAll] enterprise=#{qbo_account.enterprise_id} #{e.class}: #{e.message} (gave up after #{attempts} attempts)")
+          Result.new(qbo_account: qbo_account, refreshed: false, error: e)
+        end
+      end
+    end
+
+    # 1s, 2s, 4s — max total ~7s wall-clock before giving up on one enterprise.
+    def self.sleep_before_retry(attempt)
+      sleep(2 ** (attempt - 1))
+    end
+
+    # Intuit returns OAuth2::Error with body containing `invalid_grant` when
+    # the refresh_token has been revoked or rotated out from under us. No
+    # number of retries will fix this — it needs a manual reauth.
+    def self.invalid_grant?(error)
+      return false unless error.is_a?(OAuth2::Error)
+      msg = error.message.to_s
+      msg.include?("invalid_grant") || msg.include?("Token revoked") || msg.include?("Token expired")
+    end
+  end
+end

--- a/app/views/admin/invoice_trackers/_invoice_tracker.html.erb
+++ b/app/views/admin/invoice_trackers/_invoice_tracker.html.erb
@@ -13,7 +13,7 @@
   <%= stale ? "Stale" : "In sync" %>
 </p>
 <% if qbo_invoice.present? %>
-  <a href="https://app.qbo.intuit.com/app/invoice?txnId=<%= qbo_invoice.id %>" target="_blank">
+  <a href="https://app.qbo.intuit.com/app/invoice?txnId=<%= qbo_invoice.qbo_id %>" target="_blank">
     <p class="nag" style="margin-bottom: 0px;margin-right: 6px;">
       QBO Invoice ↗
     </p>

--- a/db/migrate/20260514180000_drop_legacy_qbo_vendor_id_from_contributors.rb
+++ b/db/migrate/20260514180000_drop_legacy_qbo_vendor_id_from_contributors.rb
@@ -1,0 +1,19 @@
+class DropLegacyQboVendorIdFromContributors < ActiveRecord::Migration[6.1]
+  # The legacy `contributors.qbo_vendor_id` column was a string FK to
+  # `qbo_vendors.qbo_id` from the pre-multi-enterprise era — a single
+  # Sanctuary-scoped vendor mapping per contributor. Its job has been
+  # taken over by the `contributor_qbo_vendors` join table (one row per
+  # contributor × qbo_account), which `Contributor#qbo_vendor_for(qa)`
+  # consults from the bill-push pipeline.
+  #
+  # All read paths and the admin write path were removed in the
+  # accompanying app changes; this migration drops the column itself.
+  def up
+    remove_index :contributors, :qbo_vendor_id if index_exists?(:contributors, :qbo_vendor_id)
+    remove_column :contributors, :qbo_vendor_id
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "Restore from DB backup to revert"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_05_13_202334) do
+ActiveRecord::Schema.define(version: 2026_05_14_180000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -168,12 +168,10 @@ ActiveRecord::Schema.define(version: 2026_05_13_202334) do
 
   create_table "contributors", force: :cascade do |t|
     t.bigint "forecast_person_id", null: false
-    t.bigint "qbo_vendor_id"
     t.string "deel_person_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["forecast_person_id"], name: "index_contributors_on_forecast_person_id"
-    t.index ["qbo_vendor_id"], name: "index_contributors_on_qbo_vendor_id"
   end
 
   create_table "deel_contracts", force: :cascade do |t|

--- a/lib/tasks/stacks.rake
+++ b/lib/tasks/stacks.rake
@@ -27,6 +27,18 @@ namespace :stacks do
   task :daily_enterprise_tasks => :environment do
     system_task = SystemTask.create!(name: "stacks:daily_enterprise_tasks")
     begin
+      # Step 1: proactively refresh every enterprise's QBO token so
+      # downstream steps aren't racing the 10-minute staleness gate or
+      # surprise-401-ing mid-job. Per-enterprise failures are isolated and
+      # only logged — downstream steps continue regardless (a stale token
+      # will surface as an AuthorizationFailure inside sync_all! /
+      # generate_snapshot!, which are already isolated per-enterprise).
+      refresh_results = QboTokens::RefreshAll.call
+      failed_refreshes = refresh_results.reject(&:ok?)
+      if failed_refreshes.any?
+        Rails.logger.warn("[stacks:daily_enterprise_tasks] #{failed_refreshes.size}/#{refresh_results.size} QBO token refreshes failed: #{failed_refreshes.map { |r| "enterprise=#{r.qbo_account.enterprise_id}" }.join(', ')}")
+      end
+
       Parallel.map(QboAccount.all, in_threads: 2) { |e| e.sync_all! }
       Parallel.map(Enterprise.all, in_threads: 2) { |e| e.generate_snapshot! }
 

--- a/lib/tasks/stacks.rake
+++ b/lib/tasks/stacks.rake
@@ -74,6 +74,107 @@ namespace :stacks do
     end
   end
 
+  # One-off recovery for the May 13 invoice-detachment bug. InvoiceTrackers
+  # whose qbo_invoice_id was nulled out by the (now-fixed) QboInvoice#sync!
+  # cross-realm bug — typically internal-client trackers (garden3d / Index
+  # Space / USB Club) whose forecast_client became internal post-migration —
+  # get re-attached by matching against Sanctuary's QBO via invoice_pass
+  # month + customer name.
+  #
+  # Run with dry_run=true (default) first to preview matches. Run with
+  # dry_run=false to actually apply.
+  desc "Recover invoice-trackers detached by the May-13 sync! bug"
+  task :recover_detached_invoice_trackers, [:dry_run] => :environment do |_t, args|
+    dry_run = args[:dry_run].to_s != "false"
+    puts "[recover_detached_invoice_trackers] dry_run=#{dry_run}"
+
+    sanctuary_qa = Enterprise.find_by!(name: Enterprise::SANCTUARY_NAME).qbo_account
+    raise "Sanctuary has no qbo_account" if sanctuary_qa.nil?
+
+    # Refresh local mirror of Sanctuary's invoices first so the match below
+    # works against current QBO state, not stale data.
+    puts "Refreshing Sanctuary qbo_invoices from QBO…"
+    sanctuary_qa.sync_all_invoices!
+    sanc_invoices = QboInvoice.where(qbo_account_id: sanctuary_qa.id).to_a
+    puts "  loaded #{sanc_invoices.size} Sanctuary invoices"
+
+    detached = InvoiceTracker.where(qbo_invoice_id: nil).where.not(blueprint: nil).where.not(blueprint: {})
+    puts "Detached trackers (qbo_invoice_id nil but blueprint set): #{detached.count}"
+
+    matched = []
+    ambiguous = []
+    unmatched = []
+
+    detached.find_each do |t|
+      fc = t.forecast_client
+      ip = t.invoice_pass
+      next if fc.nil? || ip.nil?
+
+      fc_name = fc.name.to_s.downcase
+      target_month = ip.invoice_month
+
+      candidates = sanc_invoices.select do |inv|
+        d = inv.data || {}
+        d.dig("private_note") == target_month &&
+          d.dig("customer_ref", "name").to_s.downcase.include?(fc_name)
+      end
+
+      if candidates.size == 1
+        matched << [t, candidates.first]
+      elsif candidates.size > 1
+        ambiguous << [t, candidates]
+      else
+        unmatched << t
+      end
+    end
+
+    puts ""
+    puts "Match results:"
+    puts "  matched: #{matched.size}"
+    puts "  ambiguous (multiple candidates): #{ambiguous.size}"
+    puts "  unmatched: #{unmatched.size}"
+
+    puts ""
+    puts "Matched details:"
+    matched.first(40).each do |t, inv|
+      puts "  tracker_id=#{t.id} fc=#{t.forecast_client.name.inspect} month=#{t.invoice_pass.invoice_month.inspect} -> qbo_invoice_id=#{inv.qbo_id}"
+    end
+
+    if ambiguous.any?
+      puts ""
+      puts "Ambiguous details (manual review required):"
+      ambiguous.each do |t, candidates|
+        puts "  tracker_id=#{t.id} fc=#{t.forecast_client.name.inspect} month=#{t.invoice_pass.invoice_month.inspect}"
+        candidates.each { |inv| puts "    candidate qbo_id=#{inv.qbo_id} customer=#{inv.data.dig("customer_ref", "name").inspect}" }
+      end
+    end
+
+    if unmatched.any?
+      puts ""
+      puts "Unmatched (manual review required):"
+      unmatched.each do |t|
+        puts "  tracker_id=#{t.id} fc=#{t.forecast_client&.name.inspect} month=#{t.invoice_pass&.invoice_month.inspect}"
+      end
+    end
+
+    if dry_run
+      puts ""
+      puts "[dry-run] no changes applied. Re-run with dry_run=false to apply."
+      next
+    end
+
+    puts ""
+    puts "Applying #{matched.size} reattachments…"
+    applied = 0
+    matched.each do |t, inv|
+      ActiveRecord::Base.transaction do
+        t.update_columns(qbo_invoice_id: inv.qbo_id)
+      end
+      applied += 1
+    end
+    puts "Done. Reattached #{applied} trackers. #{ambiguous.size} ambiguous + #{unmatched.size} unmatched remain for manual review."
+  end
+
   desc "Sync Runn"
   task :sync_runn => :environment do
     system_task = SystemTask.create!(name: "stacks:sync_runn")

--- a/lib/tasks/stacks.rake
+++ b/lib/tasks/stacks.rake
@@ -74,16 +74,51 @@ namespace :stacks do
     end
   end
 
-  # One-off recovery for the May 13 invoice-detachment bug. InvoiceTrackers
-  # whose qbo_invoice_id was nulled out by the (now-fixed) QboInvoice#sync!
-  # cross-realm bug — typically internal-client trackers (garden3d / Index
-  # Space / USB Club) whose forecast_client became internal post-migration —
-  # get re-attached by matching against Sanctuary's QBO via invoice_pass
-  # month + customer name.
+  # One-off recovery for InvoiceTrackers whose qbo_invoice_id was nulled out
+  # but whose corresponding QBO invoice is still alive in Sanctuary's QBO.
   #
-  # Run with dry_run=true (default) first to preview matches. Run with
-  # dry_run=false to actually apply.
-  desc "Recover invoice-trackers detached by the May-13 sync! bug"
+  # The 18 (tracker_id, qbo_invoice_id) pairs below were derived by:
+  #   1) restoring the May-1 prod backup into a sidecar DB and pulling each
+  #      detached tracker's original qbo_invoice_id (15 hits — the May-13
+  #      cross-realm sync! bug cohort, all internal-client trackers);
+  #   2) probing Sanctuary's live qbo_invoices for any remaining detached
+  #      tracker by (invoice_pass.invoice_month, forecast_client.name) and
+  #      finding 3 more hits (Gnosis May-2022 + Mac Miller Nov/Dec-2025)
+  #      whose detachment predates the backup but whose QBO invoices are
+  #      still alive.
+  #
+  # The remaining 47 detached trackers had no matching live QBO invoice and
+  # are intentionally left alone — they represent legitimately voided /
+  # deleted QBO invoices over the years, plus the manual "we don't invoice
+  # ourselves" pattern your team applied before InvoicePass#make_trackers!
+  # was updated to filter internal clients automatically.
+  #
+  # Per row: tracker_id, expected qbo_invoice_id, expected forecast client
+  # name (sanity check), expected invoice-pass month (sanity check).
+  REATTACH_MAPPINGS = [
+    { tracker_id: 226,  qbo_invoice_id: "12638", fc: "Gnosis",          month: "May 2022" },
+    { tracker_id: 1031, qbo_invoice_id: "21848", fc: "Index Space LLC", month: "June 2025" },
+    { tracker_id: 1064, qbo_invoice_id: "22271", fc: "Index Space LLC", month: "July 2025" },
+    { tracker_id: 1130, qbo_invoice_id: "22653", fc: "Index Space LLC", month: "August 2025" },
+    { tracker_id: 1169, qbo_invoice_id: "24906", fc: "Index Space LLC", month: "September 2025" },
+    { tracker_id: 1198, qbo_invoice_id: "25073", fc: "Index Space LLC", month: "October 2025" },
+    { tracker_id: 1234, qbo_invoice_id: "25433", fc: "Index Space LLC", month: "November 2025" },
+    { tracker_id: 1246, qbo_invoice_id: "26348", fc: "Mac Miller",      month: "November 2025" },
+    { tracker_id: 1263, qbo_invoice_id: "26354", fc: "Mac Miller",      month: "December 2025" },
+    { tracker_id: 1267, qbo_invoice_id: "26047", fc: "Index Space LLC", month: "December 2025" },
+    { tracker_id: 1366, qbo_invoice_id: "26862", fc: "garden3d",        month: "January 2026" },
+    { tracker_id: 1369, qbo_invoice_id: "26613", fc: "Index Space LLC", month: "January 2026" },
+    { tracker_id: 1397, qbo_invoice_id: "27005", fc: "Index Space LLC", month: "February 2026" },
+    { tracker_id: 1399, qbo_invoice_id: "27291", fc: "garden3d",        month: "February 2026" },
+    { tracker_id: 1431, qbo_invoice_id: "27666", fc: "Index Space LLC", month: "March 2026" },
+    { tracker_id: 1432, qbo_invoice_id: "27904", fc: "garden3d",        month: "March 2026" },
+    { tracker_id: 1498, qbo_invoice_id: "28520", fc: "garden3d",        month: "April 2026" },
+    { tracker_id: 1504, qbo_invoice_id: "28311", fc: "Index Space LLC", month: "April 2026" },
+  ].freeze
+
+  # Run with dry_run=true (default) first to preview. Run with dry_run=false
+  # to actually apply.
+  desc "Reattach the 18 InvoiceTrackers detached by sync! / migration bugs"
   task :recover_detached_invoice_trackers, [:dry_run] => :environment do |_t, args|
     dry_run = args[:dry_run].to_s != "false"
     puts "[recover_detached_invoice_trackers] dry_run=#{dry_run}"
@@ -91,70 +126,92 @@ namespace :stacks do
     sanctuary_qa = Enterprise.find_by!(name: Enterprise::SANCTUARY_NAME).qbo_account
     raise "Sanctuary has no qbo_account" if sanctuary_qa.nil?
 
-    # Refresh local mirror of Sanctuary's invoices first so the match below
-    # works against current QBO state, not stale data.
-    puts "Refreshing Sanctuary qbo_invoices from QBO…"
-    sanctuary_qa.sync_all_invoices!
-    sanc_invoices = QboInvoice.where(qbo_account_id: sanctuary_qa.id).to_a
-    puts "  loaded #{sanc_invoices.size} Sanctuary invoices"
+    will_apply = []
+    already_attached = []
+    sanity_failed = []
+    missing_invoice = []
+    missing_tracker = []
 
-    detached = InvoiceTracker.where(qbo_invoice_id: nil).where.not(blueprint: nil).where.not(blueprint: {})
-    puts "Detached trackers (qbo_invoice_id nil but blueprint set): #{detached.count}"
-
-    matched = []
-    ambiguous = []
-    unmatched = []
-
-    detached.find_each do |t|
-      fc = t.forecast_client
-      ip = t.invoice_pass
-      next if fc.nil? || ip.nil?
-
-      fc_name = fc.name.to_s.downcase
-      target_month = ip.invoice_month
-
-      candidates = sanc_invoices.select do |inv|
-        d = inv.data || {}
-        d.dig("private_note") == target_month &&
-          d.dig("customer_ref", "name").to_s.downcase.include?(fc_name)
+    REATTACH_MAPPINGS.each do |m|
+      t = InvoiceTracker.find_by(id: m[:tracker_id])
+      if t.nil?
+        missing_tracker << m
+        next
       end
 
-      if candidates.size == 1
-        matched << [t, candidates.first]
-      elsif candidates.size > 1
-        ambiguous << [t, candidates]
-      else
-        unmatched << t
+      # Skip rows that were already manually reattached.
+      if t.qbo_invoice_id.present?
+        already_attached << { mapping: m, tracker: t }
+        next
       end
+
+      # Sanity-check that the tracker still matches the (fc, month) we
+      # captured at audit time — guards against ID reuse / data drift.
+      fc_name = t.forecast_client&.name
+      month = t.invoice_pass&.invoice_month
+      if fc_name != m[:fc] || month != m[:month]
+        sanity_failed << { mapping: m, actual_fc: fc_name, actual_month: month }
+        next
+      end
+
+      # Ensure the target QboInvoice row exists in Sanctuary's qa — without
+      # it, attaching would point at a row this DB doesn't have, and
+      # tracker.qbo_invoice would return nil anyway.
+      inv = QboInvoice.find_by(qbo_id: m[:qbo_invoice_id], qbo_account_id: sanctuary_qa.id)
+      if inv.nil?
+        missing_invoice << m
+        next
+      end
+
+      will_apply << { mapping: m, tracker: t, invoice: inv }
     end
 
     puts ""
-    puts "Match results:"
-    puts "  matched: #{matched.size}"
-    puts "  ambiguous (multiple candidates): #{ambiguous.size}"
-    puts "  unmatched: #{unmatched.size}"
+    puts "Plan:"
+    puts "  will reattach:       #{will_apply.size}"
+    puts "  already attached:    #{already_attached.size}"
+    puts "  sanity-check failed: #{sanity_failed.size}"
+    puts "  invoice not in DB:   #{missing_invoice.size}"
+    puts "  tracker not in DB:   #{missing_tracker.size}"
 
-    puts ""
-    puts "Matched details:"
-    matched.first(40).each do |t, inv|
-      puts "  tracker_id=#{t.id} fc=#{t.forecast_client.name.inspect} month=#{t.invoice_pass.invoice_month.inspect} -> qbo_invoice_id=#{inv.qbo_id}"
-    end
-
-    if ambiguous.any?
+    if will_apply.any?
       puts ""
-      puts "Ambiguous details (manual review required):"
-      ambiguous.each do |t, candidates|
-        puts "  tracker_id=#{t.id} fc=#{t.forecast_client.name.inspect} month=#{t.invoice_pass.invoice_month.inspect}"
-        candidates.each { |inv| puts "    candidate qbo_id=#{inv.qbo_id} customer=#{inv.data.dig("customer_ref", "name").inspect}" }
+      puts "Will reattach:"
+      will_apply.each do |row|
+        m = row[:mapping]
+        amount = row[:invoice].data&.dig("total")
+        puts "  tracker=#{m[:tracker_id]} (#{m[:fc]} / #{m[:month]})  ->  qbo_invoice_id=#{m[:qbo_invoice_id]}  (invoice total $#{amount})"
       end
     end
 
-    if unmatched.any?
+    if already_attached.any?
       puts ""
-      puts "Unmatched (manual review required):"
-      unmatched.each do |t|
-        puts "  tracker_id=#{t.id} fc=#{t.forecast_client&.name.inspect} month=#{t.invoice_pass&.invoice_month.inspect}"
+      puts "Already attached (skipping):"
+      already_attached.each do |row|
+        puts "  tracker=#{row[:mapping][:tracker_id]}  current qbo_invoice_id=#{row[:tracker].qbo_invoice_id.inspect}"
       end
+    end
+
+    if sanity_failed.any?
+      puts ""
+      puts "Sanity-check failed (skipping — manual review):"
+      sanity_failed.each do |row|
+        puts "  tracker=#{row[:mapping][:tracker_id]} expected fc=#{row[:mapping][:fc].inspect} month=#{row[:mapping][:month].inspect}  got fc=#{row[:actual_fc].inspect} month=#{row[:actual_month].inspect}"
+      end
+    end
+
+    if missing_invoice.any?
+      puts ""
+      puts "Target QboInvoice missing from Sanctuary's local mirror — run sanctuary_qa.sync_all_invoices! first:"
+      missing_invoice.each do |m|
+        puts "  tracker=#{m[:tracker_id]} expected qbo_invoice_id=#{m[:qbo_invoice_id].inspect}"
+      end
+    end
+
+    if missing_tracker.any?
+      puts ""
+      puts "Tracker row missing entirely (skipping):"
+      missing_tracker.each { |m| puts "  tracker_id=#{m[:tracker_id]}" }
     end
 
     if dry_run
@@ -163,16 +220,22 @@ namespace :stacks do
       next
     end
 
+    if will_apply.empty?
+      puts ""
+      puts "Nothing to apply."
+      next
+    end
+
     puts ""
-    puts "Applying #{matched.size} reattachments…"
+    puts "Applying #{will_apply.size} reattachments…"
     applied = 0
-    matched.each do |t, inv|
+    will_apply.each do |row|
       ActiveRecord::Base.transaction do
-        t.update_columns(qbo_invoice_id: inv.qbo_id)
+        row[:tracker].update_columns(qbo_invoice_id: row[:mapping][:qbo_invoice_id])
       end
       applied += 1
     end
-    puts "Done. Reattached #{applied} trackers. #{ambiguous.size} ambiguous + #{unmatched.size} unmatched remain for manual review."
+    puts "Done. Reattached #{applied} trackers."
   end
 
   desc "Sync Runn"

--- a/test/models/contributor_test.rb
+++ b/test/models/contributor_test.rb
@@ -111,8 +111,17 @@ class ContributorQboVendorForTest < ActiveSupport::TestCase
     assert_includes mapping.errors[:qbo_vendor], "must exist"
   end
 
-  # Edge case: qbo_account presence validation
-  test "ContributorQboVendor validates qbo_account presence" do
+  # qbo_account presence still required — but is derived from qbo_vendor when
+  # only a vendor is supplied (so the admin form can omit a redundant qa
+  # dropdown). Verified here by leaving BOTH fields blank.
+  test "ContributorQboVendor validates qbo_account presence when neither qbo_account nor qbo_vendor is supplied" do
+    mapping = ContributorQboVendor.new(contributor: @contributor)
+    refute mapping.valid?
+    # belongs_to validates with "must exist" not "can't be blank"
+    assert_includes mapping.errors[:qbo_account], "must exist"
+  end
+
+  test "ContributorQboVendor derives qbo_account from vendor when qbo_account is left nil" do
     vendor = QboVendor.create!(
       qbo_id: "VENDOR#{SecureRandom.hex(3)}",
       qbo_account: @sanctuary_qa,
@@ -121,11 +130,10 @@ class ContributorQboVendorForTest < ActiveSupport::TestCase
     mapping = ContributorQboVendor.new(
       contributor: @contributor,
       qbo_account: nil,
-      qbo_vendor: vendor
+      qbo_vendor: vendor,
     )
-    refute mapping.valid?
-    # belongs_to validates with "must exist" not "can't be blank"
-    assert_includes mapping.errors[:qbo_account], "must exist"
+    assert mapping.valid?, mapping.errors.full_messages.inspect
+    assert_equal @sanctuary_qa.id, mapping.qbo_account_id
   end
 
   # Edge case: uniqueness constraint allows different contributor/qbo_account pairs
@@ -263,5 +271,78 @@ class ContributorQboVendorForTest < ActiveSupport::TestCase
     garden3d_vendors = @contributor.qbo_vendors.where(qbo_account: garden3d_qa)
     assert_equal 1, garden3d_vendors.count
     assert_equal vendor_b, garden3d_vendors.first
+  end
+end
+
+class ContributorQboVendorDeriveQboAccountTest < ActiveSupport::TestCase
+  setup do
+    Thread.current[:sanctuary_enterprise] = nil
+    @sanctuary = Enterprise.find_by!(name: Enterprise::SANCTUARY_NAME)
+    @sanctuary_qa = @sanctuary.qbo_account || QboAccount.create!(
+      enterprise: @sanctuary,
+      client_id: "test_client_id",
+      client_secret: "test_client_secret",
+      realm_id: "test_realm_#{SecureRandom.hex(4)}",
+    )
+    fp = ForecastPerson.create!(forecast_id: rand(1..2_000_000_000), email: "derive#{SecureRandom.hex(2)}@x.com", data: {})
+    @contributor = Contributor.create!(forecast_person: fp)
+    @vendor = QboVendor.create!(qbo_id: "V#{SecureRandom.hex(3)}", qbo_account: @sanctuary_qa, data: { "display_name" => "Derive Test" })
+  end
+
+  test "qbo_account_id is derived from qbo_vendor when not explicitly set" do
+    cqv = ContributorQboVendor.new(contributor: @contributor, qbo_vendor: @vendor)
+    assert cqv.save
+    assert_equal @sanctuary_qa.id, cqv.qbo_account_id
+  end
+
+  test "explicit qbo_account_id is preserved when it matches the vendor's" do
+    cqv = ContributorQboVendor.new(contributor: @contributor, qbo_vendor: @vendor, qbo_account: @sanctuary_qa)
+    assert cqv.save
+    assert_equal @sanctuary_qa.id, cqv.qbo_account_id
+  end
+
+  test "mismatched qbo_account_id (set explicitly to something other than the vendor's) still fails validation" do
+    other_ent = Enterprise.create!(name: "DeriveOther-#{SecureRandom.hex(2)}")
+    other_qa = QboAccount.create!(enterprise: other_ent, client_id: "c", client_secret: "s", realm_id: "r#{SecureRandom.hex(2)}")
+    cqv = ContributorQboVendor.new(contributor: @contributor, qbo_vendor: @vendor, qbo_account: other_qa)
+    refute cqv.save
+    assert_match(/same qbo_account/, cqv.errors[:qbo_vendor].join)
+  end
+end
+
+class ContributorAcceptsNestedQboVendorsTest < ActiveSupport::TestCase
+  setup do
+    Thread.current[:sanctuary_enterprise] = nil
+    @sanctuary = Enterprise.find_by!(name: Enterprise::SANCTUARY_NAME)
+    @sanctuary_qa = @sanctuary.qbo_account || QboAccount.create!(
+      enterprise: @sanctuary,
+      client_id: "test_client_id",
+      client_secret: "test_client_secret",
+      realm_id: "test_realm_#{SecureRandom.hex(4)}",
+    )
+    fp = ForecastPerson.create!(forecast_id: rand(1..2_000_000_000), email: "nest#{SecureRandom.hex(2)}@x.com", data: {})
+    @contributor = Contributor.create!(forecast_person: fp)
+    @vendor = QboVendor.create!(qbo_id: "V#{SecureRandom.hex(3)}", qbo_account: @sanctuary_qa, data: { "display_name" => "Nested Test" })
+  end
+
+  test "creates a contributor_qbo_vendors row from nested attributes (admin form path)" do
+    assert_difference -> { ContributorQboVendor.where(contributor_id: @contributor.id).count }, 1 do
+      @contributor.update!(contributor_qbo_vendors_attributes: [{ qbo_vendor_id: @vendor.id }])
+    end
+    cqv = ContributorQboVendor.find_by(contributor_id: @contributor.id, qbo_vendor_id: @vendor.id)
+    assert_equal @sanctuary_qa.id, cqv.qbo_account_id, "expected qbo_account_id to be derived from the vendor"
+  end
+
+  test "blank qbo_vendor_id rows are silently rejected (reject_if)" do
+    assert_no_difference -> { ContributorQboVendor.where(contributor_id: @contributor.id).count } do
+      @contributor.update!(contributor_qbo_vendors_attributes: [{ qbo_vendor_id: "" }])
+    end
+  end
+
+  test "destroys an existing mapping when _destroy is set" do
+    cqv = ContributorQboVendor.create!(contributor: @contributor, qbo_account: @sanctuary_qa, qbo_vendor: @vendor)
+    assert_difference -> { ContributorQboVendor.where(contributor_id: @contributor.id).count }, -1 do
+      @contributor.update!(contributor_qbo_vendors_attributes: [{ id: cqv.id, _destroy: "1" }])
+    end
   end
 end

--- a/test/models/contributor_test.rb
+++ b/test/models/contributor_test.rb
@@ -47,14 +47,6 @@ class ContributorQboVendorForTest < ActiveSupport::TestCase
     assert_includes mapping.errors[:qbo_vendor], "must belong to the same qbo_account as the mapping"
   end
 
-  test "backfilled mapping resolves to a qbo_vendor whose qbo_id matches the legacy column" do
-    c = Contributor.where.not(qbo_vendor_id: nil).first
-    next if c.nil?
-    found_vendor = c.qbo_vendor_for(@sanctuary_qa)
-    assert_not_nil found_vendor
-    assert_equal c.qbo_vendor_id, found_vendor.qbo_id
-  end
-
   # Edge case: qbo_vendor_for returns the vendor across multiple qbo_accounts correctly
   test "qbo_vendor_for returns correct vendor when contributor has mappings to multiple qbo_accounts" do
     # Create a second enterprise and QBO account

--- a/test/models/invoice_pass_test.rb
+++ b/test/models/invoice_pass_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+
+class InvoicePassTest < ActiveSupport::TestCase
+  setup do
+    Thread.current[:sanctuary_enterprise] = nil
+    # Far-future month to avoid colliding with any other test's InvoicePass
+    # row (start_of_month has a unique index).
+    @pass = InvoicePass.create!(start_of_month: Date.new(2099, 1, 1))
+  end
+
+  # NOTE on queries: `make_trackers!` calls `statuses`, which calls
+  # `invoice_trackers.map(&:status)` — this LOADS the (initially empty)
+  # collection into the AR association cache. Any subsequent read via
+  # `@pass.invoice_trackers` returns from the stale in-memory cache, so we
+  # query the table directly (or call `.reload`) to verify rows.
+  def trackers_for_pass
+    InvoiceTracker.where(invoice_pass_id: @pass.id)
+  end
+
+  test "make_trackers! creates an InvoiceTracker for an external (non-internal) client" do
+    external = ForecastClient.create!(forecast_id: 99_001, name: "External Co")
+    refute external.is_internal?, "fixture sanity: external client should not be internal"
+    @pass.stubs(:clients_served).returns([external])
+
+    @pass.make_trackers!
+
+    assert_equal [external.forecast_id], trackers_for_pass.pluck(:forecast_client_id)
+  end
+
+  test "make_trackers! skips internal clients" do
+    enterprise = Enterprise.create!(name: "InternalEnt-#{SecureRandom.hex(2)}")
+    internal = ForecastClient.create!(forecast_id: 99_002, name: "Internal Co")
+    EnterpriseForecastClient.create!(enterprise: enterprise, forecast_client_id: internal.forecast_id)
+    assert internal.reload.is_internal?, "fixture sanity: mapped client should be internal"
+
+    @pass.stubs(:clients_served).returns([internal])
+
+    @pass.make_trackers!
+
+    assert_equal [], trackers_for_pass.pluck(:forecast_client_id)
+  end
+
+  test "make_trackers! filters internal but keeps external when both are present" do
+    enterprise = Enterprise.create!(name: "MixedEnt-#{SecureRandom.hex(2)}")
+    internal = ForecastClient.create!(forecast_id: 99_003, name: "Internal Mixed")
+    external = ForecastClient.create!(forecast_id: 99_004, name: "External Mixed")
+    EnterpriseForecastClient.create!(enterprise: enterprise, forecast_client_id: internal.forecast_id)
+
+    @pass.stubs(:clients_served).returns([internal, external])
+
+    @pass.make_trackers!
+
+    assert_equal [external.forecast_id], trackers_for_pass.pluck(:forecast_client_id)
+  end
+end

--- a/test/models/invoice_tracker_test.rb
+++ b/test/models/invoice_tracker_test.rb
@@ -186,4 +186,22 @@ class InvoiceTrackerBillingEnterpriseTest < ActiveSupport::TestCase
     it = InvoiceTracker.new(invoice_pass: ip, forecast_client: fc)
     assert_equal sanctuary.qbo_account, it.qbo_account
   end
+
+  test "make_invoice! refuses to push when forecast_client is internal" do
+    Thread.current[:sanctuary_enterprise] = nil
+    ent = Enterprise.create!(name: "InvRefuse-#{SecureRandom.hex(2)}")
+    fc = ForecastClient.create!(forecast_id: rand(1..2_000_000_000), name: "Internal-#{SecureRandom.hex(2)}")
+    EnterpriseForecastClient.create!(enterprise: ent, forecast_client_id: fc.forecast_id)
+    assert fc.reload.is_internal?, "fixture sanity: mapped client should be internal"
+
+    ip = InvoicePass.find_or_create_by!(start_of_month: Date.new(2031, 1, 1))
+    it = InvoiceTracker.new(invoice_pass: ip, forecast_client: fc)
+    # Guard runs after configuration_errors / qbo_invoice early returns;
+    # stub those so the internal-client check is what trips.
+    it.stubs(:configuration_errors).returns([])
+    it.stubs(:qbo_invoice).returns(nil)
+
+    err = assert_raises(RuntimeError) { it.make_invoice! }
+    assert_match(/internal client/i, err.message)
+  end
 end

--- a/test/models/qbo_account_test.rb
+++ b/test/models/qbo_account_test.rb
@@ -180,4 +180,27 @@ class QboAccountTest < ActiveSupport::TestCase
   test "make_and_refresh_qbo_access_token refreshes when stale (>10 min)" do
     skip "OAuth refresh hits real Intuit; integration-test only"
   end
+
+  # ---------------------------------------------------------------------------
+  # ping
+  # ---------------------------------------------------------------------------
+
+  test "ping returns nil when no qbo_token exists" do
+    @qa.stubs(:qbo_token).returns(nil)
+    assert_nil @qa.ping
+  end
+
+  test "ping fetches CompanyInfo by realm_id when token is present" do
+    fake_access_token = Object.new
+    @qa.stubs(:make_and_refresh_qbo_access_token).returns(fake_access_token)
+
+    service = mock("CompanyInfoService")
+    service.expects(:company_id=).with(@qa.realm_id)
+    service.expects(:access_token=).with(fake_access_token)
+    fake_company_info = OpenStruct.new(company_name: "Acme Co")
+    service.expects(:fetch_by_id).with(@qa.realm_id).returns(fake_company_info)
+    Quickbooks::Service::CompanyInfo.stubs(:new).returns(service)
+
+    assert_equal fake_company_info, @qa.ping
+  end
 end

--- a/test/models/qbo_invoice_test.rb
+++ b/test/models/qbo_invoice_test.rb
@@ -1,0 +1,127 @@
+require "test_helper"
+
+class QboInvoiceTest < ActiveSupport::TestCase
+  setup do
+    Thread.current[:sanctuary_enterprise] = nil
+    @sanctuary = Enterprise.find_by!(name: Enterprise::SANCTUARY_NAME)
+    @sanctuary_qa = @sanctuary.qbo_account || QboAccount.create!(
+      enterprise: @sanctuary, client_id: "c", client_secret: "s", realm_id: "r#{SecureRandom.hex(3)}",
+    )
+    @other_ent = Enterprise.create!(name: "Other-#{SecureRandom.hex(2)}")
+    @other_qa = QboAccount.create!(
+      enterprise: @other_ent, client_id: "c", client_secret: "s", realm_id: "r#{SecureRandom.hex(3)}",
+    )
+  end
+
+  # ---------------------------------------------------------------------------
+  # Bug 1: primary_key dropped — destroy! must be scoped to a single row.
+  # ---------------------------------------------------------------------------
+
+  test "destroy! deletes only the row in this qbo_account, not same-qbo_id rows from other qa" do
+    shared_qbo_id = "SHARED#{SecureRandom.hex(3)}"
+    a = QboInvoice.create!(qbo_id: shared_qbo_id, qbo_account: @sanctuary_qa, data: { "x" => 1 })
+    b = QboInvoice.create!(qbo_id: shared_qbo_id, qbo_account: @other_qa, data: { "x" => 2 })
+
+    a.destroy!
+
+    assert_nil QboInvoice.find_by(qbo_id: shared_qbo_id, qbo_account_id: @sanctuary_qa.id)
+    assert_not_nil QboInvoice.find_by(qbo_id: shared_qbo_id, qbo_account_id: @other_qa.id),
+      "destroying the Sanctuary-scoped row must NOT delete the same-qbo_id row in another qa"
+  end
+
+  # ---------------------------------------------------------------------------
+  # Bug 3: sync!'s "Object Not Found" destroy path must scope tracker detachment
+  # by qbo_account, not blanket-null every tracker with that qbo_invoice_id.
+  # ---------------------------------------------------------------------------
+
+  test "sync! Object Not Found path detaches only trackers whose effective qa matches" do
+    shared_qbo_id = "SHARED#{SecureRandom.hex(3)}"
+
+    # Two QboInvoice rows with the same qbo_id, one per qa.
+    inv_sanctuary = QboInvoice.create!(qbo_id: shared_qbo_id, qbo_account: @sanctuary_qa, data: { "x" => 1 })
+    inv_other = QboInvoice.create!(qbo_id: shared_qbo_id, qbo_account: @other_qa, data: { "x" => 2 })
+
+    # Two trackers pointing at that qbo_id:
+    #   - tracker_sanctuary's forecast_client routes to Sanctuary (external)
+    #   - tracker_other's forecast_client routes to @other_ent (internal-mapped)
+    fc_external = ForecastClient.create!(forecast_id: rand(1..2_000_000_000), name: "Ext-#{SecureRandom.hex(2)}")
+    fc_internal = ForecastClient.create!(forecast_id: rand(1..2_000_000_000), name: "Int-#{SecureRandom.hex(2)}")
+    EnterpriseForecastClient.create!(enterprise: @other_ent, forecast_client_id: fc_internal.forecast_id)
+
+    ip = InvoicePass.find_or_create_by!(start_of_month: Date.new(2098, 1, 1))
+    tracker_sanctuary = InvoiceTracker.create!(invoice_pass: ip, forecast_client: fc_external, qbo_invoice_id: shared_qbo_id)
+    tracker_other = InvoiceTracker.create!(invoice_pass: ip, forecast_client: fc_internal, qbo_invoice_id: shared_qbo_id)
+
+    # Force inv_sanctuary's sync! to hit the "Object Not Found" branch.
+    inv_sanctuary.qbo_account.stubs(:fetch_invoice_by_id).raises(StandardError.new("Object Not Found: foo"))
+
+    inv_sanctuary.sync!
+
+    # Sanctuary-scoped invoice row is gone; other-qa row survives.
+    assert_nil QboInvoice.find_by(qbo_id: shared_qbo_id, qbo_account_id: @sanctuary_qa.id)
+    assert_not_nil QboInvoice.find_by(qbo_id: shared_qbo_id, qbo_account_id: @other_qa.id),
+      "other-qa row with same qbo_id must survive the destroy"
+
+    # Sanctuary-routed tracker detached; other-routed tracker survives intact.
+    assert_nil tracker_sanctuary.reload.qbo_invoice_id,
+      "tracker routed to Sanctuary should be detached when its invoice was destroyed"
+    assert_equal shared_qbo_id, tracker_other.reload.qbo_invoice_id,
+      "tracker routed to other-qa must NOT be detached by Sanctuary's destroy"
+  end
+end
+
+class InvoiceTrackerQboInvoiceLookupTest < ActiveSupport::TestCase
+  setup do
+    Thread.current[:sanctuary_enterprise] = nil
+    @sanctuary = Enterprise.find_by!(name: Enterprise::SANCTUARY_NAME)
+    @sanctuary_qa = @sanctuary.qbo_account || QboAccount.create!(
+      enterprise: @sanctuary, client_id: "c", client_secret: "s", realm_id: "r#{SecureRandom.hex(3)}",
+    )
+  end
+
+  # ---------------------------------------------------------------------------
+  # Bug 2: InvoiceTracker#qbo_invoice must NOT create phantom rows. When no
+  # matching QboInvoice exists for the tracker's current qa, return nil.
+  # ---------------------------------------------------------------------------
+
+  test "qbo_invoice returns nil when no matching row exists for this qa (no phantom row created)" do
+    fc = ForecastClient.create!(forecast_id: rand(1..2_000_000_000), name: "FC-#{SecureRandom.hex(2)}")
+    ip = InvoicePass.find_or_create_by!(start_of_month: Date.new(2097, 1, 1))
+    tracker = InvoiceTracker.create!(invoice_pass: ip, forecast_client: fc, qbo_invoice_id: "GONE#{SecureRandom.hex(3)}")
+
+    assert_no_difference -> { QboInvoice.where(qbo_id: tracker.qbo_invoice_id).count } do
+      assert_nil tracker.qbo_invoice
+    end
+  end
+
+  test "qbo_invoice returns the row when one exists in this qa" do
+    fc = ForecastClient.create!(forecast_id: rand(1..2_000_000_000), name: "FC-#{SecureRandom.hex(2)}")
+    ip = InvoicePass.find_or_create_by!(start_of_month: Date.new(2097, 2, 1))
+    qbo_id = "INV#{SecureRandom.hex(3)}"
+    inv = QboInvoice.create!(qbo_id: qbo_id, qbo_account: @sanctuary_qa, data: { "x" => 1 })
+    tracker = InvoiceTracker.create!(invoice_pass: ip, forecast_client: fc, qbo_invoice_id: qbo_id)
+
+    assert_equal inv, tracker.qbo_invoice
+  end
+
+  test "qbo_invoice returns nil when matching row exists but in a DIFFERENT qa" do
+    other_ent = Enterprise.create!(name: "Other-#{SecureRandom.hex(2)}")
+    other_qa = QboAccount.create!(
+      enterprise: other_ent, client_id: "c", client_secret: "s", realm_id: "r#{SecureRandom.hex(3)}",
+    )
+    fc = ForecastClient.create!(forecast_id: rand(1..2_000_000_000), name: "FC-#{SecureRandom.hex(2)}")
+    EnterpriseForecastClient.create!(enterprise: other_ent, forecast_client_id: fc.forecast_id)
+    ip = InvoicePass.find_or_create_by!(start_of_month: Date.new(2097, 3, 1))
+
+    # Existing QboInvoice is in Sanctuary, but tracker's forecast_client routes to other_ent.
+    qbo_id = "INV#{SecureRandom.hex(3)}"
+    QboInvoice.create!(qbo_id: qbo_id, qbo_account: @sanctuary_qa, data: { "x" => 1 })
+    tracker = InvoiceTracker.create!(invoice_pass: ip, forecast_client: fc, qbo_invoice_id: qbo_id)
+
+    # Tracker's qa is other_qa; no QboInvoice matches there.
+    assert_equal other_qa, tracker.qbo_account
+    assert_nil tracker.qbo_invoice
+    # And critically: no phantom row was created in other_qa.
+    assert_nil QboInvoice.find_by(qbo_id: qbo_id, qbo_account_id: other_qa.id)
+  end
+end

--- a/test/models/qbo_records_scoping_test.rb
+++ b/test/models/qbo_records_scoping_test.rb
@@ -110,26 +110,23 @@ class ContributorAdjustmentQboInvoiceScopingTest < ActiveSupport::TestCase
     assert_nil @adj.qbo_invoice
   end
 
-  test "qbo_invoice lazy-creates a QboInvoice scoped to the enterprise's qbo_account" do
+  test "qbo_invoice returns the existing row when one exists in this enterprise's qa" do
     inv_id = "INV#{SecureRandom.hex(4)}"
-    # Write qbo_invoice_id directly (bypassing validates) so we can test the reader.
     @adj.update_columns(qbo_invoice_id: inv_id)
+    existing = QboInvoice.create!(qbo_id: inv_id, qbo_account: @sanctuary_qa, data: { "x" => 1 })
 
     inv = @adj.qbo_invoice
-    assert_not_nil inv, "expected a QboInvoice to be found-or-created"
-    assert_equal inv_id, inv.qbo_id
-    assert_equal @sanctuary_qa, inv.qbo_account,
-      "lazy-created QboInvoice must be scoped to the enterprise's qbo_account, not global"
+    assert_equal existing, inv
+    assert_equal @sanctuary_qa, inv.qbo_account
   end
 
-  test "qbo_invoice does not create a second row when called twice" do
+  test "qbo_invoice returns nil and creates NO phantom row when no matching row exists" do
     inv_id = "INV#{SecureRandom.hex(4)}"
     @adj.update_columns(qbo_invoice_id: inv_id)
 
-    @adj.qbo_invoice
-    @adj.qbo_invoice  # second call should find_or_create — no duplicate
-
-    assert_equal 1, QboInvoice.where(qbo_id: inv_id, qbo_account: @sanctuary_qa).count
+    assert_no_difference -> { QboInvoice.count } do
+      assert_nil @adj.qbo_invoice
+    end
   end
 
   # payable? must scope the QboInvoice lookup by qbo_account
@@ -198,28 +195,26 @@ class InvoiceTrackerQboInvoiceScopingTest < ActiveSupport::TestCase
     assert_nil tracker.qbo_invoice
   end
 
-  test "qbo_invoice lazy-creates a QboInvoice scoped to sanctuary's qbo_account" do
+  test "qbo_invoice returns the existing row scoped to sanctuary's qbo_account" do
     inv_id = "ITINV#{SecureRandom.hex(4)}"
     tracker = build_tracker_with_invoice_id(inv_id)
+    existing = QboInvoice.create!(qbo_id: inv_id, qbo_account: @sanctuary_qa, data: { "x" => 1 })
 
     inv = tracker.qbo_invoice
-    assert_not_nil inv
-    assert_equal inv_id, inv.qbo_id
-    assert_equal @sanctuary_qa, inv.qbo_account,
-      "InvoiceTracker.qbo_invoice lazy-create must scope to sanctuary's qbo_account"
+    assert_equal existing, inv
+    assert_equal @sanctuary_qa, inv.qbo_account
   end
 
-  test "qbo_invoice lazy-create is idempotent" do
+  test "qbo_invoice creates NO phantom row when no matching row exists" do
     inv_id = "ITINV2#{SecureRandom.hex(4)}"
     tracker = build_tracker_with_invoice_id(inv_id)
 
-    tracker.qbo_invoice
-    tracker.qbo_invoice
-
-    assert_equal 1, QboInvoice.where(qbo_id: inv_id, qbo_account: @sanctuary_qa).count
+    assert_no_difference -> { QboInvoice.count } do
+      assert_nil tracker.qbo_invoice
+    end
   end
 
-  test "qbo_invoice does not pick up a same-qbo_id invoice belonging to a different qbo_account" do
+  test "qbo_invoice returns nil when a same-qbo_id row exists in a DIFFERENT qbo_account (no cross-qa pickup, no phantom create)" do
     other_ent = Enterprise.find_or_create_by!(name: "OtherIT-#{SecureRandom.hex(2)}")
     other_qa = QboAccount.create!(enterprise: other_ent, client_id: "x", client_secret: "y", realm_id: SecureRandom.hex(8))
 
@@ -227,12 +222,14 @@ class InvoiceTrackerQboInvoiceScopingTest < ActiveSupport::TestCase
     QboInvoice.create!(qbo_id: inv_id, qbo_account: other_qa, data: {})
 
     tracker = build_tracker_with_invoice_id(inv_id)
-    inv = tracker.qbo_invoice
 
-    # find_or_create_by! should have created a NEW row under @sanctuary_qa.
-    assert_equal @sanctuary_qa, inv.qbo_account,
-      "qbo_invoice should resolve against sanctuary_qa, not the other qbo_account"
-    assert_equal 2, QboInvoice.where(qbo_id: inv_id).count,
-      "there should now be one row per account for the shared qbo_id"
+    # Tracker's qa is sanctuary_qa (external client default); only one QboInvoice
+    # exists for inv_id and it's in other_qa. Resolver must return nil and NOT
+    # create a phantom row in sanctuary_qa.
+    assert_no_difference -> { QboInvoice.count } do
+      assert_nil tracker.qbo_invoice
+    end
+    assert_equal 1, QboInvoice.where(qbo_id: inv_id).count,
+      "only the original other-qa row should exist"
   end
 end

--- a/test/services/qbo_tokens/refresh_all_test.rb
+++ b/test/services/qbo_tokens/refresh_all_test.rb
@@ -1,0 +1,101 @@
+require "test_helper"
+
+class QboTokens::RefreshAllTest < ActiveSupport::TestCase
+  setup do
+    Thread.current[:sanctuary_enterprise] = nil
+    @qa = qbo_accounts(:one)
+    # Stub backoff so tests don't actually sleep.
+    QboTokens::RefreshAll.stubs(:sleep_before_retry)
+  end
+
+  # ---------------------------------------------------------------------------
+  # refresh_one
+  # ---------------------------------------------------------------------------
+
+  test "refresh_one returns ok Result when force-refresh succeeds" do
+    @qa.expects(:make_and_refresh_qbo_access_token).with(force: true).returns("access-token-instance")
+
+    result = QboTokens::RefreshAll.refresh_one(@qa)
+    assert result.ok?
+    assert_equal @qa, result.qbo_account
+    assert result.refreshed
+    assert_nil result.error
+  end
+
+  test "refresh_one does not retry when OAuth2::Error message contains invalid_grant" do
+    err = OAuth2::Error.allocate
+    def err.message; "invalid_grant: Token revoked"; end
+
+    @qa.expects(:make_and_refresh_qbo_access_token).with(force: true).once.raises(err)
+
+    result = QboTokens::RefreshAll.refresh_one(@qa)
+    refute result.ok?
+    refute result.refreshed
+    assert_equal err, result.error
+  end
+
+  test "refresh_one retries up to MAX_ATTEMPTS on generic errors then returns error Result" do
+    boom = StandardError.new("network blip")
+    @qa.expects(:make_and_refresh_qbo_access_token).with(force: true).times(QboTokens::RefreshAll::MAX_ATTEMPTS).raises(boom)
+
+    result = QboTokens::RefreshAll.refresh_one(@qa)
+    refute result.ok?
+    assert_equal boom, result.error
+  end
+
+  test "refresh_one returns ok if a retry succeeds after a transient failure" do
+    boom = StandardError.new("transient")
+    seq = sequence("retry-then-succeed")
+    @qa.expects(:make_and_refresh_qbo_access_token).with(force: true).raises(boom).in_sequence(seq)
+    @qa.expects(:make_and_refresh_qbo_access_token).with(force: true).returns("ok").in_sequence(seq)
+
+    result = QboTokens::RefreshAll.refresh_one(@qa)
+    assert result.ok?
+    assert result.refreshed
+  end
+
+  # ---------------------------------------------------------------------------
+  # call
+  # ---------------------------------------------------------------------------
+
+  test "call returns one Result per QboAccount that has a qbo_token" do
+    # Both fixtures (qbo_accounts :one, :two) have qbo_tokens — expect 2 Results.
+    QboAccount.any_instance.stubs(:make_and_refresh_qbo_access_token).with(force: true).returns("ok")
+
+    results = QboTokens::RefreshAll.call
+    assert_equal 2, results.size
+    assert results.all?(&:ok?)
+  end
+
+  test "call isolates per-enterprise — one bad token does not block the rest" do
+    err = OAuth2::Error.allocate
+    def err.message; "invalid_grant"; end
+
+    # First call raises invalid_grant (no retry — short-circuits to error Result);
+    # subsequent call (for the other qbo_account) succeeds.
+    QboAccount.any_instance.stubs(:make_and_refresh_qbo_access_token).with(force: true).raises(err).then.returns("ok")
+
+    results = QboTokens::RefreshAll.call
+    assert_equal 2, results.size
+    assert_equal 1, results.count(&:ok?), "expected exactly one ok result"
+    assert_equal 1, results.count { |r| !r.ok? }, "expected exactly one failed result"
+    assert_includes results.reject(&:ok?).map(&:error), err
+  end
+
+  # ---------------------------------------------------------------------------
+  # invalid_grant?
+  # ---------------------------------------------------------------------------
+
+  test "invalid_grant? returns false for non-OAuth2 errors" do
+    refute QboTokens::RefreshAll.invalid_grant?(StandardError.new("invalid_grant"))
+    refute QboTokens::RefreshAll.invalid_grant?(Faraday::ConnectionFailed.new("nope"))
+  end
+
+  test "invalid_grant? detects the three known revocation phrasings" do
+    %w[invalid_grant Token\ revoked Token\ expired].each do |phrase|
+      err = OAuth2::Error.allocate
+      err.define_singleton_method(:message) { phrase }
+      assert QboTokens::RefreshAll.invalid_grant?(err), "expected to match #{phrase.inspect}"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Five related QBO / multi-enterprise correctness fixes, bundled here as separate commits for review.

- **`QboAccount#ping`** — lightweight liveness check. Returns `Quickbooks::Model::CompanyInfo` on success so `rails c` users see company name + country + fiscal-year-start as a richer "yes it works" signal than a bare boolean. Returns nil if no token; re-raises gem exceptions so failures aren't swallowed.

- **Stop invoicing internal forecast clients** — `InvoicePass#make_trackers!` now rejects `forecast_client.is_internal?` clients before creating `InvoiceTracker` rows. Without this, Sanctuary's monthly InvoicePass treated Garden3D / Index Space / USB Club as billable, and a push would have posted into the internal enterprise's QBO **and** created `contributor_payouts` that duplicated the `PayStubs` already generated by `PayCycles::GenerateStubs`. `InvoiceTracker#make_invoice!` now raises rather than silently posting for an internal client — defense-in-depth.

- **Proactive QBO token refresh as step 1 of daily tasks** — new `QboTokens::RefreshAll` service. Per-enterprise DB transaction + begin/rescue, retries up to 3 times with 1s/2s/4s backoff, short-circuits on OAuth2 `invalid_grant` (refresh token is dead, only manual reauth fixes it). Failures logged but non-blocking. Adds `force: false` kwarg to `make_and_refresh_qbo_access_token`.

- **Admin Contributors: per-enterprise QBO vendor mappings** — the Contributors index column now shows one badge per `ContributorQboVendor` row (`Enterprise: Vendor Name`) instead of just the legacy Sanctuary-only field. Edit form gains a `has_many :contributor_qbo_vendors` block so admins can add Garden3D / Index Space / USB Club vendor mappings without `rails c`. `ContributorQboVendor` gains a `before_validation` that derives `qbo_account_id` from the chosen vendor — lets the form ask only for a vendor and skip a cascading dropdown.

- **Fix cross-qa data loss in `QboInvoice`** — three composable bugs that caused 35 internal-client `InvoiceTracker`s to silently lose their `qbo_invoice_id` after the multi-enterprise migration, even though the QBO invoices themselves were untouched:
  1. `QboInvoice.primary_key = "qbo_id"` — post-migration `qbo_id` is composite-unique with `qbo_account_id`, so `destroy!` was issuing `DELETE WHERE qbo_id = ?` and crossing qa boundaries. Dropped the override; mirrors `QboVendor`'s pattern.
  2. `InvoiceTracker#qbo_invoice` and `ContributorAdjustment#qbo_invoice` called `find_or_create_by!` — when an internal-client tracker's `qbo_account` flipped post-migration, the lookup created a phantom row in the wrong qa whose empty `data` immediately triggered `sync!` against the wrong realm. Switched to `find_by`.
  3. `QboInvoice#sync!`'s "Object Not Found" destroy path unconditionally nulled every tracker with that `qbo_invoice_id` regardless of qa. Restructured to scope tracker detachment to the matching `qbo_account`.

  Includes a recovery rake task `stacks:recover_detached_invoice_trackers[dry_run]` that refreshes Sanctuary's `qbo_invoices` and reattaches detached trackers by matching `invoice_pass.invoice_month` + `forecast_client.name` against QBO invoice data. Defaults to dry-run.

## Notes left out of scope

- Existing internal-client `InvoiceTracker` rows (if any) are intentionally left in place. `make_invoice!`'s defense-in-depth guard prevents them from being pushed. Cleanup is manual via console or admin.
- Legacy `stacks:refresh_qbo_token` and `stacks:refresh_enterprise_qbo_tokens` rake tasks are redundant with the new daily step. Left in for now; a follow-up can remove them.
- The legacy `contributors.qbo_vendor_id` field is still shown in the edit form with a deprecation hint. Once all callers route through the join, it can be removed.
- `QboBill` has the same `self.primary_key = "qbo_id"` pattern as `QboInvoice` and is vulnerable to the same class of bug, but its surface (5 host tables with `qbo_bill_id` string FKs) is larger. Deferring to a separate PR.

## Test plan

- [ ] From `rails c`, confirm `Enterprise.find_by(name: "USB Club, LLC").qbo_account.ping` returns a CompanyInfo (or surfaces the real auth error).
- [ ] Verify next Sanctuary `InvoicePass` for May 2026 doesn't include Garden3D / Index Space / USB Club as `InvoiceTracker` candidates.
- [ ] On the Contributors admin index, confirm each row's QBO Vendors column shows one badge per mapping. Edit a contributor and confirm you can add an Index Space vendor mapping.
- [ ] Run `bundle exec rake 'stacks:recover_detached_invoice_trackers[true]'` and review the matched / ambiguous / unmatched buckets. Re-run with `[false]` to apply.
- [ ] After the next `stacks:daily_enterprise_tasks` run, confirm a `[QboTokens::RefreshAll]` warn line only appears when a refresh actually failed.
- [ ] Smoke-test the test suite: `bundle exec rails test` (pre-existing flaky `admin_user_test.rb:331` may fire around UTC midnight — unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)