### PR TITLE
Fix NoMethodError in QboProfitAndLossReport#data_for_enterprise

### DIFF
--- a/app/models/qbo_profit_and_loss_report.rb
+++ b/app/models/qbo_profit_and_loss_report.rb
@@ -48,6 +48,14 @@ class QboProfitAndLossReport < ApplicationRecord
         idx = data[accounting_method]["rows"].index(row)
         top_level_category_row =
           data[accounting_method]["rows"][idx..].find{|r| TOP_LEVEL_CATEGORIES.values.include?(r[0])}
+        # QBO P&L reports emit "Other Income" / "Other Expense" sections
+        # AFTER the main Income / COGS / Expenses sections. A vertical-tagged
+        # row in those below-the-line sections (e.g., "[SC] Depreciation"
+        # under Other Expense) has no following Total X line, so the find
+        # above returns nil. Those rows don't bucket into revenue/cogs/
+        # expenses and are skipped — net_revenue still tracks the main
+        # sections, which is what the dashboard reports against.
+        next acc if top_level_category_row.nil?
         acc[TOP_LEVEL_CATEGORIES.key(top_level_category_row[0])] += row[1].to_f
         acc
       end

--- a/test/models/qbo_profit_and_loss_report_test.rb
+++ b/test/models/qbo_profit_and_loss_report_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+
+class QboProfitAndLossReportTest < ActiveSupport::TestCase
+  setup do
+    Thread.current[:sanctuary_enterprise] = nil
+    @sanctuary = Enterprise.find_by!(name: Enterprise::SANCTUARY_NAME)
+    @qa = @sanctuary.qbo_account || QboAccount.create!(
+      enterprise: @sanctuary, client_id: "c", client_secret: "s", realm_id: "r#{SecureRandom.hex(3)}",
+    )
+  end
+
+  test "data_for_enterprise handles vertical-tagged rows that appear after Total Expenses (Other Income/Expense sections)" do
+    # Real QBO data shape: Income / COGS / Expenses sections with Totals,
+    # then "Other Income" / "Other Expense" rows BELOW Total Expenses. A
+    # vertical-tagged row in the below-the-line section has no following
+    # Total X line — that's the case that used to NoMethodError on
+    # `top_level_category_row[0]`.
+    rows = [
+      ["[SC] Service revenue", "1000.0"],
+      ["Total Income", "1000.0"],
+      ["[SC] Subcontractors", "200.0"],
+      ["Total Cost of Goods Sold", "200.0"],
+      ["[SC] Software", "100.0"],
+      ["Total Expenses", "100.0"],
+      ["Net Income", "700.0"],
+      ["[SC] Depreciation", "50.0"],  # below-the-line, NO following Total X
+    ]
+    report = QboProfitAndLossReport.create!(
+      qbo_account: @qa,
+      starts_at: Date.new(2099, 1, 1),
+      ends_at: Date.new(2099, 1, 31),
+      data: { cash: { rows: rows }, accrual: { rows: rows } },
+    )
+
+    result = nil
+    assert_nothing_raised do
+      result = report.data_for_enterprise(@sanctuary, "cash", "Jan 2099", :SC)
+    end
+    assert_equal 1000.0, result[:revenue]
+    assert_equal 200.0,  result[:cogs]
+    assert_equal 100.0,  result[:expenses]
+    # net_revenue = revenue - cogs - expenses; the orphaned Depreciation row
+    # is intentionally NOT subtracted (it doesn't belong to any main section).
+    assert_equal 700.0,  result[:net_revenue]
+  end
+
+  test "data_for_enterprise still buckets correctly when every vertical row has a parent section" do
+    rows = [
+      ["[SC] Service revenue", "1000.0"],
+      ["Total Income", "1000.0"],
+      ["[SC] Subcontractors", "200.0"],
+      ["Total Cost of Goods Sold", "200.0"],
+      ["[SC] Software", "100.0"],
+      ["Total Expenses", "100.0"],
+      ["Net Income", "700.0"],
+    ]
+    report = QboProfitAndLossReport.create!(
+      qbo_account: @qa,
+      starts_at: Date.new(2099, 2, 1),
+      ends_at: Date.new(2099, 2, 28),
+      data: { cash: { rows: rows }, accrual: { rows: rows } },
+    )
+
+    result = report.data_for_enterprise(@sanctuary, "cash", "Feb 2099", :SC)
+    assert_equal 1000.0, result[:revenue]
+    assert_equal 200.0,  result[:cogs]
+    assert_equal 100.0,  result[:expenses]
+    assert_equal 700.0,  result[:net_revenue]
+  end
+end


### PR DESCRIPTION
## Summary

Fixes the `NoMethodError: undefined method '[]' for nil:NilClass` exception that Stacksbot has been firing on `stacks:daily_enterprise_tasks`. Backtrace lands at `app/models/qbo_profit_and_loss_report.rb:51` inside `data_for_enterprise`, called via `enterprise.rb:110:in 'key_datapoints_for_period'` from `generate_snapshot!`.

## Root cause

`data_for_enterprise` walks the P&L rows for each vertical-tagged line and buckets it into `revenue` / `cogs` / `expenses` by finding the next "Total X" row after its index. That works for line items inside the **main** Income / COGS / Expenses sections. But QBO P&L reports emit `"Other Income"` and `"Other Expense"` sections AFTER `"Total Expenses"`, and a vertical-tagged row in those below-the-line sections (e.g., `["[SC] Depreciation", "769.0"]`) has no following Total X — so the find returns nil, and `top_level_category_row[0]` on line 51 explodes.

Confirmed locally: 224 historical rows across the `qbo_profit_and_loss_reports` table match this pattern, almost all `[SC] Depreciation`.

## Fix

`next acc if top_level_category_row.nil?` — skip those rows. They don't belong to revenue / cogs / expenses and shouldn't be aggregated into any of them. `net_revenue` continues to track only the main sections, which is what the dashboard reports against. Existing behavior for rows WITH a parent section is unchanged.

## Test plan

- [x] `bundle exec rails test test/models/qbo_profit_and_loss_report_test.rb` — 2 new tests, one covering the below-the-line case (would NoMethodError before the fix), one covering normal rows.
- [x] Full suite: 307 runs / 643 assertions / 0 failures.
- [ ] After merging: `heroku run rake stacks:daily_enterprise_tasks --app <app>` (or wait for the next scheduled run) — no more `NoMethodError` in Stacksbot exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)