### PR TITLE
Runn sync: catch bulk-actuals 'Project with id X not found' as Skipped

### DIFF
--- a/app/models/project_tracker_forecast_to_runn_sync_task.rb
+++ b/app/models/project_tracker_forecast_to_runn_sync_task.rb
@@ -158,8 +158,14 @@ class ProjectTrackerForecastToRunnSyncTask < ApplicationRecord
   # `raise_if_skip_required!` catches these when our local runn_project
   # mirror is fresh; this is the defensive catch for when the mirror is
   # stale relative to live Runn state.
+  # Runn returns two variants of the "project unreachable" error depending
+  # on the endpoint: GET /projects/:id 404s with "Project not found", and
+  # POST /actuals/bulk 400s with "Project with id <X> not found." for
+  # each offending actual. Both indicate the same condition — our local
+  # runn_project mirror points at a Runn project that no longer exists
+  # (or never did) — so we treat them identically.
   RUNN_PROJECT_STATE_ERROR_PATTERNS = [
-    /Project not found/i,
+    /Project (?:with id \S+ )?not found/i,
     /non-billable project/i,
   ].freeze
 

--- a/test/models/project_tracker_forecast_to_runn_sync_task_test.rb
+++ b/test/models/project_tracker_forecast_to_runn_sync_task_test.rb
@@ -211,6 +211,20 @@ class ProjectTrackerForecastToRunnSyncTaskTest < ActiveSupport::TestCase
     end
   end
 
+  test "raise_skipped_if_runn_project_state_error! converts bulk-actuals 'Project with id X not found' into Skipped" do
+    # POST /actuals/bulk emits this variant (with the runn project id
+    # embedded in the message) when the project has been deleted upstream.
+    pt = mock("project_tracker")
+    pt.stubs(:id).returns(1)
+    pt.stubs(:name).returns("Stale PT")
+    @task.stubs(:project_tracker).returns(pt)
+
+    err = RuntimeError.new('{"error":"Bad Request","message":"{ actuals[0]: \'Project with id 834099 not found.\', actuals[1]: \'Project with id 834099 not found.\' }","statusCode":400}')
+    assert_raises(Stacks::Errors::Skipped) do
+      @task.send(:raise_skipped_if_runn_project_state_error!, err)
+    end
+  end
+
   test "raise_skipped_if_runn_project_state_error! converts 'non-billable project' into Skipped" do
     pt = mock("project_tracker")
     pt.stubs(:id).returns(1)


### PR DESCRIPTION
## Summary
- The daily Runn sync was throwing an unhandled error to Sentry/Twist when a ProjectTracker pointed at a Runn project that had been deleted upstream — specifically **PT #117 "Youswim Ongoing Work"** → stale `RunnProject` with `runn_id=834099`.
- The existing graceful-skip catch (`RUNN_PROJECT_STATE_ERROR_PATTERNS`) only matched the bare `"Project not found"` string that `GET /projects/:id` returns. The bulk-actuals endpoint emits `"Project with id 834099 not found."` (with the id embedded), which slipped through.
- Broadens the regex to match both variants. Sync will now `raise Stacks::Errors::Skipped`, surfacing a notification on the PT admin page instead of erroring out.

## Test plan
- [x] New unit test covers the bulk-actuals error shape.
- [x] Full suite: 341 / 0 / 0 / 2 skip.
- [ ] After merge & deploy, the next daily sync for PT #117 should land as `Skipped` (visible on /admin/project_trackers/117) — not crash.
- [ ] Then we can decide whether to relink PT #117 in the admin UI or clear the stale local `RunnProject` row manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)