### PR TITLE
Reimbursement: sync as QBO Bill

### DIFF
--- a/app/admin/contributors.rb
+++ b/app/admin/contributors.rb
@@ -106,9 +106,6 @@ ActiveAdmin.register Contributor do
     return unless current_admin_user.is_admin?
 
     if r.accepted?
-      # Un-accepting: detach + destroy the QBO bill so the books stay aligned.
-      # No-op if the bill was never synced.
-      r.detach_and_destroy_qbo_bill if r.qbo_bill_id.present?
       r.update!(
         accepted_by: nil,
         accepted_at: nil

--- a/app/admin/contributors.rb
+++ b/app/admin/contributors.rb
@@ -106,6 +106,9 @@ ActiveAdmin.register Contributor do
     return unless current_admin_user.is_admin?
 
     if r.accepted?
+      # Un-accepting: detach + destroy the QBO bill so the books stay aligned.
+      # No-op if the bill was never synced.
+      r.detach_and_destroy_qbo_bill if r.qbo_bill_id.present?
       r.update!(
         accepted_by: nil,
         accepted_at: nil
@@ -115,6 +118,14 @@ ActiveAdmin.register Contributor do
         accepted_by: current_admin_user,
         accepted_at: DateTime.now
       )
+      # Push to QBO so the reimbursement is payable through the same flow as
+      # every other host. Best-effort: log + continue if the QBO push fails
+      # (admin can retry manually).
+      begin
+        r.sync_qbo_bill!
+      rescue => e
+        Rails.logger.error("[reimbursement_accept] sync_qbo_bill! failed for ##{r.id}: #{e.class}: #{e.message}")
+      end
     end
 
     return redirect_to(

--- a/app/admin/contributors.rb
+++ b/app/admin/contributors.rb
@@ -115,14 +115,15 @@ ActiveAdmin.register Contributor do
         accepted_by: current_admin_user,
         accepted_at: DateTime.now
       )
-      # Push to QBO so the reimbursement is payable through the same flow as
-      # every other host. Best-effort: log + continue if the QBO push fails
-      # (admin can retry manually).
-      begin
-        r.sync_qbo_bill!
-      rescue => e
-        Rails.logger.error("[reimbursement_accept] sync_qbo_bill! failed for ##{r.id}: #{e.class}: #{e.message}")
-      end
+    end
+
+    # Keep QBO in sync after either toggle. sync_qbo_bill! is idempotent —
+    # creates if missing, updates the existing bill otherwise. Best-effort:
+    # log + continue on failure; admin can retry manually.
+    begin
+      r.sync_qbo_bill!
+    rescue => e
+      Rails.logger.error("[reimbursement_accept] sync_qbo_bill! failed for ##{r.id}: #{e.class}: #{e.message}")
     end
 
     return redirect_to(

--- a/app/models/reimbursement.rb
+++ b/app/models/reimbursement.rb
@@ -2,6 +2,7 @@ class Reimbursement < ApplicationRecord
   acts_as_paranoid
   include LedgerItem
   include BustsTaskCache
+  include SyncsAsQboBill
 
   belongs_to :accepted_by, class_name: 'AdminUser', optional: true
 
@@ -31,6 +32,19 @@ class Reimbursement < ApplicationRecord
 
   def payable?
     accepted?
+  end
+
+  # SyncsAsQboBill contract
+  def bill_txn_date
+    accepted_at&.to_date || created_at.to_date
+  end
+
+  def bill_description
+    "https://stacks.garden3d.net/admin/ledgers/#{ledger_id}/reimbursements/#{id}"
+  end
+
+  def bill_doc_number_code
+    "RB"
   end
 
   def effective_on_for_display

--- a/db/migrate/20260613225103_add_qbo_bill_id_to_reimbursements.rb
+++ b/db/migrate/20260613225103_add_qbo_bill_id_to_reimbursements.rb
@@ -1,0 +1,11 @@
+class AddQboBillIdToReimbursements < ActiveRecord::Migration[6.1]
+  # Reimbursements sync as QBO Bills like every other payable host
+  # (ContributorPayout, ContributorAdjustment, ProfitShare, Trueup, PayStub).
+  # Existing accepted reimbursements get backfilled out-of-band via
+  # `bundle exec rake reimbursements:backfill_qbo_bills` so the migration
+  # stays fast and offline.
+  def change
+    add_column :reimbursements, :qbo_bill_id, :string
+    add_index  :reimbursements, :qbo_bill_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_06_02_155349) do
+ActiveRecord::Schema.define(version: 2026_06_13_225103) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -978,9 +978,11 @@ ActiveRecord::Schema.define(version: 2026_06_02_155349) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "ledger_id", null: false
+    t.string "qbo_bill_id"
     t.index ["accepted_by_id"], name: "index_reimbursements_on_accepted_by_id"
     t.index ["deleted_at"], name: "index_reimbursements_on_deleted_at"
     t.index ["ledger_id"], name: "index_reimbursements_on_ledger_id"
+    t.index ["qbo_bill_id"], name: "index_reimbursements_on_qbo_bill_id"
   end
 
   create_table "review_trees", force: :cascade do |t|

--- a/lib/tasks/reimbursements.rake
+++ b/lib/tasks/reimbursements.rake
@@ -1,0 +1,24 @@
+namespace :reimbursements do
+  desc "Push every accepted Reimbursement to QBO that hasn't synced yet"
+  task backfill_qbo_bills: :environment do
+    synced = 0
+    skipped = 0
+    errors = 0
+
+    Reimbursement.where.not(accepted_by_id: nil).where(qbo_bill_id: nil).find_each do |r|
+      r.sync_qbo_bill!
+      if r.reload.qbo_bill_id.present?
+        synced += 1
+      else
+        # sync_qbo_bill! short-circuits silently when the contributor has no
+        # ContributorQboVendor mapping or the enterprise has no QBO account.
+        skipped += 1
+      end
+    rescue => e
+      errors += 1
+      warn "Reimbursement ##{r.id}: #{e.class}: #{e.message}"
+    end
+
+    puts "Synced #{synced} reimbursements; #{skipped} skipped (missing mapping); #{errors} errors."
+  end
+end


### PR DESCRIPTION
## Summary

Makes \`Reimbursement\` follow the same QBO Bill lifecycle as every other payable host (ContributorPayout, ContributorAdjustment, ProfitShare, Trueup, PayStub). Previously reimbursements never pushed to QBO and were settled by hand via a matching negative ContributorAdjustment booked off-platform — that made them invisible to the QBO vendor record.

## Changes

- Migration adds \`qbo_bill_id\` (string) + index to \`reimbursements\`
- \`Reimbursement\` includes \`SyncsAsQboBill\` and implements the contract: \`bill_txn_date\`, \`bill_description\`, \`bill_doc_number_code\` (\`\"RB\"\`)
- Acceptance toggle in \`app/admin/contributors.rb\`:
  - **Accept** → \`sync_qbo_bill!\` (best-effort; logs Rails error on failure so the admin can retry)
  - **Deny** → \`detach_and_destroy_qbo_bill\` so the books stay aligned
- New rake task \`reimbursements:backfill_qbo_bills\` pushes existing accepted-but-unsynced rows. Idempotent; silently skips contributors lacking a \`ContributorQboVendor\` mapping.

## QBO account routing

Uses the default \"Contractors - Client Services\" category (same as other hosts). If a different expense category is wanted later, override \`Reimbursement#find_qbo_account!\`.

## Rollout

1. Merge + deploy
2. Run \`bundle exec rake reimbursements:backfill_qbo_bills\` once on production
3. Going forward, every Accept push automatically syncs the Bill

## Test plan

- [ ] CI green
- [ ] Accept a new reimbursement on staging → confirm a QBO Bill is created against the contributor's vendor record
- [ ] Deny that reimbursement → confirm the QBO Bill is detached + destroyed
- [ ] Run the backfill rake on staging → confirm existing accepted rows get qbo_bill_id populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)