### PR TITLE
Stop forecast_assignments bloat: skip no-op Forecast upserts

### DIFF
--- a/lib/stacks/forecast.rb
+++ b/lib/stacks/forecast.rb
@@ -102,6 +102,30 @@ class Stacks::Forecast
 
   private
 
+  # Forecast re-sends every record that overlaps each sync window, and sync_all_assignments!
+  # walks month-by-month from 2020, so an unconditional `upsert_all` rewrites unchanged rows
+  # on every run — once per month an assignment spans, every sync. Over time this churned
+  # forecast_assignments to ~71M updates for ~46k live rows, bloating it to 26GB of table +
+  # index dead space (plain VACUUM reclaims for reuse but never shrinks the files).
+  #
+  # Fix: only upsert rows that are NEW or whose Forecast `updated_at` actually advanced.
+  # Returns EVERY seen forecast_id (changed or not), so callers that prune-by-absence still
+  # treat unchanged-but-present records as seen.
+  def upsert_changed!(model, data)
+    return [] if data.empty?
+
+    seen_ids = data.map { |row| row[:forecast_id] }
+    stored_updated_at = model.where(forecast_id: seen_ids).pluck(:forecast_id, :updated_at).to_h
+    changed = data.select do |row|
+      prev = stored_updated_at[row[:forecast_id]]
+      incoming = row[:updated_at]
+      # New row, or no/changed Forecast timestamp -> write it; otherwise it's a no-op, skip.
+      prev.nil? || incoming.blank? || prev.to_i != Time.parse(incoming.to_s).to_i
+    end
+    model.upsert_all(changed, unique_by: :forecast_id) if changed.any?
+    seen_ids
+  end
+
   def sync_clients!
     data = clients()["clients"].map do |c|
       {
@@ -114,7 +138,7 @@ class Stacks::Forecast
         data: c,
       }
     end
-    ForecastClient.upsert_all(data, unique_by: :forecast_id)
+    upsert_changed!(ForecastClient, data)
   end
 
   def sync_people!
@@ -131,7 +155,7 @@ class Stacks::Forecast
         data: c,
       }
     end
-    ForecastPerson.upsert_all(data, unique_by: :forecast_id)
+    upsert_changed!(ForecastPerson, data)
   end
 
   def sync_projects!
@@ -152,12 +176,12 @@ class Stacks::Forecast
         data: c,
       }
     end
-    ForecastProject.upsert_all(data, unique_by: :forecast_id)
+    upsert_changed!(ForecastProject, data)
   end
 
-  # Returns the array of forecast_ids that were upserted in this call, so
-  # sync_all! can collect them across the per-month walk and prune anything
-  # not seen.
+  # Returns the array of forecast_ids SEEN in this call (whether or not they
+  # needed rewriting), so sync_all! can collect them across the per-month walk
+  # and prune only assignments it never saw.
   def sync_assignments!(start_date = Date.today, end_date = Date.today)
     data = assignments(start_date, end_date)["assignments"].map do |c|
       {
@@ -176,9 +200,7 @@ class Stacks::Forecast
         data: c,
       }
     end
-    return [] if data.empty?
-    ForecastAssignment.upsert_all(data, unique_by: :forecast_id)
-    data.map { |row| row[:forecast_id] }
+    upsert_changed!(ForecastAssignment, data)
   end
 
   def sync_all_assignments!

--- a/test/lib/stacks/forecast_test.rb
+++ b/test/lib/stacks/forecast_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+
+# Covers the no-op-skip fix for the Forecast sync: an unconditional upsert_all rewrote
+# every overlapping record on every sync window, churning forecast_assignments to ~71M
+# updates / 26GB of bloat for ~46k live rows. upsert_changed! now writes only new/changed
+# rows while still reporting every seen id so prune-by-absence stays correct.
+class StacksForecastTest < ActiveSupport::TestCase
+  def row(forecast_id, updated_at, allocation: 100)
+    {
+      forecast_id: forecast_id, start_date: "2024-01-01", end_date: "2024-01-31",
+      allocation: allocation, notes: nil, updated_at: updated_at, updated_by_id: 1,
+      project_id: 1, person_id: 1, placeholder_id: nil,
+      repeated_assignment_set_id: nil, active_on_days_off: false, data: { "id" => forecast_id },
+    }
+  end
+
+  # allocate skips initialize (which needs Forecast API config); we only exercise the helper.
+  def forecast = Stacks::Forecast.allocate
+
+  test "first sync upserts all rows and returns every seen id" do
+    ids = forecast.send(:upsert_changed!, ForecastAssignment,
+                        [row(1, "2024-01-01T00:00:00Z"), row(2, "2024-01-02T00:00:00Z")])
+    assert_equal [1, 2], ids
+    assert_equal 2, ForecastAssignment.where(forecast_id: [1, 2]).count
+  end
+
+  test "re-syncing unchanged rows skips the write entirely but still reports them as seen" do
+    data = [row(1, "2024-01-01T00:00:00Z"), row(2, "2024-01-02T00:00:00Z")]
+    forecast.send(:upsert_changed!, ForecastAssignment, data)
+
+    ForecastAssignment.expects(:upsert_all).never # the bug: this used to fire every time
+    ids = forecast.send(:upsert_changed!, ForecastAssignment, data)
+    assert_equal [1, 2], ids, "unchanged-but-present rows must still count as seen so prune won't delete them"
+  end
+
+  test "only rows whose Forecast updated_at advanced (or are new) are rewritten" do
+    forecast.send(:upsert_changed!, ForecastAssignment,
+                  [row(1, "2024-01-01T00:00:00Z", allocation: 100), row(2, "2024-01-02T00:00:00Z", allocation: 100)])
+
+    # row 1 unchanged; row 2's updated_at advances with a new allocation; row 3 is new.
+    next_data = [
+      row(1, "2024-01-01T00:00:00Z", allocation: 100),
+      row(2, "2024-02-02T00:00:00Z", allocation: 50),
+      row(3, "2024-03-01T00:00:00Z", allocation: 25),
+    ]
+    captured = nil
+    ForecastAssignment.stubs(:upsert_all).with { |rows, **| captured = rows.map { |r| r[:forecast_id] }; true }
+    ids = forecast.send(:upsert_changed!, ForecastAssignment, next_data)
+
+    assert_equal [2, 3], captured, "only the changed + new rows are sent to upsert_all"
+    assert_equal [1, 2, 3], ids, "all seen ids are still returned for pruning"
+  end
+
+  test "a changed row's new values actually land in the database" do
+    forecast.send(:upsert_changed!, ForecastAssignment, [row(1, "2024-01-01T00:00:00Z", allocation: 100)])
+    forecast.send(:upsert_changed!, ForecastAssignment, [row(1, "2024-02-01T00:00:00Z", allocation: 42)])
+    assert_equal 42, ForecastAssignment.find_by(forecast_id: 1).allocation
+  end
+end


### PR DESCRIPTION
## What

The Forecast sync rewrote **every** record on **every** run. `Stacks::Forecast` called `upsert_all` unconditionally for clients/people/projects/assignments, and `upsert_all` issues `INSERT … ON CONFLICT DO UPDATE` for each row — so unchanged rows got a fresh row-version every time. `sync_all_assignments!` makes it far worse by walking **month-by-month from 2020**, re-sending each assignment once per month it spans.

This PR adds a shared `upsert_changed!` helper that writes only rows that are **new or whose Forecast `updated_at` advanced**, while still returning every *seen* `forecast_id` so the prune-by-absence step is unchanged.

## Why (the autopsy)

`forecast_assignments` had bloated to **26 GB for ~46k live rows**. Diagnostics from the production DB:

```
Size:   26 GB = 14 GB heap + 12 GB indexes (13 of them)
Writes: 265 inserts · 14 deletes · 71,173,943 UPDATES  (~1,500 per row)
        └ 99.7% HOT · autovacuum ran 117× · no replication slot blocking it
```

71M updates for 265 inserts = almost everything was a no-op rewrite. Autovacuum reclaims dead tuples for *reuse* but never returns space to the OS, so the files only ever grew — to 82% of the Essential-tier cap.

> The **physical** bloat was already reclaimed on 2026-06-30 by migrating prod `essential-2 → standard-0` (a `pg:copy` rebuilds from live rows → 26 GB shrank to **217 MB**). **This PR prevents it from coming back.**

## Change

- New private `upsert_changed!(model, data)` — compares incoming Forecast `updated_at` against stored, upserts only the changed/new subset, returns all seen ids.
- Wired into all four syncs (`sync_clients!`, `sync_people!`, `sync_projects!`, `sync_assignments!`).
- Forecast assignments rarely change, so write volume drops by orders of magnitude.

## Tests

`test/lib/stacks/forecast_test.rb` (4 tests): all rows on first sync; unchanged re-sync writes nothing but still reports rows as seen (so prune is safe); only changed+new rows are sent to `upsert_all`; a changed row's new values land in the DB.

## Recommended follow-ups (NOT in this PR — your call)

Optional DB-side hygiene, surfaced by the same diagnostics:

1. **Drop 3 unused indexes** on `forecast_assignments` (0 scans over a long stats window, ~4.7 GB on the old bloated DB): `idx_assignments_on_project_and_daterange` (gist), `idx_assignments_on_daterange` (gist), `index_forecast_assignments_on_allocation`. Fewer indexes = cheaper writes + less bloat surface. Left out here because dropping indexes is a judgment call best made explicitly.
2. Consider `ALTER TABLE forecast_assignments SET (fillfactor = 85)` so future HOT updates stay in-page.
3. A periodic `pg_repack` as a backstop (far less needed once writes drop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)