### PR TITLE
MCP: organizer_email + occurred_at range filter + offset pagination

### DIFF
--- a/app/services/mcp/date_range.rb
+++ b/app/services/mcp/date_range.rb
@@ -1,0 +1,22 @@
+module Mcp
+  # Builds an occurred_at Range from optional ISO8601 bounds passed by the agent.
+  # One-sided bounds are fine (beginless/endless Range); invalid/blank input is ignored
+  # rather than erroring the tool call.
+  module DateRange
+    def self.parse(occurred_after, occurred_before)
+      after = time(occurred_after)
+      before = time(occurred_before)
+      return nil unless after || before
+
+      (after..before)
+    end
+
+    def self.time(str)
+      return nil if str.blank?
+
+      Time.zone.parse(str.to_s)
+    rescue ArgumentError, TypeError
+      nil
+    end
+  end
+end

--- a/app/services/mcp/list_documents_tool.rb
+++ b/app/services/mcp/list_documents_tool.rb
@@ -1,13 +1,22 @@
 module Mcp
   class ListDocumentsTool < MCP::Tool
     tool_name 'list_documents'
-    description 'List corpus-eligible documents, optionally filtered by source.'
-    input_schema(properties: { source: { type: 'string' }, limit: { type: 'integer' } })
+    description 'List corpus-eligible documents (newest first), optionally filtered by source and occurred_at range, with offset pagination.'
+    input_schema(properties: {
+      source: { type: 'string' },
+      occurred_after: { type: 'string', description: 'ISO8601 lower bound on occurred_at (inclusive)' },
+      occurred_before: { type: 'string', description: 'ISO8601 upper bound on occurred_at (inclusive)' },
+      limit: { type: 'integer' },
+      offset: { type: 'integer', description: 'Number of documents to skip, for pagination' }
+    })
     annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true)
 
-    def self.call(source: nil, limit: 50, server_context:)
-      scope = Document.corpus_eligible.order(occurred_at: :desc).limit(limit)
+    def self.call(source: nil, occurred_after: nil, occurred_before: nil, limit: 50, offset: 0, server_context:)
+      scope = Document.corpus_eligible
       scope = scope.where(source: Document.sources[source]) if source
+      range = Mcp::DateRange.parse(occurred_after, occurred_before)
+      scope = scope.where(occurred_at: range) if range
+      scope = scope.order(occurred_at: :desc).offset(offset).limit(limit)
       payload = scope.map { |d| { id: d.id, title: d.title, source: d.source, occurred_at: d.occurred_at } }
       MCP::Tool::Response.new([{ type: 'text', text: payload.to_json }])
     end

--- a/app/services/mcp/search_tool.rb
+++ b/app/services/mcp/search_tool.rb
@@ -8,14 +8,20 @@ module Mcp
         mode: { type: 'string', enum: %w[keyword semantic hybrid] },
         source: { type: 'string' },
         contact: { type: 'string' },
-        limit: { type: 'integer' }
+        occurred_after: { type: 'string', description: 'ISO8601 lower bound on occurred_at (inclusive)' },
+        occurred_before: { type: 'string', description: 'ISO8601 upper bound on occurred_at (inclusive)' },
+        limit: { type: 'integer' },
+        offset: { type: 'integer', description: 'Number of results to skip, for pagination' }
       },
       required: ['query']
     )
     annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true)
 
-    def self.call(query:, mode: 'hybrid', source: nil, contact: nil, limit: 20, server_context:)
-      results = Stacks::Etl::Search.call(query: query, mode: mode.to_sym, source: source, contact: contact, limit: limit)
+    def self.call(query:, mode: 'hybrid', source: nil, contact: nil, occurred_after: nil, occurred_before: nil, limit: 20, offset: 0, server_context:)
+      results = Stacks::Etl::Search.call(
+        query: query, mode: mode.to_sym, source: source, contact: contact,
+        date_range: Mcp::DateRange.parse(occurred_after, occurred_before), limit: limit, offset: offset
+      )
       payload = results.map do |r|
         { document_id: r[:document].id, title: r[:document].title, occurred_at: r[:document].occurred_at,
           speaker: r[:chunk].speaker_name, text: r[:chunk].content }

--- a/lib/stacks/etl/meet/calendar_enricher.rb
+++ b/lib/stacks/etl/meet/calendar_enricher.rb
@@ -10,7 +10,7 @@ module Stacks
       class CalendarEnricher
         WINDOW = 2.hours
 
-        # => { title: String|nil, attendees: [{ email:, name: }] }
+        # => { title: String|nil, attendees: [{ email:, name: }], organizer_email: String|nil }
         def self.enrich(user_email:, started_at:, meeting_code: nil, fallback_title: nil)
           new(user_email).enrich(started_at: started_at, meeting_code: meeting_code, fallback_title: fallback_title)
         end
@@ -27,21 +27,28 @@ module Stacks
         # meeting's title/attendees to an unrelated ad-hoc call.
         def enrich(started_at:, meeting_code:, fallback_title:, title_hint: nil)
           at = coerce_time(started_at)
-          return { title: fallback_title, attendees: [] } if at.nil?
+          return miss(fallback_title) if at.nil?
 
           resp = service.list_events('primary',
                                      time_min: (at - WINDOW).utc.iso8601,
                                      time_max: (at + WINDOW).utc.iso8601,
                                      single_events: true, max_results: 50)
           event = pick_event(Array(resp.items), meeting_code, title_hint)
-          return { title: fallback_title, attendees: [] } unless event
+          return miss(fallback_title) unless event
 
-          { title: event.summary.presence || fallback_title, attendees: attendees_for(event) }
+          { title: event.summary.presence || fallback_title,
+            attendees: attendees_for(event),
+            organizer_email: event.organizer&.email&.downcase }
         rescue StandardError
-          { title: fallback_title, attendees: [] }
+          miss(fallback_title)
         end
 
         private
+
+        # A no-match/error result: the doc-name fallback title, no attendees, no organizer.
+        def miss(fallback_title)
+          { title: fallback_title, attendees: [], organizer_email: nil }
+        end
 
         def service
           @service ||= Auth.calendar_service(sub: @user_email)

--- a/lib/stacks/etl/meet/drive_source.rb
+++ b/lib/stacks/etl/meet/drive_source.rb
@@ -73,7 +73,7 @@ module Stacks
             contacts: contacts,
             segments: segments,
             raw_metadata: { 'drive_doc_id' => file.id },
-            build_source_record: ->(doc) { build_meeting(doc, file, segments, title, speaker_count) }
+            build_source_record: ->(doc) { build_meeting(doc, file, segments, title, speaker_count, enrichment[:organizer_email]) }
           }
         end
 
@@ -131,10 +131,11 @@ module Stacks
           end
         end
 
-        def build_meeting(doc, file, segments, title, speaker_count)
+        def build_meeting(doc, file, segments, title, speaker_count, organizer_email)
           meeting = Meeting.find_or_initialize_by(drive_transcript_doc_id: file.id)
           meeting.update!(meet_source: :drive, title: title, started_at: file.created_time,
                           participant_count: speaker_count,
+                          organizer_email: organizer_email,
                           raw_metadata: { 'document_id' => doc.id })
           meeting.segments.destroy_all
           segments.each_with_index do |s, i|

--- a/lib/stacks/etl/meet/meet_api_source.rb
+++ b/lib/stacks/etl/meet/meet_api_source.rb
@@ -69,7 +69,7 @@ module Stacks
             # drive_doc_id kept for reference only; Drive ingest is partitioned to an older
             # window so the two sources never produce the same meeting (no fragile merge).
             raw_metadata: { 'conference_record' => cr.name, 'space' => cr.space, 'drive_doc_id' => drive_doc_id },
-            build_source_record: ->(doc) { build_meeting(doc, cr, participants, segments, title) }
+            build_source_record: ->(doc) { build_meeting(doc, cr, participants, segments, title, enrichment[:organizer_email]) }
           }
         end
 
@@ -125,10 +125,11 @@ module Stacks
           [segments, drive_doc_id]
         end
 
-        def build_meeting(doc, cr, participants, segments, title)
+        def build_meeting(doc, cr, participants, segments, title, organizer_email)
           meeting = Meeting.find_or_initialize_by(meet_conference_record_id: cr.name)
           meeting.update!(meet_source: :meet_api, title: title, started_at: cr.start_time,
                           ended_at: cr.end_time, participant_count: participants.size,
+                          organizer_email: organizer_email,
                           raw_metadata: { 'document_id' => doc.id })
           meeting.participants.destroy_all
           participants.each_value { |p| meeting.participants.create!(name: p[:name], email: p[:email]) }

--- a/lib/stacks/etl/search.rb
+++ b/lib/stacks/etl/search.rb
@@ -1,13 +1,17 @@
 module Stacks
   module Etl
     class Search
-      def self.call(query:, mode: :hybrid, source: nil, contact: nil, date_range: nil, limit: 20)
+      def self.call(query:, mode: :hybrid, source: nil, contact: nil, date_range: nil, limit: 20, offset: 0)
         base = filtered(Chunk.corpus_eligible, source: source, contact: contact, date_range: date_range)
         ids =
           case mode.to_sym
-          when :keyword  then keyword_ids(base, query, limit)
-          when :semantic then semantic_ids(base, query, limit)
-          else fuse(keyword_ids(base, query, limit), semantic_ids(base, query, limit), limit)
+          when :keyword  then keyword_ids(base, query, limit, offset)
+          when :semantic then semantic_ids(base, query, limit, offset)
+          else
+            # Hybrid: fuse the top (offset+limit) of each ranked list, then take the page.
+            # (Offset can't be pushed into the per-list queries — the fused ranking differs.)
+            depth = offset + limit
+            fuse(keyword_ids(base, query, depth), semantic_ids(base, query, depth), depth).drop(offset).first(limit)
           end
         chunks = Chunk.where(id: ids).includes(:document).index_by(&:id)
         ids.map { |id| chunks[id] }.compact.map { |c| { chunk: c, document: c.document, score: nil } }
@@ -24,18 +28,18 @@ module Stacks
         scope
       end
 
-      def self.keyword_ids(scope, query, limit)
-        scope.keyword_search(query).limit(limit).pluck(:id)
+      def self.keyword_ids(scope, query, limit, offset = 0)
+        scope.keyword_search(query).offset(offset).limit(limit).pluck(:id)
       end
 
-      def self.semantic_ids(scope, query, limit)
+      def self.semantic_ids(scope, query, limit, offset = 0)
         return [] unless scope.exists?
         vector = Embedder.embed([query], input_type: 'query')[:vectors].first
         # Constrain to corpus-eligible chunks via a SUBQUERY (scope.select(:id)), not a
         # materialized id list — keeps the wall airtight without a giant IN (...) array.
         Embedding.where(model: Embedder::MODEL, owner_type: 'Chunk', owner_id: scope.select(:id))
                  .nearest_neighbors(:embedding, vector, distance: 'cosine')
-                 .limit(limit).map(&:owner_id)
+                 .offset(offset).limit(limit).map(&:owner_id)
       end
 
       def self.fuse(a, b, limit)

--- a/test/lib/stacks/etl/meet/calendar_enricher_test.rb
+++ b/test/lib/stacks/etl/meet/calendar_enricher_test.rb
@@ -2,11 +2,12 @@ require 'test_helper'
 require 'ostruct'
 
 class Stacks::Etl::Meet::CalendarEnricherTest < ActiveSupport::TestCase
-  def event(summary:, conf_id: nil, attendees: [])
+  def event(summary:, conf_id: nil, attendees: [], organizer: nil)
     OpenStruct.new(
       summary: summary,
       conference_data: conf_id ? OpenStruct.new(conference_id: conf_id) : nil,
-      attendees: attendees.map { |email, name| OpenStruct.new(email: email, display_name: name) }
+      attendees: attendees.map { |email, name| OpenStruct.new(email: email, display_name: name) },
+      organizer: organizer ? OpenStruct.new(email: organizer) : nil
     )
   end
 
@@ -18,18 +19,20 @@ class Stacks::Etl::Meet::CalendarEnricherTest < ActiveSupport::TestCase
     enr
   end
 
-  test 'matches by meeting code and returns title + attendee emails' do
-    enr = enricher_returning([event(summary: 'Standup', conf_id: 'abc-defg-hjk', attendees: [['a@x.co', 'A']])])
+  test 'matches by meeting code and returns title + attendee emails + organizer' do
+    enr = enricher_returning([event(summary: 'Standup', conf_id: 'abc-defg-hjk', attendees: [['a@x.co', 'A']], organizer: 'Boss@X.co')])
     r = enr.enrich(started_at: Time.utc(2026, 1, 1, 9), meeting_code: 'abc-defg-hjk', fallback_title: 'abc-defg-hjk')
     assert_equal 'Standup', r[:title]
     assert_equal ['a@x.co'], r[:attendees].map { |x| x[:email] }
+    assert_equal 'boss@x.co', r[:organizer_email] # downcased
   end
 
-  test 'a code with no matching event returns the fallback and no attendees' do
+  test 'a code with no matching event returns the fallback, no attendees, no organizer' do
     enr = enricher_returning([event(summary: 'Other', conf_id: 'zzz')])
     r = enr.enrich(started_at: Time.utc(2026, 1, 1, 9), meeting_code: 'abc-defg-hjk', fallback_title: 'abc-defg-hjk')
     assert_equal 'abc-defg-hjk', r[:title]
     assert_empty r[:attendees]
+    assert_nil r[:organizer_email]
   end
 
   test 'matches by exact title hint when there is no code (Drive path)' do

--- a/test/lib/stacks/etl/search_test.rb
+++ b/test/lib/stacks/etl/search_test.rb
@@ -22,6 +22,23 @@ class Stacks::Etl::SearchTest < ActiveSupport::TestCase
     assert_empty results
   end
 
+  test 'date_range filters chunks by occurred_at' do
+    recent = Chunk.create!(document: @doc, position: 10, content: 'gateway recent note', source: :meet, occurred_at: Time.utc(2026, 6, 1))
+    old    = Chunk.create!(document: @doc, position: 11, content: 'gateway old note',    source: :meet, occurred_at: Time.utc(2025, 1, 1))
+    ids = Stacks::Etl::Search.call(query: 'gateway', mode: :keyword, date_range: (Time.utc(2026, 1, 1)..)).map { |r| r[:chunk].id }
+    assert_includes ids, recent.id
+    refute_includes ids, old.id
+  end
+
+  test 'offset skips the leading results (pagination)' do
+    Chunk.create!(document: @doc, position: 12, content: 'gateway alpha', source: :meet)
+    Chunk.create!(document: @doc, position: 13, content: 'gateway beta',  source: :meet)
+    all     = Stacks::Etl::Search.call(query: 'gateway', mode: :keyword, limit: 10, offset: 0).map { |r| r[:chunk].id }
+    skipped = Stacks::Etl::Search.call(query: 'gateway', mode: :keyword, limit: 10, offset: 1).map { |r| r[:chunk].id }
+    assert_operator all.size, :>=, 2
+    assert_equal all.drop(1), skipped
+  end
+
   test 'semantic mode embeds the query, ranks by neighbor distance, and walls off excluded chunks' do
     skip_without_pgvector # creates Embedding records + runs a neighbor (vector) query
     Embedding.create!(owner: @hit, model: Stacks::Etl::Embedder::MODEL, embedding: Array.new(1024) { 0.0 }.tap { |v| v[0] = 1.0 })

--- a/test/services/mcp/date_range_test.rb
+++ b/test/services/mcp/date_range_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class Mcp::DateRangeTest < ActiveSupport::TestCase
+  test 'both bounds build an inclusive range' do
+    r = Mcp::DateRange.parse('2026-01-01', '2026-02-01')
+    assert r.cover?(Time.zone.parse('2026-01-15'))
+    refute r.cover?(Time.zone.parse('2026-03-01'))
+  end
+
+  test 'a single bound builds an open-ended range' do
+    assert Mcp::DateRange.parse('2026-01-01', nil).cover?(Time.zone.parse('2030-01-01'))  # endless
+    refute Mcp::DateRange.parse('2026-01-01', nil).cover?(Time.zone.parse('2020-01-01'))
+    assert Mcp::DateRange.parse(nil, '2026-01-01').cover?(Time.zone.parse('2000-01-01'))  # beginless
+  end
+
+  test 'no bounds or unparseable input yields nil (filter is skipped)' do
+    assert_nil Mcp::DateRange.parse(nil, nil)
+    assert_nil Mcp::DateRange.parse('', '')
+    assert_nil Mcp::DateRange.parse('not-a-date', nil)
+  end
+end

--- a/test/services/mcp/tools_test.rb
+++ b/test/services/mcp/tools_test.rb
@@ -25,4 +25,20 @@ class Mcp::ToolsTest < ActiveSupport::TestCase
     assert_includes ids, @doc.id
     refute_includes ids, @excluded.id
   end
+
+  test 'list_documents filters by occurred_at range and paginates with offset' do
+    a = Document.create!(source: :meet, external_id: 'a', title: 'Recent A', excluded: :not_excluded, occurred_at: Time.utc(2026, 6, 3))
+    b = Document.create!(source: :meet, external_id: 'b', title: 'Recent B', excluded: :not_excluded, occurred_at: Time.utc(2026, 6, 2))
+    _old = Document.create!(source: :meet, external_id: 'c', title: 'Old', excluded: :not_excluded, occurred_at: Time.utc(2025, 1, 1))
+
+    ranged = ids_for(Mcp::ListDocumentsTool.call(occurred_after: '2026-06-01', server_context: {}))
+    assert_equal [a.id, b.id], ranged, 'only in-range docs, newest first'
+
+    page2 = ids_for(Mcp::ListDocumentsTool.call(occurred_after: '2026-06-01', limit: 1, offset: 1, server_context: {}))
+    assert_equal [b.id], page2, 'offset skips the first (newest) in-range doc'
+  end
+
+  def ids_for(resp)
+    JSON.parse(resp.content.first[:text]).map { |d| d['id'] }
+  end
 end


### PR DESCRIPTION
Follow-ups on the Meet ETL / MCP server (#115), all in one PR.

## 1. Populate `meetings.organizer_email`
It was a column the admin Meetings page displays, but **nothing in the ingest ever wrote it**. Now `CalendarEnricher#enrich` returns the matched Calendar event's `organizer.email`, and both `build_meeting` paths (Meet API + Drive) set it.

## 2. Time-span filtering (agents can now scope by date)
The search *engine* already accepted a `date_range`; it just wasn't exposed. Added `occurred_after` / `occurred_before` (ISO8601, inclusive, one-sided OK) to the **`search`** and **`list_documents`** MCP tools, parsed into an `occurred_at` Range by `Mcp::DateRange`.

## 3. Pagination
Neither tool had an offset. Added `offset` to **`search`** (engine + tool) and **`list_documents`**. Hybrid search fuses the top `offset+limit` of each ranked list, then returns the requested page.

## Tests
- Enricher returns `organizer_email` on a match, `nil` on a miss.
- `Search` filters by `date_range` and skips leading results with `offset`.
- `Mcp::DateRange.parse` (both/one-sided/invalid bounds).
- `list_documents` tool honours the range + offset.

## After merge
Deploy, then re-seed the test corpus so the existing meetings pick up `organizer_email` (the current 30 were ingested before this change; unchanged docs aren't re-processed, so the seed data gets wiped + re-synced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)