### PR TITLE
Preload ONNX embedding pipeline at boot so semantic search stops timing out

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -14,10 +14,19 @@ worker_shutdown_timeout 8
 
 before_fork do
   ActiveRecord::Base.connection_pool.disconnect! if defined?(ActiveRecord)
+  # Native ONNX inference sessions don't survive `fork`; drop anything built during
+  # preload so each worker rebuilds its own healthy session in on_worker_boot.
+  Stacks::Etl::Embedder.reset! if defined?(Stacks::Etl::Embedder)
 end
 
 on_worker_boot do
   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
+  # Preload the local embedding model so the FIRST semantic/hybrid MCP `search`
+  # doesn't pay the multi-second ONNX cold start synchronously — which made the
+  # initial query time out. Done in a background thread so a slow first-ever model
+  # download can't block the worker from accepting connections (worker_timeout /
+  # Heroku boot). See docs/meet-etl-deploy.md and Stacks::Etl::Embedder.warm!.
+  Thread.new { Stacks::Etl::Embedder.warm! } if defined?(Stacks::Etl::Embedder)
 end
 
 plugin :tmp_restart

--- a/docs/meet-etl-deploy.md
+++ b/docs/meet-etl-deploy.md
@@ -49,9 +49,17 @@ transport runs **stateless**, so it's safe across multiple web dynos.
 
 `search` with `mode: semantic|hybrid` embeds the **query** at request time using the
 local model **on the web dyno** serving `/api/mcp`. So that dyno needs enough RAM for
-the quantized model (~340 MB) and eats a one-time model load on the first semantic
-query (slow first request, then cached for the dyno's life). Use a **Standard-2X+ /
-Performance** web dyno, or preload the model at boot. Keyword search has no such cost.
+the quantized model (~340 MB). Use a **Standard-2X+ / Performance** web dyno. Keyword
+search has no such cost.
+
+The model's multi-second cold start (load + ONNX session init) is **preloaded at boot**
+so it no longer lands on the first user query: `config/puma.rb`'s `on_worker_boot` warms
+`Stacks::Etl::Embedder` in a background thread in each worker (native ONNX sessions don't
+survive `fork`, so it's done per-worker post-fork, not once during preload). Warming is
+best-effort — a failure is logged, not fatal — and the first request still works if it
+races the warmup (it just waits on the in-flight build via a mutex rather than starting a
+second one). On a cold slug both workers download the model concurrently once; baking the
+model into the slug (see follow-ups) removes that.
 
 ## 2. Connect the agent to MCP
 

--- a/lib/stacks/etl/embedder.rb
+++ b/lib/stacks/etl/embedder.rb
@@ -5,9 +5,33 @@ module Stacks
       DIMENSIONS = 1024
       QUERY_PREFIX = 'Represent this sentence for searching relevant passages: '.freeze
 
-      # Memoized, quantized ONNX pipeline. Downloads + caches the model on first call.
+      PIPELINE_MUTEX = Mutex.new
+
+      # Memoized, quantized ONNX pipeline. Downloads + caches the model on first call
+      # and spins up the ONNX runtime session — a multi-second cold start. Guarded by
+      # a mutex so a warmup thread and a concurrent first request can't each pay (or
+      # race) that build; whichever arrives first builds it, the rest reuse it.
       def self.pipeline
-        @pipeline ||= Informers.pipeline('embedding', MODEL, quantized: true)
+        return @pipeline if @pipeline
+        PIPELINE_MUTEX.synchronize { @pipeline ||= Informers.pipeline('embedding', MODEL, quantized: true) }
+      end
+
+      # Drop the memoized pipeline. Native ONNX sessions don't survive `fork`, so a
+      # preload+cluster web server must reset in each worker before rebuilding.
+      def self.reset!
+        PIPELINE_MUTEX.synchronize { @pipeline = nil }
+      end
+
+      # Force the cold start (model load + ONNX session init + first inference) ahead
+      # of real traffic, so the FIRST semantic/hybrid search isn't the one that pays it
+      # and times out. Safe to call from a boot-time background thread: any failure is
+      # logged and swallowed rather than taking down the worker.
+      def self.warm!
+        embed(['warmup'], input_type: 'query')
+        true
+      rescue => e
+        Rails.logger.warn("[Stacks::Etl::Embedder] pipeline warmup failed: #{e.class}: #{e.message}")
+        false
       end
 
       def self.embed(texts, input_type: 'document')

--- a/test/lib/stacks/etl/embedder_test.rb
+++ b/test/lib/stacks/etl/embedder_test.rb
@@ -21,4 +21,29 @@ class Stacks::Etl::EmbedderTest < ActiveSupport::TestCase
     out = Stacks::Etl::Embedder.embed('solo')
     assert_equal [[0.2] * 1024], out[:vectors]
   end
+
+  test 'warm! forces a query embed through the pipeline and returns true' do
+    captured = nil
+    Stacks::Etl::Embedder.stubs(:pipeline).returns(->(arr) { captured = arr; arr.map { [0.0] * 1024 } })
+    assert_equal true, Stacks::Etl::Embedder.warm!
+    # It runs a throwaway QUERY embed so the whole cold path (prefix + inference) is exercised.
+    assert_equal 1, captured.length
+    assert captured.first.start_with?(Stacks::Etl::Embedder::QUERY_PREFIX)
+  end
+
+  test 'warm! swallows and reports pipeline build failures without raising' do
+    Stacks::Etl::Embedder.stubs(:pipeline).raises(RuntimeError.new('model download failed'))
+    assert_nothing_raised { assert_equal false, Stacks::Etl::Embedder.warm! }
+  end
+
+  test 'reset! drops the memoized pipeline so it is rebuilt on next use' do
+    Informers.expects(:pipeline).twice.returns(->(arr) { arr.map { [0.1] * 1024 } })
+    Stacks::Etl::Embedder.reset!
+    Stacks::Etl::Embedder.pipeline
+    Stacks::Etl::Embedder.pipeline # memoized -> still one build
+    Stacks::Etl::Embedder.reset!
+    Stacks::Etl::Embedder.pipeline # rebuilt -> second build
+  ensure
+    Stacks::Etl::Embedder.reset!
+  end
 end


### PR DESCRIPTION
## Problem

The MCP `search` tool (`mode: semantic|hybrid`) embeds the query with a local quantized ONNX model on the web dyno. The pipeline was built **lazily on the first `embed` call**, so the first semantic/hybrid request paid the full cold start (model load + ONNX session init + first inference) synchronously — and **timed out** (observed in the field: semantic search returning nothing because it never completed).

The deploy runbook already flagged this exact behavior and prescribed the fix: *preload the model at boot.*

## Fix

- **`Embedder.warm!`** — forces the cold start ahead of traffic; failures are logged and swallowed so warmup can never take down a worker.
- **`Embedder.reset!`** — drops the memoized session. Native ONNX sessions don't survive `fork`, so a `preload_app!` + clustered web server must rebuild per worker.
- **`Embedder.pipeline`** — now mutex-guarded so a warmup thread and a concurrent first request can't race or double-build; a request arriving mid-warm waits on the in-flight build instead of starting a second cold one.
- **`config/puma.rb`** — warms each worker in a background thread in `on_worker_boot` (so a slow first-ever model download can't block the worker from accepting connections / hit `worker_timeout`), and resets any preload-inherited session in `before_fork`.
- **`docs/meet-etl-deploy.md`** — updated the web-dyno cold-start note to reflect automatic boot preload.

## Testing

- 3 new tests in `embedder_test.rb` (TDD — watched fail, then pass): `warm!` success path, `warm!` failure-swallowing, `reset!` rebuild.
- ETL + services + embedding suites: **179 runs, 0 failures, 1 skip** (pre-existing pgvector skip).
- Confirmed under `RAILS_ENV=production` eager-load that `Stacks::Etl::Embedder` is defined and responds to `warm!`/`reset!`, so the `puma.rb` `defined?` guards actually fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)