### PR TITLE
Gemini Notes ingestion (progressive enhancement to Meet ETL)

### DIFF
--- a/app/models/chunk.rb
+++ b/app/models/chunk.rb
@@ -4,7 +4,7 @@ class Chunk < ApplicationRecord
   has_many :mentions, dependent: :destroy
   has_one :embedding, as: :owner, dependent: :destroy
 
-  enum source: { meet: 0 }
+  enum source: { meet: 0, gemini_notes: 1 }
 
   scope :keyword_search, ->(query) {
     where("content_tsv @@ plainto_tsquery('english', :q)", q: query)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -4,7 +4,7 @@ class Document < ApplicationRecord
   has_many :document_contacts, dependent: :destroy
   has_many :contacts, through: :document_contacts
 
-  enum source: { meet: 0 }
+  enum source: { meet: 0, gemini_notes: 1 }
   enum excluded: { not_excluded: 0, auto_excluded: 1, manually_excluded: 2, manually_included: 3 }
   enum excluded_reason: {
     none: 0, one_on_one: 1, performance_review: 2, compensation: 3,

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -1,7 +1,7 @@
 class Meeting < ApplicationRecord
-  has_one :document, as: :source_record
+  has_many :documents, as: :source_record
   has_many :participants, class_name: 'MeetingParticipant', dependent: :destroy
   has_many :segments, class_name: 'MeetingTranscriptSegment', dependent: :destroy
 
-  enum meet_source: { meet_api: 0, drive: 1 }
+  enum meet_source: { meet_api: 0, drive: 1, gemini_notes: 2 }
 end

--- a/db/migrate/20260701000001_add_gemini_notes_doc_id_to_meetings.rb
+++ b/db/migrate/20260701000001_add_gemini_notes_doc_id_to_meetings.rb
@@ -1,0 +1,8 @@
+class AddGeminiNotesDocIdToMeetings < ActiveRecord::Migration[6.1]
+  def change
+    add_column :meetings, :gemini_notes_doc_id, :string
+    add_index :meetings, :gemini_notes_doc_id, unique: true,
+              where: "gemini_notes_doc_id IS NOT NULL",
+              name: "index_meetings_on_gemini_notes_doc_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_06_29_000001) do
+ActiveRecord::Schema.define(version: 2026_07_01_000001) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -547,7 +547,9 @@ ActiveRecord::Schema.define(version: 2026_06_29_000001) do
     t.jsonb "raw_metadata", default: {}, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "gemini_notes_doc_id"
     t.index ["drive_transcript_doc_id"], name: "index_meetings_on_drive_transcript_doc_id", unique: true, where: "(drive_transcript_doc_id IS NOT NULL)"
+    t.index ["gemini_notes_doc_id"], name: "index_meetings_on_gemini_notes_doc_id", unique: true, where: "(gemini_notes_doc_id IS NOT NULL)"
     t.index ["meet_conference_record_id"], name: "index_meetings_on_meet_conference_record_id", unique: true, where: "(meet_conference_record_id IS NOT NULL)"
   end
 

--- a/docs/meet-etl-deploy.md
+++ b/docs/meet-etl-deploy.md
@@ -81,6 +81,8 @@ local embedding model needs RAM and the run is long):
 heroku run:detached --size=performance-l "rake 'stacks:etl:backfill_meet_all[90]'" --app <app>
 ```
 
+> **Gemini notes included:** `backfill_meet_all` now sweeps "Notes by Gemini" Drive docs (Drive-only, `until_time: nil`) for the same historical window, immediately after the transcript sweep.
+
 - Impersonates every active Workspace user (~65), error-isolated per user. If **every**
   user fails (e.g. broken auth) the SystemTask is marked errored, not green.
 - Covers only the **older** window (up to ~7 days ago); the recent window is owned by the
@@ -99,11 +101,7 @@ Add a **Heroku Scheduler** job (Scheduler lets you pick the dyno size):
 - **Dyno size:** Performance-L (enough RAM for the embedding model; faster)
 - **Frequency:** daily (overnight)
 
-`stacks:etl:sync_all` is the nightly entry point across ALL sources (today just Meet — it
-invokes `sync_meet_all`; future sources are added there, so the Scheduler job never changes).
-It pulls the recent window (default last 10 days; run `sync_meet_all[N]` directly to change) via the
-richer Meet REST API for every user, embedding new transcripts locally. It owns the recent
-window; the Drive backfill owns everything older, so the two never double-ingest a meeting.
+`stacks:etl:sync_all` is the nightly entry point across ALL sources. It now invokes `sync_meet_all` (Meet REST API transcripts, recent window) and then `sync_gemini_notes_all` (Gemini notes, Drive-only, `until_time: nil`, recent window — default 10 days). Future sources are added here so the Scheduler job never changes.
 
 ## 5. Operating notes
 

--- a/docs/superpowers/plans/2026-07-01-gemini-notes-ingestion.md
+++ b/docs/superpowers/plans/2026-07-01-gemini-notes-ingestion.md
@@ -1,0 +1,643 @@
+# Gemini Notes Ingestion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ingest Google Meet "Notes by Gemini" Drive docs into the org vector corpus as a search-only, progressive-enhancement source alongside Meet transcripts, subject to the same privacy exclusion wall.
+
+**Architecture:** Notes are treated as "another source" reusing the existing Document → Chunk → Embedding → MCP pipeline. A new `GeminiNotesSource` (parallel to `DriveSource`) queries Drive for notes docs, parses them, and yields normalized docs with `source: :gemini_notes` that link to the transcript's `Meeting` (or stand alone). Transcripts are untouched and remain load-bearing.
+
+**Tech Stack:** Rails 6.1, Ruby 3.1, Minitest + mocha (no WebMock — stub Drive/Calendar via mocha), PostgreSQL + pgvector (`neighbor`), `google-apis-drive_v3`.
+
+## Global Constraints
+
+- Progressive enhancement: transcripts remain primary. Search/attribution/exclusion MUST work without notes. Nothing may require notes to exist.
+- Search-only this increment. Do NOT parse Next-steps/Decisions into structured records (that is spec #2).
+- Notes inherit their meeting's exclusion decision EXACTLY (a 1:1's notes are excluded like its transcript). Joined notes copy the transcript Document's `excluded`/`excluded_reason` verbatim; standalone notes classify via `Classifier(title:, participant_count:)`.
+- Notes are Drive-only (no Meet API); deduped by the notes Drive doc id alone; no `until_time` overlap guard.
+- Transcripts are swept BEFORE notes in every entry point so the join target exists.
+- `db/schema.rb` hand-manages pgvector/content_tsv omissions — after any `db:migrate`, strip re-added `enable_extension "vector"`, `t.vector "embedding"` + its hnsw index, and the `content_tsv` column (see the comments in schema.rb). CI uses in-dyno Postgres; tests that create `Embedding` rows must call `skip_without_pgvector` in setup.
+- Contact provenance tag stays `etl:meet` for notes (same pipeline).
+
+## File Structure
+
+- **Create** `lib/stacks/etl/meet/drive_doc.rb` — shared module: `clean_title`, date-stamp regexes, `coerce` (extracted from `DriveSource`; included by both sources).
+- **Create** `lib/stacks/etl/meet/gemini_notes_source.rb` — `Stacks::Etl::Meet::GeminiNotesSource`: Drive query for notes docs, parse, `each_meeting`, `normalize`, `build_meeting`, join.
+- **Create** `db/migrate/20260701000001_add_gemini_notes_doc_id_to_meetings.rb`.
+- **Modify** `app/models/document.rb` (source enum), `app/models/chunk.rb` (source enum), `app/models/meeting.rb` (meet_source enum + `has_many :documents`).
+- **Modify** `lib/stacks/etl/connector.rb` (Document + Chunk source from `normalized[:source]`).
+- **Modify** `lib/stacks/etl/meet/connector.rb` (`:gemini_notes` mode + inherit-exclusion in `exclusion_for`).
+- **Modify** `lib/stacks/etl/meet/drive_source.rb` (use the shared `DriveDoc` module).
+- **Modify** `lib/stacks/etl/meet.rb` (allow `mode: :gemini_notes` — already generic).
+- **Modify** `lib/tasks/etl.rake` (`sync_all` + `backfill_meet_all` run a notes sweep after transcripts).
+- **Tests** under `test/lib/stacks/etl/meet/` and `test/lib/stacks/etl/`.
+
+---
+
+### Task 1: Schema + model enums
+
+**Files:**
+- Create: `db/migrate/20260701000001_add_gemini_notes_doc_id_to_meetings.rb`
+- Modify: `app/models/document.rb`, `app/models/chunk.rb`, `app/models/meeting.rb`, `db/schema.rb`
+- Test: `test/models/meeting_test.rb` (create if absent)
+
+**Interfaces:**
+- Produces: `Document.sources["gemini_notes"] == 1`, `Chunk.sources["gemini_notes"] == 1`, `Meeting.meet_sources["gemini_notes"] == 2`, `meetings.gemini_notes_doc_id` (string, unique-where-not-null), `Meeting#documents` (has_many, polymorphic `source_record`).
+
+- [ ] **Step 1: Write the migration**
+
+```ruby
+# db/migrate/20260701000001_add_gemini_notes_doc_id_to_meetings.rb
+class AddGeminiNotesDocIdToMeetings < ActiveRecord::Migration[6.1]
+  def change
+    add_column :meetings, :gemini_notes_doc_id, :string
+    add_index :meetings, :gemini_notes_doc_id, unique: true,
+              where: "gemini_notes_doc_id IS NOT NULL",
+              name: "index_meetings_on_gemini_notes_doc_id"
+  end
+end
+```
+
+- [ ] **Step 2: Run the migration + fix schema.rb by hand**
+
+Run: `RAILS_ENV=test bundle exec rake db:migrate` then `git diff db/schema.rb`.
+Expected: schema.rb gains `t.string "gemini_notes_doc_id"` + its index AND regenerates the pgvector/content_tsv/composite-FK lines. **Manually revert** everything except the version bump + the two new gemini_notes_doc_id lines (restore the `# … intentionally omitted here` comment block for content_tsv/vector, the composite-FK comments, and drop the re-added `t.vector`/`enable_extension "vector"`/hnsw index). Verify with `RAILS_ENV=test bundle exec rake db:schema:load` — no error.
+
+- [ ] **Step 3: Add the enum values + association**
+
+```ruby
+# app/models/document.rb — change the source enum line to:
+  enum source: { meet: 0, gemini_notes: 1 }
+# app/models/chunk.rb — change:
+  enum source: { meet: 0, gemini_notes: 1 }
+# app/models/meeting.rb — change the has_one + enum:
+  has_many :documents, as: :source_record
+  enum meet_source: { meet_api: 0, drive: 1, gemini_notes: 2 }
+```
+
+- [ ] **Step 4: Find and fix any `meeting.document` (singular) callers**
+
+Run: `grep -rn "\.document\b" app lib | grep -iE "meeting" ` and `grep -rn "source_record" app/admin`.
+For each caller of the old `has_one :document` (e.g. an admin show page), replace `meeting.document` with `meeting.documents.find_by(source: :meet)` (the transcript) or `meeting.documents.first`. If none exist, note it and continue.
+
+- [ ] **Step 5: Test the enums + association**
+
+```ruby
+# test/models/meeting_test.rb
+require "test_helper"
+class MeetingTest < ActiveSupport::TestCase
+  test "a meeting can own a transcript and a notes document" do
+    m = Meeting.create!(meet_source: :drive, drive_transcript_doc_id: "t1")
+    t = Document.create!(source: :meet, external_id: "t1", source_record: m)
+    n = Document.create!(source: :gemini_notes, external_id: "n1", source_record: m)
+    assert_equal [t.id, n.id].sort, m.documents.pluck(:id).sort
+    assert_equal 1, Document.sources["gemini_notes"]
+    assert_equal 1, Chunk.sources["gemini_notes"]
+    assert_equal 2, Meeting.meet_sources["gemini_notes"]
+  end
+end
+```
+
+- [ ] **Step 6: Run + commit**
+
+Run: `bundle exec rails test test/models/meeting_test.rb` → PASS.
+`git add -A && git commit -m "Gemini notes: schema + source/meet_source enums + Meeting has_many documents"`
+
+---
+
+### Task 2: Shared `DriveDoc` module (extract from DriveSource)
+
+**Files:**
+- Create: `lib/stacks/etl/meet/drive_doc.rb`
+- Modify: `lib/stacks/etl/meet/drive_source.rb`
+- Test: existing `test/lib/stacks/etl/meet/drive_source_test.rb` must still pass (behavior preserved).
+
+**Interfaces:**
+- Produces: `Stacks::Etl::Meet::DriveDoc` module with private-style methods `clean_title(name)` (strips a trailing `- Transcript` OR ` - Notes by Gemini` suffix AND the paren/dash date stamps) and `coerce(t)`. Included by `DriveSource` and (Task 3) `GeminiNotesSource`.
+
+- [ ] **Step 1: Create the shared module** (move the regexes + methods out of `DriveSource`, generalizing the suffix)
+
+```ruby
+# lib/stacks/etl/meet/drive_doc.rb
+module Stacks
+  module Etl
+    module Meet
+      # Shared helpers for Google Meet Drive Docs (transcripts + Gemini notes), whose
+      # names share the same "<Title> - <date> <tz> - <Kind>" shape.
+      module DriveDoc
+        # Strips the "- Transcript" / " - Notes by Gemini" suffix, then Meet's date stamp
+        # in either the parenthetical "(2026/06/27 17:00 GMT-7)" or dash
+        # "- 2026/06/22 17:15 EDT" form. Requires a real date + clock time so a normal title
+        # like "Planning - Q3" or "Retro (5:00 format)" survives.
+        SUFFIX = /\s*-\s*(?:Transcript|Notes by Gemini)\s*\z/i
+        PAREN_DATE_STAMP = %r{\s*\((?:\d{2,4}[/-]\d{1,2}[/-]\d{1,2}|[^)]*\bGMT\b)[^)]*\)\s*\z}
+        DASH_DATE_STAMP  = %r{\s*-\s*\d{2,4}[/-]\d{1,2}[/-]\d{1,2}\s+\d{1,2}:\d{2}(?:\s*[AP]M)?(?:\s+[A-Za-z0-9+\-]{2,6})?\s*\z}i
+
+        def clean_title(name)
+          name.to_s.sub(SUFFIX, "").sub(PAREN_DATE_STAMP, "").sub(DASH_DATE_STAMP, "").strip.presence || name.to_s
+        end
+
+        def coerce(t)
+          return nil if t.nil?
+          t.is_a?(String) ? Time.parse(t) : t
+        end
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Use it in DriveSource; delete the duplicated code**
+
+In `lib/stacks/etl/meet/drive_source.rb`: add `include DriveDoc` to the class, and **delete** the now-duplicated `clean_title`, `PAREN_DATE_STAMP`, `DASH_DATE_STAMP`, and `coerce` definitions. Add `require_relative "drive_doc"` if the app's autoloading needs it (it should not — Zeitwerk resolves `Stacks::Etl::Meet::DriveDoc` from the path).
+
+- [ ] **Step 3: Run the existing drive_source tests**
+
+Run: `bundle exec rails test test/lib/stacks/etl/meet/drive_source_test.rb`
+Expected: PASS unchanged (clean_title dash/paren cases, coerce). If the `- Notes by Gemini` generalization changed any transcript case, it should not (transcripts never carry that suffix).
+
+- [ ] **Step 4: Commit**
+
+`git add -A && git commit -m "Extract shared DriveDoc (clean_title/date-stamps/coerce) from DriveSource"`
+
+---
+
+### Task 3: `GeminiNotesSource` parser (pure parsing of an exported notes doc)
+
+**Files:**
+- Create: `lib/stacks/etl/meet/gemini_notes_source.rb`
+- Test: `test/lib/stacks/etl/meet/gemini_notes_source_test.rb`
+
+**Interfaces:**
+- Produces: `Stacks::Etl::Meet::GeminiNotesSource` with private parse helpers, unit-testable via `allocate` + `send`:
+  - `transcript_doc_id_from(text) -> String|nil` (the `/document/d/<id>` in the `[Transcript](…)` line)
+  - `invited_emails_from(text) -> [String]` (lowercased `mailto:` emails, room resources skipped)
+  - `body_segments(text, occurred_at:) -> [{ speaker_name: nil, speaker_email: nil, text:, started_at: }]`
+
+- [ ] **Step 1: Write the parser tests**
+
+```ruby
+# test/lib/stacks/etl/meet/gemini_notes_source_test.rb
+require "test_helper"
+class Stacks::Etl::Meet::GeminiNotesSourceTest < ActiveSupport::TestCase
+  SAMPLE = <<~TXT
+    Notes
+
+    ## Sync Title
+
+    Invited [Ayaka Takao](mailto:Ayaka@Index-Space.org) [Hugh Francis](mailto:hugh@sanctuary.computer) [Room](mailto:room@resource.calendar.google.com)
+
+    Meeting records [Transcript](https://docs.google.com/document/d/TRANSCRIPT_ID_123/edit?usp=drive_web)
+
+    ### Summary
+    We decided to ship the gateway redesign.
+
+    ### Next steps
+    - [Hugh Francis] Finish Slides: Complete the case study slides.
+  TXT
+
+  def src = Stacks::Etl::Meet::GeminiNotesSource.allocate
+
+  test "extracts the transcript doc id from the Transcript link" do
+    assert_equal "TRANSCRIPT_ID_123", src.send(:transcript_doc_id_from, SAMPLE)
+    assert_nil src.send(:transcript_doc_id_from, "no link here")
+  end
+
+  test "extracts invited emails (lowercased), skipping room resources" do
+    assert_equal ["ayaka@index-space.org", "hugh@sanctuary.computer"],
+                 src.send(:invited_emails_from, SAMPLE)
+  end
+
+  test "body segments carry the notes text with the meeting time and no speaker" do
+    at = Time.utc(2026, 6, 30, 15)
+    segs = src.send(:body_segments, SAMPLE, occurred_at: at)
+    assert segs.any?
+    joined = segs.map { |s| s[:text] }.join(" ")
+    assert_includes joined, "ship the gateway redesign"
+    assert_includes joined, "Finish Slides"
+    assert_nil segs.first[:speaker_name]
+    assert_equal at, segs.first[:started_at]
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bundle exec rails test test/lib/stacks/etl/meet/gemini_notes_source_test.rb`
+Expected: FAIL (`uninitialized constant … GeminiNotesSource`).
+
+- [ ] **Step 3: Implement the class shell + parsers**
+
+```ruby
+# lib/stacks/etl/meet/gemini_notes_source.rb
+require "digest"
+module Stacks
+  module Etl
+    module Meet
+      class GeminiNotesSource
+        include DriveDoc
+        QUERY = "mimeType='application/vnd.google-apps.document' and name contains 'Notes by Gemini'".freeze
+
+        def initialize(user_email, since:, until_time: nil)
+          @user_email = user_email
+          @since = coerce(since)
+          @until_time = coerce(until_time) # notes have no overlap guard; callers pass nil
+          @service = Auth.drive_service(sub: user_email)
+        end
+
+        private
+
+        def transcript_doc_id_from(text)
+          # The "Meeting records [Transcript](…/document/d/<id>/…)" line.
+          m = text.to_s.match(%r{\[Transcript\]\(https://docs\.google\.com/document/d/([A-Za-z0-9_-]+)})
+          m && m[1]
+        end
+
+        def invited_emails_from(text)
+          # Emails only appear as mailto: links, primarily in the "Invited" block.
+          text.to_s.scan(/mailto:([^)\s]+)/).flatten.map { |e| e.downcase }
+              .reject { |e| e.end_with?("resource.calendar.google.com") }.uniq
+        end
+
+        def body_segments(text, occurred_at:)
+          # Search-only: the whole notes body IS the searchable content. Split into
+          # paragraph-ish blocks so the Chunker has natural boundaries; drop the trailing
+          # Gemini feedback/footer noise.
+          cleaned = text.to_s.gsub(/We've updated the Decisions section.*\z/m, "")
+                        .gsub(/Let us know what you think.*\z/m, "")
+                        .gsub(/You should review Gemini's notes.*\z/m, "")
+          cleaned.split(/\n{2,}/).map(&:strip).reject(&:empty?).map do |para|
+            { speaker_name: nil, speaker_email: nil, text: para, started_at: occurred_at, ended_at: nil }
+          end
+        end
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `bundle exec rails test test/lib/stacks/etl/meet/gemini_notes_source_test.rb` → PASS.
+
+- [ ] **Step 5: Commit**
+
+`git add -A && git commit -m "GeminiNotesSource: parse transcript link, invited emails, body segments"`
+
+---
+
+### Task 4: Base Connector — Document/Chunk source from `normalized[:source]`
+
+**Files:**
+- Modify: `lib/stacks/etl/connector.rb`
+- Test: `test/lib/stacks/etl/connector_test.rb`
+
+**Interfaces:**
+- Produces: `Connector#ingest` keys the Document on `normalized[:source] || source`, and `index_chunks!` already sets `chunk.source = document.source`, so a normalized doc carrying `source: :gemini_notes` becomes a `gemini_notes` Document + chunks. Default (no `:source` key) is unchanged (`:meet`).
+
+- [ ] **Step 1: Add the failing test** (append to `connector_test.rb`; the class has `FakeConnector` with `source = :meet` and stubs Embedder)
+
+```ruby
+  test "a normalized doc can override the source (e.g. gemini_notes)" do
+    n = normalized(external_id: "gn1", hash: "h").merge(source: :gemini_notes)
+    FakeConnector.new([n]).run
+    doc = Document.find_by!(external_id: "gn1")
+    assert doc.gemini_notes?
+    assert doc.chunks.all?(&:gemini_notes?)
+  end
+```
+
+- [ ] **Step 2: Run → FAIL** (`doc.gemini_notes?` false — it was created as `:meet`).
+
+Run: `bundle exec rails test test/lib/stacks/etl/connector_test.rb -n /override the source/`
+
+- [ ] **Step 3: Implement** — in `lib/stacks/etl/connector.rb`, `ingest`, change the find line:
+
+```ruby
+        doc = Document.find_or_initialize_by(source: normalized[:source] || source, external_id: normalized[:external_id])
+```
+
+(No other change — `index_chunks!` already does `source: document.source`.)
+
+- [ ] **Step 4: Run → PASS**, and run the whole file to confirm no regressions:
+
+Run: `bundle exec rails test test/lib/stacks/etl/connector_test.rb` → all PASS.
+
+- [ ] **Step 5: Commit**
+
+`git add -A && git commit -m "Connector: allow a normalized doc to set its own source"`
+
+---
+
+### Task 5: `GeminiNotesSource#each_meeting` + normalize + join + exclusion inheritance
+
+**Files:**
+- Modify: `lib/stacks/etl/meet/gemini_notes_source.rb`, `lib/stacks/etl/meet/connector.rb`
+- Test: `test/lib/stacks/etl/meet/gemini_notes_source_test.rb`
+
+**Interfaces:**
+- Consumes: `DriveDoc#clean_title`, the parsers from Task 3, `Document.find_by(source: :meet, external_id:)`, `Classifier`, `Connector#run`.
+- Produces: `GeminiNotesSource#each_meeting { |normalized| }` yielding, per notes doc, a hash with `source: :gemini_notes`, `external_id: <notes file id>`, `title`, `occurred_at`, `content_hash`, `contacts` (invited emails, role "attendee"), `segments` (body), plus EITHER `inherit_exclusion: [excluded_sym, reason_sym]` (joined) OR `participant_count:` (standalone), and `build_source_record` linking the notes Document to the transcript's Meeting or a standalone `gemini_notes` Meeting. `Meet::Connector.new(mode: :gemini_notes)` runs it; `Meet::Connector#exclusion_for` honors `inherit_exclusion`.
+
+- [ ] **Step 1: Write the each_meeting/join tests** (mocha-stub Drive + Auth)
+
+```ruby
+  test "joins a notes doc to the existing transcript's meeting and inherits its exclusion" do
+    meeting = Meeting.create!(meet_source: :meet_api, meet_conference_record_id: "cr/1")
+    Document.create!(source: :meet, external_id: "TRANSCRIPT_ID_123", source_record: meeting,
+                     excluded: :auto_excluded, excluded_reason: :one_on_one)
+    file = OpenStruct.new(id: "notesfile1", name: "Sync Title - 2026/06/30 15:00 EDT - Notes by Gemini",
+                          created_time: "2026-06-30T15:00:00Z")
+    svc = mock("drive")
+    svc.stubs(:list_files).returns(OpenStruct.new(files: [file], next_page_token: nil))
+    svc.stubs(:export_file).returns(SAMPLE) # from Task 3, contains TRANSCRIPT_ID_123
+    Stacks::Etl::Meet::Auth.stubs(:drive_service).returns(svc)
+
+    n = nil
+    Stacks::Etl::Meet::GeminiNotesSource.new("hugh@sanctuary.computer", since: Time.utc(2025, 1, 1)).each_meeting { |x| n = x }
+    assert_equal :gemini_notes, n[:source]
+    assert_equal "notesfile1", n[:external_id]
+    assert_equal "Sync Title", n[:title]
+    assert_equal [:auto_excluded, :one_on_one], n[:inherit_exclusion]
+    assert_equal ["ayaka@index-space.org", "hugh@sanctuary.computer"], n[:contacts].map { |c| c[:email] }
+    doc = Document.create!(source: :gemini_notes, external_id: "notesfile1")
+    built = n[:build_source_record].call(doc)
+    assert_equal meeting.id, built.id # linked to the SAME meeting
+  end
+
+  test "a notes doc with no known transcript is standalone with its own classification" do
+    file = OpenStruct.new(id: "notesfile2", name: "Team Weekly - 2026/06/30 15:00 EDT - Notes by Gemini",
+                          created_time: "2026-06-30T15:00:00Z")
+    svc = mock("drive")
+    svc.stubs(:list_files).returns(OpenStruct.new(files: [file], next_page_token: nil))
+    svc.stubs(:export_file).returns("Notes\n\n## Team Weekly\n\nInvited [A](mailto:a@x.co) [B](mailto:b@x.co) [C](mailto:c@x.co)\n\n### Summary\nStuff happened.")
+    Stacks::Etl::Meet::Auth.stubs(:drive_service).returns(svc)
+    n = nil
+    Stacks::Etl::Meet::GeminiNotesSource.new("hugh@sanctuary.computer", since: Time.utc(2025, 1, 1)).each_meeting { |x| n = x }
+    assert_nil n[:inherit_exclusion]
+    assert_equal 3, n[:participant_count] # invited count -> classifier sees a group
+    doc = Document.create!(source: :gemini_notes, external_id: "notesfile2")
+    built = n[:build_source_record].call(doc)
+    assert_equal "notesfile2", built.gemini_notes_doc_id
+    assert built.gemini_notes?
+  end
+```
+
+- [ ] **Step 2: Run → FAIL** (`each_meeting` undefined).
+
+- [ ] **Step 3: Implement `each_meeting` + `normalize` + `build_meeting`** in `gemini_notes_source.rb`
+
+```ruby
+        def each_meeting
+          page = nil
+          loop do
+            q = "#{QUERY} and createdTime > '#{@since.utc.iso8601}'"
+            q += " and createdTime < '#{@until_time.utc.iso8601}'" if @until_time
+            resp = @service.list_files(q: q, fields: "nextPageToken, files(id,name,createdTime)", page_token: page)
+            Array(resp.files).each { |f| yield normalize(f) }
+            page = resp.next_page_token
+            break unless page
+          end
+        end
+
+        private
+
+        def normalize(file)
+          text = @service.export_file(file.id, "text/plain")
+          title = clean_title(file.name)
+          occurred_at = coerce(file.created_time)
+          transcript_id = transcript_doc_id_from(text)
+          emails = invited_emails_from(text)
+          segments = body_segments(text, occurred_at: occurred_at)
+
+          # Join to the transcript's meeting when we ingested that transcript.
+          transcript_doc = transcript_id && Document.find_by(source: :meet, external_id: transcript_id)
+          meeting = transcript_doc&.source_record
+
+          base = {
+            source: :gemini_notes,
+            external_id: file.id,
+            title: title,
+            url: "https://docs.google.com/document/d/#{file.id}",
+            occurred_at: occurred_at,
+            content_hash: Digest::SHA256.hexdigest(text.to_s),
+            contacts: emails.map { |e| { email: e, name: nil, role: "attendee" } },
+            segments: segments,
+            raw_metadata: { "gemini_notes_doc_id" => file.id, "transcript_doc_id" => transcript_id },
+            build_source_record: ->(doc) { build_meeting(doc, file, title, occurred_at, meeting) }
+          }
+          if meeting && transcript_doc
+            # Inherit the transcript's decision verbatim (identical privacy wall).
+            base.merge(inherit_exclusion: [transcript_doc.excluded.to_sym, transcript_doc.excluded_reason.to_sym])
+          else
+            base.merge(participant_count: emails.size) # standalone -> classify on invited count
+          end
+        end
+
+        def build_meeting(doc, file, title, occurred_at, joined_meeting)
+          meeting = joined_meeting || Meeting.find_or_initialize_by(gemini_notes_doc_id: file.id)
+          meeting.update!(meet_source: (joined_meeting ? meeting.meet_source : :gemini_notes),
+                          title: title, started_at: occurred_at,
+                          gemini_notes_doc_id: file.id,
+                          raw_metadata: (meeting.raw_metadata || {}).merge("gemini_notes_document_id" => doc.id))
+          meeting
+        end
+```
+
+- [ ] **Step 4: Honor `inherit_exclusion` in `Meet::Connector#exclusion_for`** (`lib/stacks/etl/meet/connector.rb`)
+
+```ruby
+        def exclusion_for(normalized)
+          return normalized[:inherit_exclusion] if normalized[:inherit_exclusion]
+          count = normalized[:participant_count] || normalized[:contacts].size
+          Classifier.call(title: normalized[:title], participant_count: count)
+        end
+```
+
+- [ ] **Step 5: Add the `:gemini_notes` mode to `Meet::Connector#source_object`**
+
+```ruby
+        def source_object(since)
+          case @mode
+          when :drive        then DriveSource.new(@admin_email, since: since || 90.days.ago, until_time: @until_time)
+          when :gemini_notes then GeminiNotesSource.new(@admin_email, since: since || 90.days.ago, until_time: @until_time)
+          else MeetApiSource.new(@admin_email, since: since)
+          end
+        end
+```
+
+- [ ] **Step 6: Run → PASS**
+
+Run: `bundle exec rails test test/lib/stacks/etl/meet/gemini_notes_source_test.rb` → PASS.
+
+- [ ] **Step 7: Commit**
+
+`git add -A && git commit -m "GeminiNotesSource: each_meeting, join to transcript meeting, exclusion inheritance"`
+
+---
+
+### Task 6: End-to-end connector ingest of notes (exclusion + attribution + search)
+
+**Files:**
+- Test: `test/lib/stacks/etl/meet/connector_test.rb`
+
+**Interfaces:**
+- Consumes: `Meet::Connector.new(mode: :gemini_notes)`, everything from Tasks 3–5.
+- Produces: proof that a joined notes doc is ingested as a `gemini_notes` Document, chunked+embedded when its meeting is eligible, and left unchunked (walled) when the meeting is a 1:1; and that invited emails land on `document_contacts`.
+
+- [ ] **Step 1: Write the ingest tests** (stub Drive + Auth; `setup` already stubs `Embedder.embed`; add `skip_without_pgvector` since ingest creates embeddings)
+
+```ruby
+  test "notes for an eligible meeting are ingested, chunked, and searchable; a 1:1's notes are walled off" do
+    skip_without_pgvector
+    # Eligible transcript meeting + a 1:1 transcript meeting already ingested:
+    ok_m = Meeting.create!(meet_source: :meet_api, meet_conference_record_id: "cr/ok")
+    Document.create!(source: :meet, external_id: "T_OK", source_record: ok_m, excluded: :not_excluded, excluded_reason: :none)
+    oo_m = Meeting.create!(meet_source: :meet_api, meet_conference_record_id: "cr/oo")
+    Document.create!(source: :meet, external_id: "T_OO", source_record: oo_m, excluded: :auto_excluded, excluded_reason: :one_on_one)
+
+    files = [
+      OpenStruct.new(id: "N_OK", name: "Roadmap - 2026/06/30 15:00 EDT - Notes by Gemini", created_time: "2026-06-30T15:00:00Z"),
+      OpenStruct.new(id: "N_OO", name: "1:1 - 2026/06/30 16:00 EDT - Notes by Gemini", created_time: "2026-06-30T16:00:00Z")
+    ]
+    svc = mock("drive")
+    svc.stubs(:list_files).returns(OpenStruct.new(files: files, next_page_token: nil))
+    svc.stubs(:export_file).with("N_OK", "text/plain").returns("Notes\n\nInvited [A](mailto:a@x.co)\n\nMeeting records [Transcript](https://docs.google.com/document/d/T_OK/edit)\n\n### Summary\nShip the gateway.")
+    svc.stubs(:export_file).with("N_OO", "text/plain").returns("Notes\n\nMeeting records [Transcript](https://docs.google.com/document/d/T_OO/edit)\n\n### Summary\nSensitive 1:1 content.")
+    Stacks::Etl::Meet::Auth.stubs(:drive_service).returns(svc)
+
+    Stacks::Etl::Meet::Connector.new(admin_email: "hugh@sanctuary.computer", mode: :gemini_notes).run(track: false)
+
+    ok = Document.find_by!(source: :gemini_notes, external_id: "N_OK")
+    assert ok.not_excluded?
+    assert ok.chunks.any?, "eligible notes should be chunked/searchable"
+    assert_equal ["a@x.co"], ok.document_contacts.pluck(:email)
+    assert_equal ok_m.id, ok.source_record_id
+
+    oo = Document.find_by!(source: :gemini_notes, external_id: "N_OO")
+    assert oo.auto_excluded?
+    assert oo.reason_one_on_one?
+    assert_equal 0, oo.chunks.count, "a 1:1's notes must be walled off"
+  end
+```
+
+- [ ] **Step 2: Run → PASS** (all wiring from Tasks 3–5 should carry it). Debug until green.
+
+Run: `bundle exec rails test test/lib/stacks/etl/meet/connector_test.rb -n /notes for an eligible/`
+
+- [ ] **Step 3: Commit**
+
+`git add -A && git commit -m "Notes ingest: eligible notes chunked+searchable, 1:1 notes walled, invited emails attributed"`
+
+---
+
+### Task 7: Wire notes sweeps into `sync_all` + `backfill_meet_all` (transcripts first)
+
+**Files:**
+- Modify: `lib/tasks/etl.rake`
+- Test: `test/lib/stacks/etl/meet/sweep_test.rb` (or wherever `sweep_all_users!` is tested)
+
+**Interfaces:**
+- Consumes: `Stacks::Etl::Meet.sweep_all_users!(task_name:, mode:, since:, until_time:)` (already generic over `mode`), `Meet::Connector` `:gemini_notes` mode.
+- Produces: `sync_all` runs the API transcript sweep THEN a `:gemini_notes` Drive sweep over the recent window; `backfill_meet_all[N]` runs the Drive transcript sweep THEN a `:gemini_notes` sweep over the historical window (both with `until_time: nil` for notes — no overlap guard).
+
+- [ ] **Step 1: Test the ordering + that notes get their own sweep** (mocha: expect `sweep_all_users!` called with `mode: :api`/`:drive` then `mode: :gemini_notes`, in order)
+
+```ruby
+  test "backfill_meet_all sweeps transcripts, then a gemini_notes sweep (no until_time)" do
+    seq = sequence("sweeps")
+    Stacks::Etl::Meet.expects(:sweep_all_users!).with(has_entry(mode: :drive)).in_sequence(seq)
+    Stacks::Etl::Meet.expects(:sweep_all_users!).with(has_entries(mode: :gemini_notes, until_time: nil)).in_sequence(seq)
+    Rake::Task["stacks:etl:backfill_meet_all"].reenable
+    Rake::Task["stacks:etl:backfill_meet_all"].invoke("30")
+  end
+```
+
+- [ ] **Step 2: Run → FAIL** (only one sweep today).
+
+- [ ] **Step 3: Implement** in `lib/tasks/etl.rake` — after the existing transcript sweeps, add the notes sweep:
+
+```ruby
+    # inside backfill_meet_all, AFTER the Drive transcript sweep:
+      Stacks::Etl::Meet.sweep_all_users!(
+        task_name: "stacks:etl:backfill_gemini_notes_all",
+        mode: :gemini_notes,
+        since: (args[:days] || 90).to_i.days.ago,
+        until_time: nil # notes are Drive-only; no API overlap to guard against
+      )
+
+    # replace sync_all's body with transcripts-then-notes:
+    desc "Nightly ETL sync across ALL sources (currently Meet transcripts + Gemini notes)"
+    task sync_all: :environment do
+      %w[stacks:etl:sync_meet_all stacks:etl:sync_gemini_notes_all].each do |t|
+        Rake::Task[t].invoke
+      rescue => e
+        Rails.logger.error("stacks:etl:sync_all — #{t} failed: #{e.class}: #{e.message}")
+      end
+    end
+
+    desc "Org-wide Gemini-notes sync for ALL users (recent window; default 10 days)"
+    task :sync_gemini_notes_all, [:days] => :environment do |_t, args|
+      Stacks::Etl::Meet.sweep_all_users!(
+        task_name: "stacks:etl:sync_gemini_notes_all",
+        mode: :gemini_notes,
+        since: (args[:days] || 10).to_i.days.ago,
+        until_time: nil
+      )
+    end
+```
+
+- [ ] **Step 4: Run → PASS**; also run the full sweep test file.
+
+Run: `bundle exec rails test test/lib/stacks/etl/meet/sweep_test.rb`
+
+- [ ] **Step 5: Update the deploy runbook** — in `docs/meet-etl-deploy.md`, note that `sync_all` and `backfill_meet_all` now also sweep Gemini notes (Drive-only, recent + historical), one line.
+
+- [ ] **Step 6: Commit**
+
+`git add -A && git commit -m "Sweep Gemini notes in sync_all (recent) + backfill_meet_all (historical), after transcripts"`
+
+---
+
+### Task 8: MCP surface verification (notes searchable + source-filterable + walled)
+
+**Files:**
+- Test: `test/services/mcp/tools_test.rb`
+
+**Interfaces:**
+- Consumes: existing `Mcp::ListDocumentsTool`, `Mcp::SearchTool` (both already accept a `source` filter), the `gemini_notes` Document from prior tasks.
+- Produces: proof that notes surface through the existing tools with no code change, are filterable by `source`, and excluded notes are hidden.
+
+- [ ] **Step 1: Write the test** (no embeddings needed — keyword search on `content_tsv` + `list_documents`; CI-safe)
+
+```ruby
+  test "list_documents can filter to gemini_notes and hides excluded notes" do
+    m = Meeting.create!(meet_source: :meet_api, meet_conference_record_id: "cr/z")
+    note = Document.create!(source: :gemini_notes, external_id: "gn", title: "Roadmap notes", excluded: :not_excluded, source_record: m)
+    Document.create!(source: :gemini_notes, external_id: "gn2", title: "1:1 notes", excluded: :auto_excluded, source_record: m)
+
+    resp = Mcp::ListDocumentsTool.call(source: "gemini_notes", server_context: {})
+    ids = JSON.parse(resp.content.first[:text]).map { |d| d["id"] }
+    assert_equal [note.id], ids
+  end
+```
+
+- [ ] **Step 2: Run → PASS** (existing tools already support `source`; confirm the enum value flows through `Document.sources["gemini_notes"]`).
+
+Run: `bundle exec rails test test/services/mcp/tools_test.rb -n /gemini_notes/`
+
+- [ ] **Step 3: Full suite + CI-path check**
+
+Run: `bundle exec rails test test/lib/stacks/etl test/services/mcp test/models/meeting_test.rb` → all PASS.
+Run: `DISABLE_PGVECTOR=1 RAILS_ENV=test bundle exec rake db:schema:load && DISABLE_PGVECTOR=1 bundle exec rails test test/lib/stacks/etl test/services/mcp` → PASS with the embedding-touching notes tests skipped (mirrors CI). Then restore: `RAILS_ENV=test bundle exec rake db:schema:load`.
+
+- [ ] **Step 4: Commit**
+
+`git add -A && git commit -m "MCP: notes surface via existing search/list_documents, source-filterable, excluded walled"`
+
+---
+
+## Self-Review
+
+- **Spec coverage:** enum/source (T1, T4) ✓; Meeting has_many (T1) ✓; GeminiNotesSource query+parse (T2, T3, T5) ✓; join via transcript link + standalone (T5) ✓; exclusion inheritance (T5, T6) ✓; invited-email supplement (T5, T6) ✓; chunk/embed body (T3 body_segments → T6) ✓; sweeps in sync_all + backfill, transcripts-first, no notes overlap guard (T7) ✓; MCP surface (T8) ✓; progressive-enhancement (transcripts untouched; notes optional) — no task modifies transcript ingestion ✓.
+- **Type consistency:** `normalized[:source]` (T4) matches GeminiNotesSource output (T5); `inherit_exclusion: [sym, sym]` produced in T5 / consumed in T5 exclusion_for; `mode: :gemini_notes` used in T5 source_object + T7 sweeps; `gemini_notes_doc_id` column (T1) keyed in T5 build_meeting; `Meeting#documents` (T1) asserted in T1/T6.
+- **Notes/edge:** joined-meeting update in T5 preserves `meet_source` for joined meetings (only standalone becomes `:gemini_notes`); body_segments strips Gemini footer noise; contacts role "attendee" matches the connector's `sync_document_contacts` shape.

--- a/docs/superpowers/specs/2026-07-01-gemini-notes-ingestion-design.md
+++ b/docs/superpowers/specs/2026-07-01-gemini-notes-ingestion-design.md
@@ -1,0 +1,134 @@
+# Gemini Notes Ingestion — Design
+
+**Goal:** Ingest Google Meet "Notes by Gemini" docs into the org vector corpus as a
+**progressive enhancement** to the existing Meet-transcript ETL — searchable alongside
+transcripts, subject to the same privacy wall — without making anything depend on notes.
+
+## Guiding principle: progressive enhancement, not load-bearing
+
+Transcripts remain the primary, load-bearing artifact. Gemini notes are often **absent**
+(users disable "Take notes with Gemini"; meetings predate the feature), so search,
+attribution, and the exclusion wall must all work from the transcript alone. Notes only
+**add** signal when present: a distilled summary, decisions, next steps, and an extra
+source of attendee emails. Nothing in the system may require notes to exist.
+
+## Scope (decided)
+
+- **Search-only.** Each notes doc is ingested as searchable content (chunked + embedded).
+  We do **not** parse Next-steps/Decisions into structured commitment/decision records in
+  this increment — that belongs to the spec-#2 intelligence layer, which is designed to
+  draw from transcripts primarily (so accountability tracking never leans solely on
+  Gemini). The Next-steps/Decisions text is still fully searchable as content.
+- **Notes-only meetings are ingested standalone.** If a notes doc exists with no
+  transcript (transcription off, notes on), the notes become that meeting's document on
+  their own, classified independently. We do not drop meetings whose only artifact is notes.
+
+## What a Gemini notes doc looks like (from real prod data)
+
+Drive Google Doc, named `"<Title> - YYYY/MM/DD HH:MM <TZ> - Notes by Gemini"` (same
+dash-date stamp as transcripts). Body (markdown-ish) contains:
+
+- `Invited:` — attendee names as `[Name](mailto:email)` links (emails inline).
+- `Meeting records [Transcript](https://docs.google.com/document/d/<TRANSCRIPT_DOC_ID>/…)`
+  — present when a transcript exists; **the join key**. Absent for notes-only meetings.
+- `### Summary`, `### Decisions` (Aligned / Needs Further Discussion), `### Next steps`
+  (`[Owner] Action: Description`), `### Details`.
+
+## Architecture (Approach A: notes are "another source")
+
+Notes reuse the existing multi-source pipeline (Document → Chunk → Embedding → MCP) exactly
+as another source. Transcripts are untouched.
+
+### Data model
+- `Document.source` and `Chunk.source` enums gain `gemini_notes: 1` (alongside `meet: 0`).
+- `Meeting has_many :documents, as: :source_record` — a meeting can own a transcript
+  Document **and** a notes Document (both `source_record` → the same Meeting). No other
+  Meeting change.
+- The notes Document is keyed `find_or_initialize_by(source: :gemini_notes,
+  external_id: <notes Drive doc id>)` — same idempotency as transcripts.
+
+### `Stacks::Etl::Meet::GeminiNotesSource` (new, parallel to `DriveSource`)
+A focused source class that shares Drive `Auth`, `clean_title`, and date-stamp stripping
+with `DriveSource`. It:
+- Queries Drive: `mimeType='application/vnd.google-apps.document' and name contains 'Notes by Gemini'`
+  (plus the same `createdTime` window bounds as `DriveSource`, incl. `until_time`).
+- Exports each doc (`text/plain`) and parses:
+  - **title** via `clean_title` (strips `- Notes by Gemini` suffix + the date stamp),
+  - **transcript doc id** from the `…/document/d/<id>/…` in the Transcript link (nil if absent),
+  - **Invited emails** from the `mailto:` links (skip room resources),
+  - **body** = the Summary/Decisions/Next-steps/Details text → the searchable segments.
+- Yields a normalized hash with `source: :gemini_notes`, the parsed fields, a
+  `transcript_doc_id` join hint, and a `build_source_record` that links/creates the Meeting.
+
+### Join + ordering
+In the Drive backfill, **transcripts are swept first (`DriveSource`), notes second
+(`GeminiNotesSource`)** — so a notes doc's transcript Document already exists when the
+notes are processed.
+- **Joined:** parse the transcript doc id → find `Document(source: :meet,
+  external_id: <transcript_doc_id>)` → attach the notes Document's `source_record` to that
+  Document's `Meeting`.
+- **Standalone:** no transcript link, or transcript Document not found → create/find a
+  notes-only Meeting keyed on the notes Drive doc id (`meet_source: :gemini_notes`),
+  classified independently.
+
+### Exclusion inheritance (privacy — non-negotiable)
+- **Joined:** the notes Document copies the linked transcript Document's `excluded` /
+  `excluded_reason` verbatim (do NOT re-derive) — the wall is provably identical. A 1:1's
+  notes are excluded exactly like its transcript.
+- **Standalone:** classified via the existing `Classifier(title:, participant_count:)`,
+  where `participant_count` = the notes' Invited count.
+
+The connector's exclusion path is extended so a notes `normalized` carries either
+`inherit_exclusion: [excluded, reason]` (joined) or the title + Invited count (standalone).
+
+### Attribution
+The notes' Invited emails become the notes Document's `document_contacts` (resolved to the
+same Contacts via `MentionResolver.resolve_email`). This **supplements** attribution;
+transcript-only meetings still use the Calendar match. Contact source tag stays `etl:meet`.
+
+### Chunking / embedding
+The notes body flows through the existing `Chunker`/`Embedder`, modeled as segments with
+`speaker_name: nil` and `occurred_at` = the meeting time. Notes are short → a handful of
+chunks. Corpus-eligible notes get chunked + embedded exactly like transcripts.
+
+### MCP surface
+No new tools. Notes appear in `search` / `list_documents` / `get_document`, tagged
+`source: gemini_notes` (the existing `source` filter lets the agent request transcripts,
+notes, or both). Excluded notes are never returned (`corpus_eligible` filter).
+
+### Sweep windows (important: notes are Drive-only)
+The transcript's API-recent / Drive-older time-partition does **not** apply to notes —
+notes exist only as Drive Docs, never via the Meet API. So a Gemini-notes sweep is always
+Drive-based, deduped simply by the notes Drive doc id (single source, no cross-source merge
+risk). Notes are therefore swept in **both** entry points:
+- **Nightly `sync_all`:** after `sync_meet_all` (API transcripts, recent window) runs a
+  Gemini-notes Drive sweep over the same recent window — otherwise recent notes (< the
+  7-day Drive backfill guard) would never be captured, since the API sync can't see notes.
+- **`backfill_meet_all[N]`:** after `DriveSource` (historical transcripts) runs
+  `GeminiNotesSource` over the historical window.
+
+In both, **transcripts are swept before notes** so the join target exists. Notes have no
+`until_time` overlap-guard (no API counterpart to collide with); the notes-doc-id dedup
+makes overlapping windows across runs harmless.
+
+## Error handling
+- **Best-effort parsing:** a notes doc that fails to export/parse is skipped, never
+  breaking the backfill (same philosophy as Calendar enrichment).
+- **Unrecognized structure:** a notes doc with no parseable sections falls back to
+  ingesting its raw exported text (still searchable) rather than being dropped.
+- **Idempotent re-ingest:** keyed on the notes Drive doc id; content-hash gate avoids
+  re-chunking unchanged notes.
+
+## Testing
+- `GeminiNotesSource` parsing: title cleaning, transcript-doc-id extraction (present +
+  absent), Invited email extraction (incl. skipping room resources), body extraction.
+- **Join:** a notes doc links to the existing transcript's Meeting (same `source_record`).
+- **Exclusion inheritance:** a 1:1 transcript's notes are `excluded` with no
+  chunks/embeddings; a standalone 1:1 notes doc is classified excluded on its own.
+- **Attribution:** Invited emails resolve to the notes Document's `document_contacts`.
+- **MCP:** notes are searchable, filterable by `source`, and walled off when excluded.
+
+## Out of scope (future / spec #2)
+- Structured extraction of Next-steps → commitments and Decisions → decision records, with
+  owner-name → Contact resolution and cross-meeting accountability queries.
+- Any dependence on notes for core search/attribution/exclusion.

--- a/lib/stacks/etl/connector.rb
+++ b/lib/stacks/etl/connector.rb
@@ -66,7 +66,7 @@ module Stacks
 
       def ingest(normalized)
         ActiveRecord::Base.transaction do
-          doc = Document.find_or_initialize_by(source: source, external_id: normalized[:external_id])
+          doc = Document.find_or_initialize_by(source: normalized[:source] || source, external_id: normalized[:external_id])
           changed = doc.new_record? || doc.content_hash != normalized[:content_hash]
 
           doc.assign_attributes(

--- a/lib/stacks/etl/meet/connector.rb
+++ b/lib/stacks/etl/meet/connector.rb
@@ -19,6 +19,7 @@ module Stacks
         end
 
         def exclusion_for(normalized)
+          return normalized[:inherit_exclusion] if normalized[:inherit_exclusion]
           # 1:1 PRIVACY POLICY (deliberate — do NOT "improve" this to max() with the
           # contacts/Calendar count): the head-count must reflect who was ACTUALLY in the
           # meeting, never who was invited. Invite counts over-count (a no-show on a 1:1
@@ -35,10 +36,10 @@ module Stacks
         private
 
         def source_object(since)
-          if @mode == :drive
-            DriveSource.new(@admin_email, since: since || 90.days.ago, until_time: @until_time)
-          else
-            MeetApiSource.new(@admin_email, since: since)
+          case @mode
+          when :drive        then DriveSource.new(@admin_email, since: since || 90.days.ago, until_time: @until_time)
+          when :gemini_notes then GeminiNotesSource.new(@admin_email, since: since || 90.days.ago, until_time: @until_time)
+          else MeetApiSource.new(@admin_email, since: since)
           end
         end
       end

--- a/lib/stacks/etl/meet/drive_doc.rb
+++ b/lib/stacks/etl/meet/drive_doc.rb
@@ -1,0 +1,26 @@
+module Stacks
+  module Etl
+    module Meet
+      # Shared helpers for Google Meet Drive Docs (transcripts + Gemini notes), whose
+      # names share the same "<Title> - <date> <tz> - <Kind>" shape.
+      module DriveDoc
+        # Strips the "- Transcript" / " - Notes by Gemini" suffix, then Meet's date stamp
+        # in either the parenthetical "(2026/06/27 17:00 GMT-7)" or dash
+        # "- 2026/06/22 17:15 EDT" form. Requires a real date + clock time so a normal title
+        # like "Planning - Q3" or "Retro (5:00 format)" survives.
+        SUFFIX = /\s*-\s*(?:Transcript|Notes by Gemini)\s*\z/i
+        PAREN_DATE_STAMP = %r{\s*\((?:\d{2,4}[/-]\d{1,2}[/-]\d{1,2}|[^)]*\bGMT\b)[^)]*\)\s*\z}
+        DASH_DATE_STAMP  = %r{\s*-\s*\d{2,4}[/-]\d{1,2}[/-]\d{1,2}\s+\d{1,2}:\d{2}(?:\s*[AP]M)?(?:\s+[A-Za-z0-9+\-]{2,6})?\s*\z}i
+
+        def clean_title(name)
+          name.to_s.sub(SUFFIX, "").sub(PAREN_DATE_STAMP, "").sub(DASH_DATE_STAMP, "").strip.presence || name.to_s
+        end
+
+        def coerce(t)
+          return nil if t.nil?
+          t.is_a?(String) ? Time.parse(t) : t
+        end
+      end
+    end
+  end
+end

--- a/lib/stacks/etl/meet/drive_source.rb
+++ b/lib/stacks/etl/meet/drive_source.rb
@@ -4,6 +4,8 @@ module Stacks
   module Etl
     module Meet
       class DriveSource
+        include DriveDoc
+
         QUERY = "mimeType='application/vnd.google-apps.document' and name contains 'Transcript'".freeze
 
         def initialize(user_email, since:, until_time: nil)
@@ -77,35 +79,10 @@ module Stacks
           }
         end
 
-        def coerce(t)
-          return nil if t.nil?
-          t.is_a?(String) ? Time.parse(t) : t
-        end
-
         # Distinct speakers heard in the transcript — the actual-attendance head-count for
         # the 1:1 privacy classifier. parse_segments never yields a nil speaker_name.
         def distinct_speaker_count(segments)
           segments.map { |s| s[:speaker_name] }.uniq.size
-        end
-
-        # Meet names transcript docs with a trailing "- Transcript" and a date stamp in one
-        # of two forms:
-        #   dash-separated (the common one):  "Title - 2026/06/22 17:15 EDT - Transcript"
-        #   parenthetical:                    "Title (2026/06/27 17:00 GMT-7) - Transcript"
-        # Strip the "- Transcript" suffix and whichever date stamp is present, so the cleaned
-        # title is the real meeting name — which is the key the Drive Calendar enricher
-        # matches on (a date-polluted title never matches the event, losing attendee emails
-        # AND organizer_email). Both stamps require an actual DATE (Y/M/D) + clock time, so a
-        # real title like "Retro (5:00 format)", "Roadmap (Q3 2026)" or "Planning - Q3" survives.
-        PAREN_DATE_STAMP = %r{\s*\((?:\d{2,4}[/-]\d{1,2}[/-]\d{1,2}|[^)]*\bGMT\b)[^)]*\)\s*\z}
-        DASH_DATE_STAMP  = %r{\s*-\s*\d{2,4}[/-]\d{1,2}[/-]\d{1,2}\s+\d{1,2}:\d{2}(?:\s*[AP]M)?(?:\s+[A-Za-z0-9+\-]{2,6})?\s*\z}i
-        def clean_title(name)
-          name.to_s
-              .sub(/\s*-\s*Transcript\s*\z/i, '')
-              .sub(PAREN_DATE_STAMP, '')
-              .sub(DASH_DATE_STAMP, '')
-              .strip
-              .presence || name.to_s
         end
 
         # A speaker line is "Name: <text>". The name must LOOK like a name. The FIRST token

--- a/lib/stacks/etl/meet/gemini_notes_source.rb
+++ b/lib/stacks/etl/meet/gemini_notes_source.rb
@@ -43,9 +43,9 @@ module Stacks
           # Search-only: the whole notes body IS the searchable content. Split into
           # paragraph-ish blocks so the Chunker has natural boundaries; drop the trailing
           # Gemini feedback/footer noise.
-          cleaned = text.to_s.gsub(/We've updated the Decisions section.*\z/m, "")
+          cleaned = text.to_s.gsub(/We['’]ve updated the Decisions section.*\z/m, "")
                         .gsub(/Let us know what you think.*\z/m, "")
-                        .gsub(/You should review Gemini's notes.*\z/m, "")
+                        .gsub(/You should review Gemini['’]s notes.*\z/m, "")
           cleaned.split(/\n{2,}/).map(&:strip).reject(&:empty?).map do |para|
             { speaker_name: nil, speaker_email: nil, text: para, started_at: occurred_at, ended_at: nil }
           end
@@ -60,7 +60,9 @@ module Stacks
           segments = body_segments(text, occurred_at: occurred_at)
 
           # Join to the transcript's meeting when we ingested that transcript.
-          transcript_doc = transcript_id && Document.find_by(source: :meet, external_id: transcript_id)
+          # Use for_drive_doc so we match BOTH ingest shapes: DriveSource keys on external_id,
+          # MeetApiSource keys on the conference-record id and stores the Drive id in raw_metadata.
+          transcript_doc = transcript_id && Document.for_drive_doc(transcript_id).first
           meeting = transcript_doc&.source_record
 
           base = {

--- a/lib/stacks/etl/meet/gemini_notes_source.rb
+++ b/lib/stacks/etl/meet/gemini_notes_source.rb
@@ -13,6 +13,18 @@ module Stacks
           @service = Auth.drive_service(sub: user_email)
         end
 
+        def each_meeting
+          page = nil
+          loop do
+            q = "#{QUERY} and createdTime > '#{@since.utc.iso8601}'"
+            q += " and createdTime < '#{@until_time.utc.iso8601}'" if @until_time
+            resp = @service.list_files(q: q, fields: "nextPageToken, files(id,name,createdTime)", page_token: page)
+            Array(resp.files).each { |f| yield normalize(f) }
+            page = resp.next_page_token
+            break unless page
+          end
+        end
+
         private
 
         def transcript_doc_id_from(text)
@@ -37,6 +49,47 @@ module Stacks
           cleaned.split(/\n{2,}/).map(&:strip).reject(&:empty?).map do |para|
             { speaker_name: nil, speaker_email: nil, text: para, started_at: occurred_at, ended_at: nil }
           end
+        end
+
+        def normalize(file)
+          text = @service.export_file(file.id, "text/plain")
+          title = clean_title(file.name)
+          occurred_at = coerce(file.created_time)
+          transcript_id = transcript_doc_id_from(text)
+          emails = invited_emails_from(text)
+          segments = body_segments(text, occurred_at: occurred_at)
+
+          # Join to the transcript's meeting when we ingested that transcript.
+          transcript_doc = transcript_id && Document.find_by(source: :meet, external_id: transcript_id)
+          meeting = transcript_doc&.source_record
+
+          base = {
+            source: :gemini_notes,
+            external_id: file.id,
+            title: title,
+            url: "https://docs.google.com/document/d/#{file.id}",
+            occurred_at: occurred_at,
+            content_hash: Digest::SHA256.hexdigest(text.to_s),
+            contacts: emails.map { |e| { email: e, name: nil, role: "attendee" } },
+            segments: segments,
+            raw_metadata: { "gemini_notes_doc_id" => file.id, "transcript_doc_id" => transcript_id },
+            build_source_record: ->(doc) { build_meeting(doc, file, title, occurred_at, meeting) }
+          }
+          if meeting && transcript_doc
+            # Inherit the transcript's decision verbatim (identical privacy wall).
+            base.merge(inherit_exclusion: [transcript_doc.excluded.to_sym, transcript_doc.excluded_reason.to_sym])
+          else
+            base.merge(participant_count: emails.size) # standalone -> classify on invited count
+          end
+        end
+
+        def build_meeting(doc, file, title, occurred_at, joined_meeting)
+          meeting = joined_meeting || Meeting.find_or_initialize_by(gemini_notes_doc_id: file.id)
+          meeting.update!(meet_source: (joined_meeting ? meeting.meet_source : :gemini_notes),
+                          title: title, started_at: occurred_at,
+                          gemini_notes_doc_id: file.id,
+                          raw_metadata: (meeting.raw_metadata || {}).merge("gemini_notes_document_id" => doc.id))
+          meeting
         end
       end
     end

--- a/lib/stacks/etl/meet/gemini_notes_source.rb
+++ b/lib/stacks/etl/meet/gemini_notes_source.rb
@@ -1,0 +1,44 @@
+require "digest"
+module Stacks
+  module Etl
+    module Meet
+      class GeminiNotesSource
+        include DriveDoc
+        QUERY = "mimeType='application/vnd.google-apps.document' and name contains 'Notes by Gemini'".freeze
+
+        def initialize(user_email, since:, until_time: nil)
+          @user_email = user_email
+          @since = coerce(since)
+          @until_time = coerce(until_time) # notes have no overlap guard; callers pass nil
+          @service = Auth.drive_service(sub: user_email)
+        end
+
+        private
+
+        def transcript_doc_id_from(text)
+          # The "Meeting records [Transcript](…/document/d/<id>/…)" line.
+          m = text.to_s.match(%r{\[Transcript\]\(https://docs\.google\.com/document/d/([A-Za-z0-9_-]+)})
+          m && m[1]
+        end
+
+        def invited_emails_from(text)
+          # Emails only appear as mailto: links, primarily in the "Invited" block.
+          text.to_s.scan(/mailto:([^)\s]+)/).flatten.map { |e| e.downcase }
+              .reject { |e| e.end_with?("resource.calendar.google.com") }.uniq
+        end
+
+        def body_segments(text, occurred_at:)
+          # Search-only: the whole notes body IS the searchable content. Split into
+          # paragraph-ish blocks so the Chunker has natural boundaries; drop the trailing
+          # Gemini feedback/footer noise.
+          cleaned = text.to_s.gsub(/We've updated the Decisions section.*\z/m, "")
+                        .gsub(/Let us know what you think.*\z/m, "")
+                        .gsub(/You should review Gemini's notes.*\z/m, "")
+          cleaned.split(/\n{2,}/).map(&:strip).reject(&:empty?).map do |para|
+            { speaker_name: nil, speaker_email: nil, text: para, started_at: occurred_at, ended_at: nil }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/etl.rake
+++ b/lib/tasks/etl.rake
@@ -50,6 +50,12 @@ namespace :stacks do
         since: (args[:days] || 90).to_i.days.ago,
         until_time: OVERLAP_GUARD_DAYS.days.ago
       )
+      Stacks::Etl::Meet.sweep_all_users!(
+        task_name: 'stacks:etl:backfill_gemini_notes_all',
+        mode: :gemini_notes,
+        since: (args[:days] || 90).to_i.days.ago,
+        until_time: nil # notes are Drive-only; no API overlap to guard against
+      )
     end
 
     desc 'Org-wide ongoing Meet API sync for ALL users (recent window; default 10 days)'
@@ -61,13 +67,23 @@ namespace :stacks do
       )
     end
 
+    desc 'Org-wide Gemini-notes sync for ALL users (recent window; default 10 days)'
+    task :sync_gemini_notes_all, [:days] => :environment do |_t, args|
+      Stacks::Etl::Meet.sweep_all_users!(
+        task_name: 'stacks:etl:sync_gemini_notes_all',
+        mode: :gemini_notes,
+        since: (args[:days] || 10).to_i.days.ago,
+        until_time: nil
+      )
+    end
+
     # The nightly ETL entry point. Runs the ongoing sync for EVERY source; today that's
-    # only Meet, but new sources (Notion, Gmail, …) get added here so the Scheduler job
-    # never has to change. Each source is invoked independently so one source failing
-    # doesn't stop the others.
-    desc 'Nightly ETL sync across ALL sources (currently Meet)'
+    # Meet transcripts + Gemini notes, but new sources (Notion, Gmail, …) get added here
+    # so the Scheduler job never has to change. Each source is invoked independently so
+    # one source failing doesn't stop the others.
+    desc 'Nightly ETL sync across ALL sources (currently Meet transcripts + Gemini notes)'
     task sync_all: :environment do
-      %w[stacks:etl:sync_meet_all].each do |task_name|
+      %w[stacks:etl:sync_meet_all stacks:etl:sync_gemini_notes_all].each do |task_name|
         Rake::Task[task_name].invoke
       rescue => e
         Rails.logger.error("stacks:etl:sync_all — #{task_name} failed: #{e.class}: #{e.message}")

--- a/test/lib/stacks/etl/connector_test.rb
+++ b/test/lib/stacks/etl/connector_test.rb
@@ -96,4 +96,12 @@ class Stacks::Etl::ConnectorTest < ActiveSupport::TestCase
     FakeConnector.new([doc_with_counter]).run
     assert_equal 1, call_count, 'build_source_record should NOT be called again for unchanged doc'
   end
+
+  test 'a normalized doc can override the source (e.g. gemini_notes)' do
+    n = normalized(external_id: 'gn1', hash: 'h').merge(source: :gemini_notes)
+    FakeConnector.new([n]).run
+    doc = Document.find_by!(external_id: 'gn1')
+    assert doc.gemini_notes?
+    assert doc.chunks.all?(&:gemini_notes?)
+  end
 end

--- a/test/lib/stacks/etl/meet/connector_test.rb
+++ b/test/lib/stacks/etl/meet/connector_test.rb
@@ -40,4 +40,36 @@ class Stacks::Etl::Meet::ConnectorTest < ActiveSupport::TestCase
     Stacks::Etl::Meet::Connector.new(admin_email: 'hugh@sanctuary.computer', mode: :api).run
     assert Document.find_by!(external_id: 'm3').not_excluded?
   end
+
+  test "notes for an eligible meeting are ingested, chunked, and searchable; a 1:1's notes are walled off" do
+    skip_without_pgvector
+    # Eligible transcript meeting + a 1:1 transcript meeting already ingested:
+    ok_m = Meeting.create!(meet_source: :meet_api, meet_conference_record_id: "cr/ok")
+    Document.create!(source: :meet, external_id: "T_OK", source_record: ok_m, excluded: :not_excluded, excluded_reason: :none)
+    oo_m = Meeting.create!(meet_source: :meet_api, meet_conference_record_id: "cr/oo")
+    Document.create!(source: :meet, external_id: "T_OO", source_record: oo_m, excluded: :auto_excluded, excluded_reason: :one_on_one)
+
+    files = [
+      OpenStruct.new(id: "N_OK", name: "Roadmap - 2026/06/30 15:00 EDT - Notes by Gemini", created_time: "2026-06-30T15:00:00Z"),
+      OpenStruct.new(id: "N_OO", name: "1:1 - 2026/06/30 16:00 EDT - Notes by Gemini", created_time: "2026-06-30T16:00:00Z")
+    ]
+    svc = mock("drive")
+    svc.stubs(:list_files).returns(OpenStruct.new(files: files, next_page_token: nil))
+    svc.stubs(:export_file).with("N_OK", "text/plain").returns("Notes\n\nInvited [A](mailto:a@x.co)\n\nMeeting records [Transcript](https://docs.google.com/document/d/T_OK/edit)\n\n### Summary\nShip the gateway.")
+    svc.stubs(:export_file).with("N_OO", "text/plain").returns("Notes\n\nMeeting records [Transcript](https://docs.google.com/document/d/T_OO/edit)\n\n### Summary\nSensitive 1:1 content.")
+    Stacks::Etl::Meet::Auth.stubs(:drive_service).returns(svc)
+
+    Stacks::Etl::Meet::Connector.new(admin_email: "hugh@sanctuary.computer", mode: :gemini_notes).run(track: false)
+
+    ok = Document.find_by!(source: :gemini_notes, external_id: "N_OK")
+    assert ok.not_excluded?
+    assert ok.chunks.any?, "eligible notes should be chunked/searchable"
+    assert_equal ["a@x.co"], ok.document_contacts.pluck(:email)
+    assert_equal ok_m.id, ok.source_record_id
+
+    oo = Document.find_by!(source: :gemini_notes, external_id: "N_OO")
+    assert oo.auto_excluded?
+    assert oo.reason_one_on_one?
+    assert_equal 0, oo.chunks.count, "a 1:1's notes must be walled off"
+  end
 end

--- a/test/lib/stacks/etl/meet/gemini_notes_source_test.rb
+++ b/test/lib/stacks/etl/meet/gemini_notes_source_test.rb
@@ -38,4 +38,44 @@ class Stacks::Etl::Meet::GeminiNotesSourceTest < ActiveSupport::TestCase
     assert_nil segs.first[:speaker_name]
     assert_equal at, segs.first[:started_at]
   end
+
+  test "joins a notes doc to the existing transcript's meeting and inherits its exclusion" do
+    meeting = Meeting.create!(meet_source: :meet_api, meet_conference_record_id: "cr/1")
+    Document.create!(source: :meet, external_id: "TRANSCRIPT_ID_123", source_record: meeting,
+                     excluded: :auto_excluded, excluded_reason: :one_on_one)
+    file = OpenStruct.new(id: "notesfile1", name: "Sync Title - 2026/06/30 15:00 EDT - Notes by Gemini",
+                          created_time: "2026-06-30T15:00:00Z")
+    svc = mock("drive")
+    svc.stubs(:list_files).returns(OpenStruct.new(files: [file], next_page_token: nil))
+    svc.stubs(:export_file).returns(SAMPLE) # from Task 3, contains TRANSCRIPT_ID_123
+    Stacks::Etl::Meet::Auth.stubs(:drive_service).returns(svc)
+
+    n = nil
+    Stacks::Etl::Meet::GeminiNotesSource.new("hugh@sanctuary.computer", since: Time.utc(2025, 1, 1)).each_meeting { |x| n = x }
+    assert_equal :gemini_notes, n[:source]
+    assert_equal "notesfile1", n[:external_id]
+    assert_equal "Sync Title", n[:title]
+    assert_equal [:auto_excluded, :one_on_one], n[:inherit_exclusion]
+    assert_equal ["ayaka@index-space.org", "hugh@sanctuary.computer"], n[:contacts].map { |c| c[:email] }
+    doc = Document.create!(source: :gemini_notes, external_id: "notesfile1")
+    built = n[:build_source_record].call(doc)
+    assert_equal meeting.id, built.id # linked to the SAME meeting
+  end
+
+  test "a notes doc with no known transcript is standalone with its own classification" do
+    file = OpenStruct.new(id: "notesfile2", name: "Team Weekly - 2026/06/30 15:00 EDT - Notes by Gemini",
+                          created_time: "2026-06-30T15:00:00Z")
+    svc = mock("drive")
+    svc.stubs(:list_files).returns(OpenStruct.new(files: [file], next_page_token: nil))
+    svc.stubs(:export_file).returns("Notes\n\n## Team Weekly\n\nInvited [A](mailto:a@x.co) [B](mailto:b@x.co) [C](mailto:c@x.co)\n\n### Summary\nStuff happened.")
+    Stacks::Etl::Meet::Auth.stubs(:drive_service).returns(svc)
+    n = nil
+    Stacks::Etl::Meet::GeminiNotesSource.new("hugh@sanctuary.computer", since: Time.utc(2025, 1, 1)).each_meeting { |x| n = x }
+    assert_nil n[:inherit_exclusion]
+    assert_equal 3, n[:participant_count] # invited count -> classifier sees a group
+    doc = Document.create!(source: :gemini_notes, external_id: "notesfile2")
+    built = n[:build_source_record].call(doc)
+    assert_equal "notesfile2", built.gemini_notes_doc_id
+    assert built.gemini_notes?
+  end
 end

--- a/test/lib/stacks/etl/meet/gemini_notes_source_test.rb
+++ b/test/lib/stacks/etl/meet/gemini_notes_source_test.rb
@@ -82,6 +82,53 @@ class Stacks::Etl::Meet::GeminiNotesSourceTest < ActiveSupport::TestCase
     assert_nil n[:participant_count] # joined -> inherits, does not re-classify on invited count
   end
 
+  test "joins to API-ingested transcript keyed by conference-record id (regression: for_drive_doc vs find_by)" do
+    # Regression guard: MeetApiSource keys the transcript Document on the conference-record id
+    # (external_id: "conferenceRecords/9") and stores the Drive doc id only in raw_metadata.
+    # The old find_by(external_id: transcript_drive_id) missed these rows entirely, causing the
+    # notes to fall to the standalone branch and be reclassified by Invited count — which can
+    # surface a private 1:1 with >2 invited (a no-show) into the corpus. for_drive_doc matches both.
+    meeting = Meeting.create!(meet_source: :meet_api, meet_conference_record_id: "conferenceRecords/9")
+    Document.create!(
+      source: :meet,
+      external_id: "conferenceRecords/9",
+      source_record: meeting,
+      excluded: :auto_excluded,
+      excluded_reason: :one_on_one,
+      raw_metadata: { "drive_doc_id" => "REAL_TRANSCRIPT_DRIVE_ID" }
+    )
+
+    # Notes text: Transcript link points to the Drive id (NOT the conference-record id),
+    # 3 invited emails + benign title so the standalone classifier would (wrongly) allow it.
+    api_notes_text = <<~TXT
+      Notes
+
+      ## Team Retrospective
+
+      Invited [Alice](mailto:alice@sanctuary.computer) [Bob](mailto:bob@sanctuary.computer) [Carol](mailto:carol@sanctuary.computer)
+
+      Meeting records [Transcript](https://docs.google.com/document/d/REAL_TRANSCRIPT_DRIVE_ID/edit?usp=drive_web)
+
+      ### Summary
+      We reviewed the sprint and planned the next one.
+    TXT
+
+    file = OpenStruct.new(id: "notesfile_api_regression", name: "Team Retrospective - 2026/06/30 15:00 EDT - Notes by Gemini",
+                          created_time: "2026-06-30T15:00:00Z")
+    svc = mock("drive")
+    svc.stubs(:list_files).returns(OpenStruct.new(files: [file], next_page_token: nil))
+    svc.stubs(:export_file).returns(api_notes_text)
+    Stacks::Etl::Meet::Auth.stubs(:drive_service).returns(svc)
+
+    n = nil
+    Stacks::Etl::Meet::GeminiNotesSource.new("hugh@sanctuary.computer", since: Time.utc(2025, 1, 1)).each_meeting { |x| n = x }
+    # With the fix: join succeeds via raw_metadata->>'drive_doc_id', exclusion is inherited verbatim.
+    # With the bug: join fails, falls to standalone, participant_count=3 → classifier marks not_excluded.
+    assert_equal [:auto_excluded, :one_on_one], n[:inherit_exclusion],
+                 "Expected exclusion to be inherited from API-ingested transcript; standalone path would incorrectly allow this meeting"
+    assert_nil n[:participant_count], "Expected nil participant_count (took join path, not standalone)"
+  end
+
   test "a notes doc with no known transcript is standalone with its own classification" do
     file = OpenStruct.new(id: "notesfile2", name: "Team Weekly - 2026/06/30 15:00 EDT - Notes by Gemini",
                           created_time: "2026-06-30T15:00:00Z")

--- a/test/lib/stacks/etl/meet/gemini_notes_source_test.rb
+++ b/test/lib/stacks/etl/meet/gemini_notes_source_test.rb
@@ -62,6 +62,26 @@ class Stacks::Etl::Meet::GeminiNotesSourceTest < ActiveSupport::TestCase
     assert_equal meeting.id, built.id # linked to the SAME meeting
   end
 
+  test "joining an ELIGIBLE transcript inherits not_excluded verbatim (notes stay searchable)" do
+    # Guards the progressive-enhancement path: a group meeting's transcript is eligible, so
+    # its notes must inherit [:not_excluded, :none] and be chunked — NOT dropped. A future
+    # nil-guard on the inherit values must never break this branch.
+    meeting = Meeting.create!(meet_source: :meet_api, meet_conference_record_id: "cr/2")
+    Document.create!(source: :meet, external_id: "TRANSCRIPT_ID_123", source_record: meeting,
+                     excluded: :not_excluded, excluded_reason: :none)
+    file = OpenStruct.new(id: "notesfile3", name: "Sync Title - 2026/06/30 15:00 EDT - Notes by Gemini",
+                          created_time: "2026-06-30T15:00:00Z")
+    svc = mock("drive")
+    svc.stubs(:list_files).returns(OpenStruct.new(files: [file], next_page_token: nil))
+    svc.stubs(:export_file).returns(SAMPLE)
+    Stacks::Etl::Meet::Auth.stubs(:drive_service).returns(svc)
+
+    n = nil
+    Stacks::Etl::Meet::GeminiNotesSource.new("hugh@sanctuary.computer", since: Time.utc(2025, 1, 1)).each_meeting { |x| n = x }
+    assert_equal [:not_excluded, :none], n[:inherit_exclusion]
+    assert_nil n[:participant_count] # joined -> inherits, does not re-classify on invited count
+  end
+
   test "a notes doc with no known transcript is standalone with its own classification" do
     file = OpenStruct.new(id: "notesfile2", name: "Team Weekly - 2026/06/30 15:00 EDT - Notes by Gemini",
                           created_time: "2026-06-30T15:00:00Z")

--- a/test/lib/stacks/etl/meet/gemini_notes_source_test.rb
+++ b/test/lib/stacks/etl/meet/gemini_notes_source_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+class Stacks::Etl::Meet::GeminiNotesSourceTest < ActiveSupport::TestCase
+  SAMPLE = <<~TXT
+    Notes
+
+    ## Sync Title
+
+    Invited [Ayaka Takao](mailto:Ayaka@Index-Space.org) [Hugh Francis](mailto:hugh@sanctuary.computer) [Room](mailto:room@resource.calendar.google.com)
+
+    Meeting records [Transcript](https://docs.google.com/document/d/TRANSCRIPT_ID_123/edit?usp=drive_web)
+
+    ### Summary
+    We decided to ship the gateway redesign.
+
+    ### Next steps
+    - [Hugh Francis] Finish Slides: Complete the case study slides.
+  TXT
+
+  def src = Stacks::Etl::Meet::GeminiNotesSource.allocate
+
+  test "extracts the transcript doc id from the Transcript link" do
+    assert_equal "TRANSCRIPT_ID_123", src.send(:transcript_doc_id_from, SAMPLE)
+    assert_nil src.send(:transcript_doc_id_from, "no link here")
+  end
+
+  test "extracts invited emails (lowercased), skipping room resources" do
+    assert_equal ["ayaka@index-space.org", "hugh@sanctuary.computer"],
+                 src.send(:invited_emails_from, SAMPLE)
+  end
+
+  test "body segments carry the notes text with the meeting time and no speaker" do
+    at = Time.utc(2026, 6, 30, 15)
+    segs = src.send(:body_segments, SAMPLE, occurred_at: at)
+    assert segs.any?
+    joined = segs.map { |s| s[:text] }.join(" ")
+    assert_includes joined, "ship the gateway redesign"
+    assert_includes joined, "Finish Slides"
+    assert_nil segs.first[:speaker_name]
+    assert_equal at, segs.first[:started_at]
+  end
+end

--- a/test/lib/tasks/etl_rake_test.rb
+++ b/test/lib/tasks/etl_rake_test.rb
@@ -18,4 +18,22 @@ class EtlRakeTest < ActiveSupport::TestCase
     assert task.settled_at.present?, "expected settled_at to be set"
     assert_nil task.notification_id, "expected notification_id to be nil (success)"
   end
+
+  test 'backfill_meet_all sweeps transcripts, then a gemini_notes sweep (no until_time)' do
+    seq = sequence('sweeps')
+    Stacks::Etl::Meet.expects(:sweep_all_users!).with(has_entry(mode: :drive)).in_sequence(seq)
+    Stacks::Etl::Meet.expects(:sweep_all_users!).with(has_entries(mode: :gemini_notes, until_time: nil)).in_sequence(seq)
+    Rake::Task['stacks:etl:backfill_meet_all'].reenable
+    Rake::Task['stacks:etl:backfill_meet_all'].invoke('30')
+  end
+
+  test 'sync_all invokes sync_meet_all (api) before sync_gemini_notes_all (gemini_notes)' do
+    seq = sequence('sync_all_sweeps')
+    Stacks::Etl::Meet.expects(:sweep_all_users!).with(has_entry(mode: :api)).in_sequence(seq)
+    Stacks::Etl::Meet.expects(:sweep_all_users!).with(has_entries(mode: :gemini_notes, until_time: nil)).in_sequence(seq)
+    Rake::Task['stacks:etl:sync_meet_all'].reenable
+    Rake::Task['stacks:etl:sync_gemini_notes_all'].reenable
+    Rake::Task['stacks:etl:sync_all'].reenable
+    Rake::Task['stacks:etl:sync_all'].invoke
+  end
 end

--- a/test/models/meeting_test.rb
+++ b/test/models/meeting_test.rb
@@ -7,7 +7,7 @@ class MeetingTest < ActiveSupport::TestCase
     meeting.segments.create!(position: 1, text: 'second', speaker_name: 'B')
     meeting.segments.create!(position: 0, text: 'first', speaker_name: 'A')
     assert_equal %w[first second], meeting.segments.order(:position).pluck(:text)
-    assert_equal meeting, meeting.document.source_record
+    assert_equal meeting, meeting.documents.find_by(source: :meet).source_record
   end
 
   test 'conference record id is unique when present' do
@@ -15,5 +15,15 @@ class MeetingTest < ActiveSupport::TestCase
     assert_raises(ActiveRecord::RecordNotUnique) do
       Meeting.create!(meet_conference_record_id: 'conferenceRecords/9', meet_source: :meet_api)
     end
+  end
+
+  test "a meeting can own a transcript and a notes document" do
+    m = Meeting.create!(meet_source: :drive, drive_transcript_doc_id: "t1")
+    t = Document.create!(source: :meet, external_id: "t1", source_record: m)
+    n = Document.create!(source: :gemini_notes, external_id: "n1", source_record: m)
+    assert_equal [t.id, n.id].sort, m.documents.pluck(:id).sort
+    assert_equal 1, Document.sources["gemini_notes"]
+    assert_equal 1, Chunk.sources["gemini_notes"]
+    assert_equal 2, Meeting.meet_sources["gemini_notes"]
   end
 end

--- a/test/services/mcp/tools_test.rb
+++ b/test/services/mcp/tools_test.rb
@@ -38,6 +38,16 @@ class Mcp::ToolsTest < ActiveSupport::TestCase
     assert_equal [b.id], page2, 'offset skips the first (newest) in-range doc'
   end
 
+  test "list_documents can filter to gemini_notes and hides excluded notes" do
+    m = Meeting.create!(meet_source: :meet_api, meet_conference_record_id: "cr/z")
+    note = Document.create!(source: :gemini_notes, external_id: "gn", title: "Roadmap notes", excluded: :not_excluded, source_record: m)
+    Document.create!(source: :gemini_notes, external_id: "gn2", title: "1:1 notes", excluded: :auto_excluded, source_record: m)
+
+    resp = Mcp::ListDocumentsTool.call(source: "gemini_notes", server_context: {})
+    ids = JSON.parse(resp.content.first[:text]).map { |d| d["id"] }
+    assert_equal [note.id], ids
+  end
+
   def ids_for(resp)
     JSON.parse(resp.content.first[:text]).map { |d| d['id'] }
   end


### PR DESCRIPTION
## Gemini Notes ingestion — progressive enhancement to the Meet ETL

Ingests Google Meet **"Notes by Gemini"** Drive docs into the org-wide vector corpus as a second source alongside transcripts. Notes are **search-only** and **additive**: transcripts stay the load-bearing artifact, and notes only add signal when present (people disable Gemini; older meetings predate it). Nothing depends on notes existing.

### What it does
- New `Stacks::Etl::Meet::GeminiNotesSource` — queries Drive for `Notes by Gemini` docs, parses title (shared `DriveDoc` clean_title/date-stamp helpers), the embedded Transcript link, Invited emails, and the body sections.
- **Join:** a notes doc attaches to its transcript's existing `Meeting` (via the transcript's Drive doc id) so notes + transcript share one Meeting; no transcript link → standalone notes-only Meeting.
- **Data model:** `Document.source`/`Chunk.source` gain `gemini_notes`; `Meeting has_many :documents, as: :source_record`; notes keyed on the notes Drive doc id (idempotent).
- **Chunk/embed** the notes body via the existing Chunker/Embedder (speaker `nil`, `occurred_at` = meeting time). Invited emails supplement attribution (`document_contacts`, source tag `etl:meet`).
- **Sweeps:** wired into **both** entry points, transcripts-first: nightly `sync_all` (recent window, after API transcripts) and `backfill_meet_all[N]` (historical, after DriveSource). Notes are Drive-only → `until_time: nil` (no API-overlap guard); new `sync_gemini_notes_all` / `backfill_gemini_notes_all` tasks.
- **MCP:** no new tools — notes surface through existing `search` / `list_documents` / `get_document`, filterable by `source`, excluded notes walled off.

### Privacy exclusion wall (the non-negotiable)
- **Joined** notes inherit the linked transcript Document's `excluded`/`excluded_reason` **verbatim** — a 1:1's notes are excluded exactly like its transcript, never re-derived.
- **Standalone** notes classify via `Classifier(title:, participant_count:)` on the Invited count.
- Excluded notes are never chunked, embedded, or returned by MCP.

### Reviewed hard — one real leak caught and fixed
Built via subagent-driven TDD (8 tasks, per-task spec+quality review) plus a final whole-branch review, which caught a **Critical exclusion leak the per-task reviews missed**: the notes→transcript join looked up transcripts by `external_id` only, matching DriveSource but **missing every API-ingested transcript** (MeetApiSource keys on the conference-record id and stores the Drive doc id in `raw_metadata`). That's the entire nightly window — those notes silently fell to standalone Invited-count classification, which could surface a private meeting (a no-show 1:1 with >2 invited, or a benign-titled HR meeting). Fixed by joining via `Document.for_drive_doc` (matches both ingest key-shapes), with a realistic API-keyed regression test that was sanity-checked to **fail on the old code and pass on the fix**.

Remaining review Minors were triaged acceptable (backfill notes-sweep is `sweep_all_users!`-internally-isolated; standalone Invited-count classification is the only signal available and spec-sanctioned; curly-apostrophe footer-strip already widened).

### Tests
Feature blast radius (ETL + MCP + models + rake) green both ways:
- Local (pgvector): **98 runs, 255 assertions, 0 failures**
- CI mirror (`DISABLE_PGVECTOR=1`): **98 runs, 0 failures, 14 skips** (the pgvector-guarded embedding tests, by design)

Transcript ingestion is behaviorally unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
