### PR TITLE
Fix Gemini-notes export to text/markdown (hyperlinks were stripped)

### DIFF
--- a/lib/stacks/etl/meet/gemini_notes_source.rb
+++ b/lib/stacks/etl/meet/gemini_notes_source.rb
@@ -52,7 +52,14 @@ module Stacks
         end
 
         def normalize(file)
-          text = @service.export_file(file.id, "text/plain")
+          # Export as MARKDOWN, not text/plain: Google's plain-text export STRIPS hyperlinks,
+          # which would flatten the "Invited [Name](mailto:email)" list and the
+          # "Meeting records [Transcript](…/document/d/<id>)" link to bare display text —
+          # leaving us with no invited emails (→ participant_count 0 → wrongly auto-excluded)
+          # and no transcript-doc-id to join on (→ every note falls to the standalone path).
+          # Markdown preserves both link forms, which is what the parsers below depend on.
+          # (Transcripts stay text/plain in DriveSource — speaker lines carry no links.)
+          text = @service.export_file(file.id, "text/markdown")
           title = clean_title(file.name)
           occurred_at = coerce(file.created_time)
           transcript_id = transcript_doc_id_from(text)

--- a/test/lib/stacks/etl/meet/gemini_notes_source_test.rb
+++ b/test/lib/stacks/etl/meet/gemini_notes_source_test.rb
@@ -145,4 +145,27 @@ class Stacks::Etl::Meet::GeminiNotesSourceTest < ActiveSupport::TestCase
     assert_equal "notesfile2", built.gemini_notes_doc_id
     assert built.gemini_notes?
   end
+
+  test "exports the notes doc as text/markdown so hyperlinks (mailto + transcript) survive" do
+    # Regression (prod): Google's text/plain export STRIPS links, flattening
+    # "[Name](mailto:email)" and "[Transcript](url)" to bare text — so invited emails and the
+    # transcript-doc-id both come back empty, every note falls to standalone and gets
+    # auto-excluded on a 0 count. Only text/markdown preserves the link syntax the parsers need.
+    # This mocha .with pins the export MIME: a revert to "text/plain" fails here.
+    meeting = Meeting.create!(meet_source: :meet_api, meet_conference_record_id: "cr/md")
+    Document.create!(source: :meet, external_id: "TRANSCRIPT_ID_123", source_record: meeting,
+                     excluded: :not_excluded, excluded_reason: :none)
+    file = OpenStruct.new(id: "notesfile_md", name: "Sync Title - 2026/06/30 15:00 EDT - Notes by Gemini",
+                          created_time: "2026-06-30T15:00:00Z")
+    svc = mock("drive")
+    svc.stubs(:list_files).returns(OpenStruct.new(files: [file], next_page_token: nil))
+    svc.expects(:export_file).with("notesfile_md", "text/markdown").returns(SAMPLE)
+    Stacks::Etl::Meet::Auth.stubs(:drive_service).returns(svc)
+
+    n = nil
+    Stacks::Etl::Meet::GeminiNotesSource.new("hugh@sanctuary.computer", since: Time.utc(2025, 1, 1)).each_meeting { |x| n = x }
+    # Links survived the export -> transcript joins (inherits) and invited emails are attributed.
+    assert_equal [:not_excluded, :none], n[:inherit_exclusion]
+    assert_equal ["ayaka@index-space.org", "hugh@sanctuary.computer"], n[:contacts].map { |c| c[:email] }
+  end
 end


### PR DESCRIPTION
## Fix: export Gemini notes as `text/markdown` (not `text/plain`)

Found while smoke-testing the notes ingestion in production before the year backfill.

### Symptom
A `sync_gemini_notes_all[10]` run created **45 notes docs, every one `auto_excluded` and `standalone`** — 0 joined to their transcripts, 0 chunked. It also created **45 new `gemini_notes` Meetings**, duplicating meetings that already had `meet_api` transcript Meetings.

### Root cause
The notes doc's `Invited [Name](mailto:email)` list and its `Meeting records [Transcript](…/document/d/<id>)` link are **hyperlinks**. `GeminiNotesSource` exported the doc as `text/plain`, and **Google's plain-text export strips hyperlinks** — flattening them to bare display text. So:
- `invited_emails_from` → `[]` → `participant_count: 0` → Classifier auto-excludes (≤2)
- `transcript_doc_id_from` → `nil` → the join key is gone → every note falls to the standalone branch → and standalone `build_meeting` mints a **new `gemini_notes` Meeting**, duplicating the transcript's meeting.

Verified directly against a live doc — `text/markdown` preserves both `mailto:` and `[Transcript](…)`; `text/plain` has neither.

### Fix
Export notes as `text/markdown` (one line in `GeminiNotesSource#normalize`). Transcripts are unaffected — `DriveSource` stays `text/plain` (speaker-line transcripts carry no links). With links preserved:
- notes **join** their transcript's Meeting and **inherit its exclusion verbatim** (the correct signal — based on the meeting's actual attendance, not the notes body), and
- attribution gets the invited emails.
Only genuinely transcript-less notes remain standalone (the intended fallback), and those no longer collide with a transcript Meeting.

A regression test pins the export MIME via a mocha `.with(id, "text/markdown")` expectation (sanity-checked: it **fails on `text/plain`**, passes on `text/markdown`).

### Self-healing + cleanup
Re-ingest keys on `content_hash`; markdown text hashes differently from the stored plain text, so a re-sweep re-processes the 45 bad rows automatically. Before the year backfill I'll also **wipe the 45 mis-created standalone `gemini_notes` Meetings + their excluded Documents** so re-ingest starts clean (the joined ones will attach to the existing transcript Meetings instead of leaving orphans).

### Tests
`test/lib/stacks/etl/meet` + `test/services/mcp` + rake: **59 runs, 0 failures** (3 pgvector skips, CI-mirror).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
