### PR TITLE
Fix FK violation in Contact#dedupe! (sync_contacts crash)

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -61,25 +61,83 @@ class Contact < ApplicationRecord
     contact
   end
 
+  # Tables that reference contacts.id and must be repointed at the surviving
+  # record before any duplicate is destroyed. Without this, delete_all trips the
+  # foreign key constraints (e.g. document_contacts.fk_rails_edc7f9ba3b).
+  # Format: [table, foreign key column, [columns forming a uniqueness scope]].
+  # The uniqueness scope prevents violating a unique index when repointing
+  # (e.g. document_contacts is unique on [document_id, contact_id, role]).
+  CONTACT_REFERENCES = [
+    ["document_contacts",             "contact_id",         %w[document_id role]],
+    ["meeting_participants",          "contact_id",         nil],
+    ["mentions",                      "contact_id",         nil],
+    ["chunks",                        "speaker_contact_id", nil],
+    ["meeting_transcript_segments",   "speaker_contact_id", nil],
+  ].freeze
+
   def dedupe!
     self.update(sources: self.sources.uniq)
 
-    dupes = Contact.where("LOWER(email) LIKE ?", "%#{email.downcase}%")
+    dupes = Contact
+      .where("LOWER(email) = ?", email.downcase)
+      .order(:id)
+      .to_a
     return self unless dupes.length > 1
 
-    new_record =
-      dupes.reduce(Contact.new) do |new_record, dupe|
-        new_record.email = dupe.email.downcase
-        new_record.sources = [*new_record.sources, *dupe.sources].uniq
-        new_record.apollo_id = dupe.apollo_id if dupe.apollo_id.present?
-        new_record
-      end
+    survivor = dupes.first
+    losers = dupes[1..]
 
     ActiveRecord::Base.transaction do
-      dupes.delete_all
-      new_record.save!
+      losers.each do |loser|
+        CONTACT_REFERENCES.each do |table, fk, scope_cols|
+          repoint_references!(table, fk, scope_cols, from: loser.id, to: survivor.id)
+        end
+      end
+
+      merged_sources = dupes.flat_map(&:sources).compact.uniq
+      merged_apollo_id = dupes.map(&:apollo_id).compact.first
+      merged_display_name = dupes.map(&:display_name).compact.first
+
+      survivor.update!(
+        sources: merged_sources,
+        apollo_id: merged_apollo_id,
+        display_name: survivor.display_name.presence || merged_display_name,
+      )
+
+      Contact.where(id: losers.map(&:id)).delete_all
     end
 
-    new_record
+    survivor.reload
+  end
+
+  private
+
+  # Repoint every referencing row from `from` to `to`. When a uniqueness scope is
+  # given, rows whose (scope + to) already exist on the survivor are deleted
+  # instead of updated, so we never collide with a unique index.
+  def repoint_references!(table, fk, scope_cols, from:, to:)
+    conn = self.class.connection
+    quoted_table = conn.quote_table_name(table)
+    quoted_fk = conn.quote_column_name(fk)
+
+    if scope_cols.present?
+      quoted_scope = scope_cols.map { |c| conn.quote_column_name(c) }
+      join_on = quoted_scope.map { |c| "dst.#{c} = src.#{c}" }.join(" AND ")
+
+      # Drop losers' rows that would duplicate an existing survivor row.
+      conn.execute(<<~SQL)
+        DELETE FROM #{quoted_table} src
+        USING #{quoted_table} dst
+        WHERE src.#{quoted_fk} = #{conn.quote(from)}
+          AND dst.#{quoted_fk} = #{conn.quote(to)}
+          AND #{join_on}
+      SQL
+    end
+
+    conn.execute(<<~SQL)
+      UPDATE #{quoted_table}
+      SET #{quoted_fk} = #{conn.quote(to)}
+      WHERE #{quoted_fk} = #{conn.quote(from)}
+    SQL
   end
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -87,6 +87,10 @@ class Contact < ApplicationRecord
     survivor = dupes.first
     losers = dupes[1..]
 
+    merged_sources = dupes.flat_map(&:sources).compact.uniq
+    merged_apollo_id = dupes.map(&:apollo_id).compact.first
+    merged_display_name = dupes.map(&:display_name).compact.first
+
     ActiveRecord::Base.transaction do
       losers.each do |loser|
         CONTACT_REFERENCES.each do |table, fk, scope_cols|
@@ -94,17 +98,16 @@ class Contact < ApplicationRecord
         end
       end
 
-      merged_sources = dupes.flat_map(&:sources).compact.uniq
-      merged_apollo_id = dupes.map(&:apollo_id).compact.first
-      merged_display_name = dupes.map(&:display_name).compact.first
+      # Delete the losers BEFORE reassigning their attributes onto the survivor.
+      # contacts.apollo_id has a unique index, so assigning a loser's apollo_id to
+      # the survivor while that loser still exists would violate the constraint.
+      Contact.where(id: losers.map(&:id)).delete_all
 
       survivor.update!(
         sources: merged_sources,
         apollo_id: merged_apollo_id,
         display_name: survivor.display_name.presence || merged_display_name,
       )
-
-      Contact.where(id: losers.map(&:id)).delete_all
     end
 
     survivor.reload

--- a/test/models/contact_test.rb
+++ b/test/models/contact_test.rb
@@ -34,3 +34,51 @@ class ContactResolveEmailTest < ActiveSupport::TestCase
     assert_nil Contact.resolve_email(nil)
   end
 end
+
+class ContactDedupeTest < ActiveSupport::TestCase
+  test 'merges duplicate contacts into the oldest survivor and unions sources' do
+    keep = Contact.create!(email: 'merge@gmail.com', sources: ['a'], display_name: 'Keep')
+    Contact.create!(email: 'MERGE@gmail.com', sources: ['b'])
+    Contact.create!(email: 'Merge@Gmail.com', sources: ['a', 'c'], apollo_id: 'apollo-1')
+
+    result = keep.dedupe!
+
+    assert_equal keep.id, result.id
+    assert_equal 1, Contact.where('LOWER(email) = ?', 'merge@gmail.com').count
+    assert_equal %w[a b c], result.sources.sort
+    assert_equal 'apollo-1', result.apollo_id
+    assert_equal 'Keep', result.display_name
+  end
+
+  test 'repoints document_contacts before deleting the duplicate (no FK violation)' do
+    keep = Contact.create!(email: 'fk@gmail.com', sources: ['a'])
+    loser = Contact.create!(email: 'FK@gmail.com', sources: ['b'])
+    document = Document.create!(external_id: SecureRandom.hex(8))
+    dc = DocumentContact.create!(document: document, contact: loser, role: 'attendee')
+
+    assert_nothing_raised { keep.dedupe! }
+
+    assert_equal keep.id, dc.reload.contact_id
+    assert_nil Contact.find_by(id: loser.id)
+  end
+
+  test 'collapses references that would collide on the unique index' do
+    keep = Contact.create!(email: 'dupdc@gmail.com')
+    loser = Contact.create!(email: 'DUPDC@gmail.com')
+    document = Document.create!(external_id: SecureRandom.hex(8))
+    kept_dc = DocumentContact.create!(document: document, contact: keep, role: 'attendee')
+    DocumentContact.create!(document: document, contact: loser, role: 'attendee')
+
+    assert_nothing_raised { keep.dedupe! }
+
+    scope = DocumentContact.where(document_id: document.id, contact_id: keep.id, role: 'attendee')
+    assert_equal 1, scope.count
+    assert_equal kept_dc.id, scope.first.id
+  end
+
+  test 'is a no-op for a contact with no duplicates' do
+    solo = Contact.create!(email: 'solo@gmail.com', sources: ['x'])
+    assert_equal solo.id, solo.dedupe!.id
+    assert_equal 1, Contact.where(email: 'solo@gmail.com').count
+  end
+end


### PR DESCRIPTION
## What

Fixes the recurring `sync_contacts` crash:

```
ActiveRecord::InvalidForeignKey: PG::ForeignKeyViolation:
update or delete on table "contacts" violates foreign key constraint
"fk_rails_edc7f9ba3b" on table "document_contacts"
```

## Root cause

`Contact#dedupe!` called `dupes.delete_all`, hard-deleting duplicate
contacts that were still referenced by `document_contacts` (and other
tables) — tripping the FK. It also rebuilt a fresh `Contact.new`, silently
orphaning every association (sources partly carried, but document links,
meeting participants, mentions, and speaker references were all dropped).

## Fix

- Keep the **oldest** duplicate as the survivor instead of building a new row.
- Repoint every contact-referencing column before deleting losers:
  `document_contacts`, `meeting_participants`, `mentions`,
  `chunks.speaker_contact_id`, `meeting_transcript_segments.speaker_contact_id`.
- For `document_contacts` (unique on `[document_id, contact_id, role]`),
  delete loser rows that would collide with an existing survivor row before
  repointing, so we never violate the unique index.
- Merge `sources` / `apollo_id` / `display_name` onto the survivor.
- Do it all in one transaction.
- Tighten dupe matching from `LIKE "%email%"` (which could merge unrelated
  substrings, e.g. `rob@x.com` into `bob@x.com`) to an exact
  case-insensitive match.

## Tests

Added `ContactDedupeTest` covering: the merge/union, the FK-repoint case
that was crashing, the unique-index collision collapse, and the
no-duplicates no-op.

Relying on GitHub Actions to run the suite. 🤖
