### PR TITLE
Add MCP finance tools: get_ar_aging + list_overdue_invoices (Stacksbot P1a)

### DIFF
--- a/app/models/qbo_invoice.rb
+++ b/app/models/qbo_invoice.rb
@@ -72,7 +72,9 @@ class QboInvoice < ApplicationRecord
   end
 
   def display_name
-    "##{data.dig("doc_number")} (#{ActionController::Base.helpers.number_to_currency(data.dig("total"))}) - #{data.dig("customer_ref", "name")} (#{status.to_s.humanize})"
+    # customer_ref can be malformed (e.g. a String) in synced jsonb — never raise here
+    customer_name = customer_ref.is_a?(Hash) ? customer_ref["name"] : nil
+    "##{data.dig("doc_number")} (#{ActionController::Base.helpers.number_to_currency(data.dig("total"))}) - #{customer_name} (#{status.to_s.humanize})"
   end
 
   def qbo_invoice_link

--- a/app/models/qbo_invoice.rb
+++ b/app/models/qbo_invoice.rb
@@ -28,6 +28,24 @@ class QboInvoice < ApplicationRecord
     scope.where("(qbo_invoices.qbo_account_id, qbo_invoices.qbo_id) NOT IN (#{values_sql})")
   }
 
+  # Synced, sent, still-owed invoices — filtered entirely in SQL. #data
+  # lazily re-fetches from the QBO API when the stored jsonb is empty, so
+  # any bulk read MUST use a scope like this one to avoid firing a live QBO
+  # request per empty row. The balance cast is wrapped in a CASE (Postgres
+  # does not guarantee AND short-circuit order) so a non-numeric balance is
+  # excluded rather than raising.
+  scope :open_receivables, -> {
+    where(<<~'SQL'.squish)
+      qbo_invoices.data IS NOT NULL
+      AND qbo_invoices.data <> '{}'::jsonb
+      AND qbo_invoices.data->>'due_date' IS NOT NULL
+      AND qbo_invoices.data->>'email_status' = 'EmailSent'
+      AND CASE WHEN qbo_invoices.data->>'balance' ~ '^-?\d+(\.\d+)?$'
+               THEN (qbo_invoices.data->>'balance')::numeric > 0
+               ELSE FALSE END
+    SQL
+  }
+
   def status
     if email_status == "EmailSent"
       overdue = (due_date - Date.today) < 0

--- a/app/models/qbo_invoice.rb
+++ b/app/models/qbo_invoice.rb
@@ -28,6 +28,13 @@ class QboInvoice < ApplicationRecord
     scope.where("(qbo_invoices.qbo_account_id, qbo_invoices.qbo_id) NOT IN (#{values_sql})")
   }
 
+  # Keep in sync by construction: open_receivables and
+  # malformed_sent_receivables share this regex, so they can never drift
+  # apart into overlapping or gapped predicates. Built via single-quoted
+  # heredoc + #sub (not #{}-interpolation) so the backslashes in the regex
+  # reach Postgres literally instead of being consumed by Ruby escaping.
+  BALANCE_NUMERIC_SQL_REGEX = '^-?\d+(\.\d+)?$'.freeze
+
   # Synced, sent, still-owed invoices — filtered entirely in SQL. #data
   # lazily re-fetches from the QBO API when the stored jsonb is empty, so
   # any bulk read MUST use a scope like this one to avoid firing a live QBO
@@ -38,12 +45,26 @@ class QboInvoice < ApplicationRecord
   # guarantee AND short-circuit order) so a non-numeric balance is excluded
   # rather than raising.
   scope :open_receivables, -> {
-    where(<<~'SQL'.squish)
+    where(<<~'SQL'.squish.sub('BALANCE_REGEX', BALANCE_NUMERIC_SQL_REGEX))
       qbo_invoices.data->>'due_date' IS NOT NULL
       AND qbo_invoices.data->>'email_status' = 'EmailSent'
-      AND CASE WHEN qbo_invoices.data->>'balance' ~ '^-?\d+(\.\d+)?$'
+      AND CASE WHEN qbo_invoices.data->>'balance' ~ 'BALANCE_REGEX'
                THEN (qbo_invoices.data->>'balance')::numeric > 0
                ELSE FALSE END
+    SQL
+  }
+
+  # Complement of open_receivables for observability: SENT invoices excluded
+  # for any reason other than being paid (numeric balance <= 0) are
+  # malformed — missing due_date, missing balance, or a non-numeric balance.
+  scope :malformed_sent_receivables, -> {
+    where(<<~'SQL'.squish.sub('BALANCE_REGEX', BALANCE_NUMERIC_SQL_REGEX))
+      qbo_invoices.data->>'email_status' = 'EmailSent'
+      AND (
+        qbo_invoices.data->>'due_date' IS NULL
+        OR qbo_invoices.data->>'balance' IS NULL
+        OR NOT (qbo_invoices.data->>'balance' ~ 'BALANCE_REGEX')
+      )
     SQL
   }
 
@@ -105,7 +126,11 @@ class QboInvoice < ApplicationRecord
     ref = data.dig("customer_ref")
     # customer_ref can be malformed (e.g. a String) in synced jsonb; always
     # hand callers a Hash so none of them re-inherit the String#[] trap.
-    ref.is_a?(Hash) ? ref : {}
+    return ref if ref.is_a?(Hash)
+    unless ref.nil?
+      Rails.logger.warn("[QboInvoice] id=#{id} qbo_id=#{qbo_id} has malformed customer_ref (#{ref.class}); treating as empty")
+    end
+    {}
   end
 
   # Destroying a QboInvoice cascades through the composite FK

--- a/app/models/qbo_invoice.rb
+++ b/app/models/qbo_invoice.rb
@@ -31,14 +31,15 @@ class QboInvoice < ApplicationRecord
   # Synced, sent, still-owed invoices — filtered entirely in SQL. #data
   # lazily re-fetches from the QBO API when the stored jsonb is empty, so
   # any bulk read MUST use a scope like this one to avoid firing a live QBO
-  # request per empty row. The balance cast is wrapped in a CASE (Postgres
-  # does not guarantee AND short-circuit order) so a non-numeric balance is
-  # excluded rather than raising.
+  # request per empty row. The ->> predicates below inherently exclude
+  # NULL/empty jsonb (->> on NULL/missing yields NULL, never a match), which
+  # is what guarantees #data's lazy live-QBO fetch can never fire from this
+  # scope. The balance cast is wrapped in a CASE (Postgres does not
+  # guarantee AND short-circuit order) so a non-numeric balance is excluded
+  # rather than raising.
   scope :open_receivables, -> {
     where(<<~'SQL'.squish)
-      qbo_invoices.data IS NOT NULL
-      AND qbo_invoices.data <> '{}'::jsonb
-      AND qbo_invoices.data->>'due_date' IS NOT NULL
+      qbo_invoices.data->>'due_date' IS NOT NULL
       AND qbo_invoices.data->>'email_status' = 'EmailSent'
       AND CASE WHEN qbo_invoices.data->>'balance' ~ '^-?\d+(\.\d+)?$'
                THEN (qbo_invoices.data->>'balance')::numeric > 0
@@ -72,8 +73,7 @@ class QboInvoice < ApplicationRecord
   end
 
   def display_name
-    # customer_ref can be malformed (e.g. a String) in synced jsonb — never raise here
-    customer_name = customer_ref.is_a?(Hash) ? customer_ref["name"] : nil
+    customer_name = customer_ref["name"]
     "##{data.dig("doc_number")} (#{ActionController::Base.helpers.number_to_currency(data.dig("total"))}) - #{customer_name} (#{status.to_s.humanize})"
   end
 
@@ -102,7 +102,10 @@ class QboInvoice < ApplicationRecord
   end
 
   def customer_ref
-    data.dig("customer_ref") || {}
+    ref = data.dig("customer_ref")
+    # customer_ref can be malformed (e.g. a String) in synced jsonb; always
+    # hand callers a Hash so none of them re-inherit the String#[] trap.
+    ref.is_a?(Hash) ? ref : {}
   end
 
   # Destroying a QboInvoice cascades through the composite FK

--- a/app/services/mcp/get_ar_aging_tool.rb
+++ b/app/services/mcp/get_ar_aging_tool.rb
@@ -30,10 +30,12 @@ module Mcp
         # a raw name aren't the same debtor just because they'd share the
         # 'Unknown' emission placeholder, so key those individually — by
         # doc_number, falling back to the invoice id (airtight: no two
-        # invoices share an id) so nil doc_numbers don't collide on "doc:".
+        # invoices share an id). Prefixes are split (not shared "doc:") so a
+        # doc_number that happens to match another row's invoice id can't
+        # collide on the same key.
         grouped = (receivables_by_enterprise[ent.id] || []).group_by do |r|
           r.customer_id.presence ||
-            (r.customer ? "name:#{r.customer}" : "doc:#{r.doc_number.presence || r.invoice_id}")
+            (r.customer ? "name:#{r.customer}" : (r.doc_number.present? ? "doc:#{r.doc_number}" : "inv:#{r.invoice_id}"))
         end
         total_cents = 0
         rows = grouped.map do |_key, rs|
@@ -45,7 +47,7 @@ module Mcp
             bucket_row['total'] += cents
           end
           total_cents += bucket_row['total']
-          { 'customer' => representative.customer || 'Unknown', 'customer_id' => representative.customer_id }
+          { 'customer' => representative.customer || 'Unknown', 'customer_id' => representative.customer_id.presence }
             .merge(bucket_row.transform_values { |cents| cents / 100.0 })
         end
         grand_total_cents += total_cents

--- a/app/services/mcp/get_ar_aging_tool.rb
+++ b/app/services/mcp/get_ar_aging_tool.rb
@@ -33,7 +33,7 @@ module Mcp
         end
         {
           enterprise: ent.name,
-          customers: rows.sort_by { |r| -r['total'] },
+          customers: rows.sort_by { |r| [-r['total'], r['customer'].to_s] },
           total_ar: rows.sum { |r| r['total'] }.round(2),
         }
       end

--- a/app/services/mcp/get_ar_aging_tool.rb
+++ b/app/services/mcp/get_ar_aging_tool.rb
@@ -1,0 +1,49 @@
+module Mcp
+  class GetArAgingTool < MCP::Tool
+    tool_name 'get_ar_aging'
+    description 'AR aging buckets (current/0-30/31-60/61-90/90+ days overdue) per customer ' \
+                'per enterprise, computed from already-synced QBO invoices. Never calls QBO live.'
+    input_schema(
+      properties: {
+        enterprise: { type: 'string', description: 'Optional enterprise name filter, e.g. "Sanctuary Computer Inc"' },
+      },
+      required: []
+    )
+    annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true)
+
+    BUCKETS = %w[current days_0_30 days_31_60 days_61_90 days_90_plus].freeze
+
+    def self.call(enterprise: nil, server_context:)
+      enterprises, error = QboReceivables.resolve_enterprises(enterprise)
+      return QboReceivables.error_response(error) if error
+
+      as_of = Date.today
+      enterprise_payloads = enterprises.map do |ent|
+        customers = Hash.new { |h, k| h[k] = BUCKETS.index_with { 0.0 }.merge('total' => 0.0) }
+        QboReceivables.receivables(ent).each do |inv|
+          bucket = QboReceivables.bucket_key(QboReceivables.days_overdue(inv, as_of))
+          row = customers[inv.customer_ref['name'] || 'Unknown']
+          row[bucket] += inv.balance
+          row['total'] += inv.balance
+        rescue StandardError
+          next # malformed synced row — skip it, never fail the whole report
+        end
+        rows = customers.map do |name, row|
+          { 'customer' => name }.merge(row.transform_values { |v| v.round(2) })
+        end
+        {
+          enterprise: ent.name,
+          customers: rows.sort_by { |r| -r['total'] },
+          total_ar: rows.sum { |r| r['total'] }.round(2),
+        }
+      end
+
+      payload = {
+        as_of: as_of.iso8601,
+        enterprises: enterprise_payloads,
+        total_ar: enterprise_payloads.sum { |e| e[:total_ar] }.round(2),
+      }
+      MCP::Tool::Response.new([{ type: 'text', text: payload.to_json }])
+    end
+  end
+end

--- a/app/services/mcp/get_ar_aging_tool.rb
+++ b/app/services/mcp/get_ar_aging_tool.rb
@@ -21,22 +21,12 @@ module Mcp
 
       grand_total_cents = 0
       enterprise_payloads = enterprises.map do |ent|
-        # Accumulate integer cents so the five buckets always sum exactly to
-        # 'total' and customer totals to 'total_ar' — independent float
-        # rounding can otherwise cross-foot off by a cent.
-        # Group by customer_id (name-keyed only for id-less rows) so a QBO
-        # customer renamed between syncs (same customer_id, drifted display
-        # name) doesn't split into multiple rows. Rows with neither an id nor
-        # a raw name aren't the same debtor just because they'd share the
-        # 'Unknown' emission placeholder, so key those individually — by
-        # doc_number, falling back to the invoice id (airtight: no two
-        # invoices share an id). Prefixes are split (not shared "doc:") so a
-        # doc_number that happens to match another row's invoice id can't
-        # collide on the same key.
-        grouped = (receivables_by_enterprise[ent.id] || []).group_by do |r|
-          r.customer_id.presence ||
-            (r.customer ? "name:#{r.customer}" : (r.doc_number.present? ? "doc:#{r.doc_number}" : "inv:#{r.invoice_id}"))
-        end
+        # Accumulate integer cents so every emitted value is a decimal-exact
+        # cent amount and buckets sum to 'total' exactly in decimal. (A
+        # consumer re-summing the parsed IEEE doubles can still see epsilon
+        # artifacts like 0.1 + 0.2 — inherent to JSON numbers, not to this
+        # report.) Grouping semantics live on Receivable#customer_key.
+        grouped = (receivables_by_enterprise[ent.id] || []).group_by(&:customer_key)
         total_cents = 0
         rows = grouped.map do |_key, rs|
           representative = rs.max_by(&:due_date)

--- a/app/services/mcp/get_ar_aging_tool.rb
+++ b/app/services/mcp/get_ar_aging_tool.rb
@@ -19,32 +19,40 @@ module Mcp
       as_of = Date.today
       receivables_by_enterprise = QboReceivables.receivables(enterprises, as_of: as_of).group_by(&:enterprise_id)
 
+      grand_total_cents = 0
       enterprise_payloads = enterprises.map do |ent|
         # Accumulate integer cents so the five buckets always sum exactly to
         # 'total' and customer totals to 'total_ar' — independent float
         # rounding can otherwise cross-foot off by a cent.
-        customers = Hash.new { |h, k| h[k] = QboReceivables::BUCKETS.index_with { 0 }.merge('total' => 0) }
-        (receivables_by_enterprise[ent.id] || []).each do |r|
-          cents = (r.balance * 100).round
-          row = customers[[r.customer_id, r.customer]]
-          row[QboReceivables.bucket_key(r.days_overdue)] += cents
-          row['total'] += cents
+        # Group by customer_id (name-keyed only for id-less rows) so a QBO
+        # customer renamed between syncs (same customer_id, drifted display
+        # name) doesn't split into multiple rows.
+        grouped = (receivables_by_enterprise[ent.id] || []).group_by { |r| r.customer_id || "name:#{r.customer}" }
+        total_cents = 0
+        rows = grouped.map do |_key, rs|
+          representative = rs.max_by(&:due_date)
+          bucket_row = QboReceivables::BUCKETS.index_with { 0 }.merge('total' => 0)
+          rs.each do |r|
+            cents = (r.balance * 100).round
+            bucket_row[QboReceivables.bucket_key(r.days_overdue)] += cents
+            bucket_row['total'] += cents
+          end
+          total_cents += bucket_row['total']
+          { 'customer' => representative.customer, 'customer_id' => representative.customer_id }
+            .merge(bucket_row.transform_values { |cents| cents / 100.0 })
         end
-        rows = customers.map do |(customer_id, customer), row|
-          { 'customer' => customer, 'customer_id' => customer_id }
-            .merge(row.transform_values { |cents| cents / 100.0 })
-        end
+        grand_total_cents += total_cents
         {
           enterprise: ent.name,
           customers: rows.sort_by { |r| [-r['total'], r['customer'].to_s] },
-          total_ar: customers.values.sum { |row| row['total'] } / 100.0,
+          total_ar: total_cents / 100.0,
         }
       end
 
       payload = {
         as_of: as_of.iso8601,
         enterprises: enterprise_payloads,
-        total_ar: enterprise_payloads.sum { |e| e[:total_ar] }.round(2),
+        total_ar: grand_total_cents / 100.0,
       }
       MCP::Tool::Response.new([{ type: 'text', text: payload.to_json }])
     end

--- a/app/services/mcp/get_ar_aging_tool.rb
+++ b/app/services/mcp/get_ar_aging_tool.rb
@@ -26,8 +26,13 @@ module Mcp
         # rounding can otherwise cross-foot off by a cent.
         # Group by customer_id (name-keyed only for id-less rows) so a QBO
         # customer renamed between syncs (same customer_id, drifted display
-        # name) doesn't split into multiple rows.
-        grouped = (receivables_by_enterprise[ent.id] || []).group_by { |r| r.customer_id || "name:#{r.customer}" }
+        # name) doesn't split into multiple rows. Rows with neither an id nor
+        # a name (both defaulted to 'Unknown') aren't the same debtor just
+        # because they share a placeholder name, so key those individually by
+        # doc_number rather than pooling unrelated debtors into one row.
+        grouped = (receivables_by_enterprise[ent.id] || []).group_by do |r|
+          r.customer_id.presence || (r.customer == 'Unknown' ? "doc:#{r.doc_number}" : "name:#{r.customer}")
+        end
         total_cents = 0
         rows = grouped.map do |_key, rs|
           representative = rs.max_by(&:due_date)

--- a/app/services/mcp/get_ar_aging_tool.rb
+++ b/app/services/mcp/get_ar_aging_tool.rb
@@ -1,8 +1,9 @@
 module Mcp
   class GetArAgingTool < MCP::Tool
     tool_name 'get_ar_aging'
-    description 'AR aging buckets (current/0-30/31-60/61-90/90+ days overdue) per customer ' \
-                'per enterprise, computed from already-synced QBO invoices. Never calls QBO live.'
+    description 'AR aging buckets (current = not yet due, then 1-30/31-60/61-90/over-90 days ' \
+                'overdue) per customer per enterprise, computed from already-synced QBO ' \
+                'invoices. Never calls QBO live.'
     input_schema(
       properties: {
         enterprise: { type: 'string', description: 'Optional enterprise name filter, e.g. "Sanctuary Computer Inc"' },
@@ -11,22 +12,22 @@ module Mcp
     )
     annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true)
 
-    BUCKETS = %w[current days_0_30 days_31_60 days_61_90 days_90_plus].freeze
+    BUCKETS = %w[current days_1_30 days_31_60 days_61_90 days_over_90].freeze
 
     def self.call(enterprise: nil, server_context:)
       enterprises, error = QboReceivables.resolve_enterprises(enterprise)
       return QboReceivables.error_response(error) if error
 
       as_of = Date.today
+      receivables_by_enterprise = QboReceivables.receivables(enterprises, as_of: as_of).group_by(&:enterprise_id)
+
       enterprise_payloads = enterprises.map do |ent|
         customers = Hash.new { |h, k| h[k] = BUCKETS.index_with { 0.0 }.merge('total' => 0.0) }
-        QboReceivables.receivables(ent).each do |inv|
-          bucket = QboReceivables.bucket_key(QboReceivables.days_overdue(inv, as_of))
-          row = customers[inv.customer_ref['name'] || 'Unknown']
-          row[bucket] += inv.balance
-          row['total'] += inv.balance
-        rescue StandardError
-          next # malformed synced row — skip it, never fail the whole report
+        (receivables_by_enterprise[ent.id] || []).each do |r|
+          bucket = QboReceivables.bucket_key(r.days_overdue)
+          row = customers[r.customer]
+          row[bucket] += r.balance
+          row['total'] += r.balance
         end
         rows = customers.map do |name, row|
           { 'customer' => name }.merge(row.transform_values { |v| v.round(2) })

--- a/app/services/mcp/get_ar_aging_tool.rb
+++ b/app/services/mcp/get_ar_aging_tool.rb
@@ -14,7 +14,7 @@ module Mcp
 
     def self.call(enterprise: nil, server_context:)
       enterprises, error = QboReceivables.resolve_enterprises(enterprise)
-      return QboReceivables.error_response(error) if error
+      return Responses.error(error) if error
 
       as_of = Date.today
       receivables_by_enterprise = QboReceivables.receivables(enterprises, as_of: as_of).group_by(&:enterprise_id)
@@ -27,11 +27,13 @@ module Mcp
         # Group by customer_id (name-keyed only for id-less rows) so a QBO
         # customer renamed between syncs (same customer_id, drifted display
         # name) doesn't split into multiple rows. Rows with neither an id nor
-        # a name (both defaulted to 'Unknown') aren't the same debtor just
-        # because they share a placeholder name, so key those individually by
-        # doc_number rather than pooling unrelated debtors into one row.
+        # a raw name aren't the same debtor just because they'd share the
+        # 'Unknown' emission placeholder, so key those individually — by
+        # doc_number, falling back to the invoice id (airtight: no two
+        # invoices share an id) so nil doc_numbers don't collide on "doc:".
         grouped = (receivables_by_enterprise[ent.id] || []).group_by do |r|
-          r.customer_id.presence || (r.customer == 'Unknown' ? "doc:#{r.doc_number}" : "name:#{r.customer}")
+          r.customer_id.presence ||
+            (r.customer ? "name:#{r.customer}" : "doc:#{r.doc_number.presence || r.invoice_id}")
         end
         total_cents = 0
         rows = grouped.map do |_key, rs|
@@ -43,7 +45,7 @@ module Mcp
             bucket_row['total'] += cents
           end
           total_cents += bucket_row['total']
-          { 'customer' => representative.customer, 'customer_id' => representative.customer_id }
+          { 'customer' => representative.customer || 'Unknown', 'customer_id' => representative.customer_id }
             .merge(bucket_row.transform_values { |cents| cents / 100.0 })
         end
         grand_total_cents += total_cents
@@ -59,7 +61,7 @@ module Mcp
         enterprises: enterprise_payloads,
         total_ar: grand_total_cents / 100.0,
       }
-      MCP::Tool::Response.new([{ type: 'text', text: payload.to_json }])
+      Responses.ok(payload)
     end
   end
 end

--- a/app/services/mcp/get_ar_aging_tool.rb
+++ b/app/services/mcp/get_ar_aging_tool.rb
@@ -12,8 +12,6 @@ module Mcp
     )
     annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true)
 
-    BUCKETS = %w[current days_1_30 days_31_60 days_61_90 days_over_90].freeze
-
     def self.call(enterprise: nil, server_context:)
       enterprises, error = QboReceivables.resolve_enterprises(enterprise)
       return QboReceivables.error_response(error) if error
@@ -22,7 +20,7 @@ module Mcp
       receivables_by_enterprise = QboReceivables.receivables(enterprises, as_of: as_of).group_by(&:enterprise_id)
 
       enterprise_payloads = enterprises.map do |ent|
-        customers = Hash.new { |h, k| h[k] = BUCKETS.index_with { 0.0 }.merge('total' => 0.0) }
+        customers = Hash.new { |h, k| h[k] = QboReceivables::BUCKETS.index_with { 0.0 }.merge('total' => 0.0) }
         (receivables_by_enterprise[ent.id] || []).each do |r|
           bucket = QboReceivables.bucket_key(r.days_overdue)
           row = customers[r.customer]

--- a/app/services/mcp/get_ar_aging_tool.rb
+++ b/app/services/mcp/get_ar_aging_tool.rb
@@ -20,20 +20,24 @@ module Mcp
       receivables_by_enterprise = QboReceivables.receivables(enterprises, as_of: as_of).group_by(&:enterprise_id)
 
       enterprise_payloads = enterprises.map do |ent|
-        customers = Hash.new { |h, k| h[k] = QboReceivables::BUCKETS.index_with { 0.0 }.merge('total' => 0.0) }
+        # Accumulate integer cents so the five buckets always sum exactly to
+        # 'total' and customer totals to 'total_ar' — independent float
+        # rounding can otherwise cross-foot off by a cent.
+        customers = Hash.new { |h, k| h[k] = QboReceivables::BUCKETS.index_with { 0 }.merge('total' => 0) }
         (receivables_by_enterprise[ent.id] || []).each do |r|
-          bucket = QboReceivables.bucket_key(r.days_overdue)
-          row = customers[r.customer]
-          row[bucket] += r.balance
-          row['total'] += r.balance
+          cents = (r.balance * 100).round
+          row = customers[[r.customer_id, r.customer]]
+          row[QboReceivables.bucket_key(r.days_overdue)] += cents
+          row['total'] += cents
         end
-        rows = customers.map do |name, row|
-          { 'customer' => name }.merge(row.transform_values { |v| v.round(2) })
+        rows = customers.map do |(customer_id, customer), row|
+          { 'customer' => customer, 'customer_id' => customer_id }
+            .merge(row.transform_values { |cents| cents / 100.0 })
         end
         {
           enterprise: ent.name,
           customers: rows.sort_by { |r| [-r['total'], r['customer'].to_s] },
-          total_ar: rows.sum { |r| r['total'] }.round(2),
+          total_ar: customers.values.sum { |row| row['total'] } / 100.0,
         }
       end
 

--- a/app/services/mcp/get_document_tool.rb
+++ b/app/services/mcp/get_document_tool.rb
@@ -7,7 +7,7 @@ module Mcp
 
     def self.call(id:, server_context:)
       doc = Document.corpus_eligible.find_by(id: id)
-      return MCP::Tool::Response.new([{ type: 'text', text: { error: 'Document not found' }.to_json }]) unless doc
+      return Responses.error('Document not found') unless doc
 
       meeting = doc.source_record
       segments = meeting.is_a?(Meeting) ? meeting.segments.order(:position).map { |s| { speaker: s.speaker_name, text: s.text } } : []

--- a/app/services/mcp/get_document_tool.rb
+++ b/app/services/mcp/get_document_tool.rb
@@ -11,7 +11,7 @@ module Mcp
 
       meeting = doc.source_record
       segments = meeting.is_a?(Meeting) ? meeting.segments.order(:position).map { |s| { speaker: s.speaker_name, text: s.text } } : []
-      MCP::Tool::Response.new([{ type: 'text', text: { id: doc.id, title: doc.title, url: doc.url, occurred_at: doc.occurred_at, segments: segments }.to_json }])
+      Responses.ok({ id: doc.id, title: doc.title, url: doc.url, occurred_at: doc.occurred_at, segments: segments })
     end
   end
 end

--- a/app/services/mcp/list_documents_tool.rb
+++ b/app/services/mcp/list_documents_tool.rb
@@ -18,7 +18,7 @@ module Mcp
       scope = scope.where(occurred_at: range) if range
       scope = scope.order(occurred_at: :desc).offset(offset).limit(limit)
       payload = scope.map { |d| { id: d.id, title: d.title, source: d.source, occurred_at: d.occurred_at } }
-      MCP::Tool::Response.new([{ type: 'text', text: payload.to_json }])
+      Responses.ok(payload)
     end
   end
 end

--- a/app/services/mcp/list_overdue_invoices_tool.rb
+++ b/app/services/mcp/list_overdue_invoices_tool.rb
@@ -21,7 +21,7 @@ module Mcp
       min_days = [min_days_overdue.to_i, 1].max
       enterprise_names = enterprises.index_by(&:id)
 
-      invoices = QboReceivables.receivables(enterprises, as_of: as_of)
+      invoices = QboReceivables.receivables(enterprises, as_of: as_of, details: true)
         .select { |r| r.days_overdue >= min_days }
         .map do |r|
           {

--- a/app/services/mcp/list_overdue_invoices_tool.rb
+++ b/app/services/mcp/list_overdue_invoices_tool.rb
@@ -7,40 +7,37 @@ module Mcp
     input_schema(
       properties: {
         enterprise: { type: 'string', description: 'Optional enterprise name filter, e.g. "Sanctuary Computer Inc"' },
-        min_days_overdue: { type: 'integer', description: 'Only invoices at least this many days overdue (default 1)' },
+        min_days_overdue: { type: 'integer', description: 'Only invoices at least this many days overdue (default 1; minimum 1 — values below 1 are treated as 1)' },
       },
       required: []
     )
     annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true)
-
-    OVERDUE_STATUSES = %i[unpaid_overdue partially_paid_overdue].freeze
 
     def self.call(enterprise: nil, min_days_overdue: 1, server_context:)
       enterprises, error = QboReceivables.resolve_enterprises(enterprise)
       return QboReceivables.error_response(error) if error
 
       as_of = Date.today
-      invoices = enterprises.flat_map do |ent|
-        QboReceivables.receivables(ent).filter_map do |inv|
-          next unless OVERDUE_STATUSES.include?(inv.status)
-          days = QboReceivables.days_overdue(inv, as_of)
-          next if days < min_days_overdue.to_i
+      min_days = [min_days_overdue.to_i, 1].max
+      enterprise_names = enterprises.index_by(&:id)
+
+      invoices = QboReceivables.receivables(enterprises, as_of: as_of)
+        .select { |r| r.days_overdue >= min_days }
+        .map do |r|
           {
-            doc_number: inv.data['doc_number'],
-            customer: inv.customer_ref['name'] || 'Unknown',
-            enterprise: ent.name,
-            total: inv.total,
-            balance: inv.balance,
-            due_date: inv.due_date.iso8601,
-            days_overdue: days,
-            status: inv.status,
-            qbo_invoice_link: inv.qbo_invoice_link,
-            display_name: inv.display_name,
+            doc_number: r.doc_number,
+            customer: r.customer,
+            enterprise: enterprise_names[r.enterprise_id].name,
+            total: r.total,
+            balance: r.balance,
+            due_date: r.due_date.iso8601,
+            days_overdue: r.days_overdue,
+            status: r.status,
+            qbo_invoice_link: r.qbo_invoice_link,
+            display_name: r.display_name,
           }
-        rescue StandardError
-          nil # malformed synced row — skip it, never fail the whole report
         end
-      end.sort_by { |row| [-row[:days_overdue], row[:doc_number].to_s] }
+        .sort_by { |row| [-row[:days_overdue], row[:doc_number].to_s] }
 
       payload = { as_of: as_of.iso8601, count: invoices.length, invoices: invoices }
       MCP::Tool::Response.new([{ type: 'text', text: payload.to_json }])

--- a/app/services/mcp/list_overdue_invoices_tool.rb
+++ b/app/services/mcp/list_overdue_invoices_tool.rb
@@ -27,7 +27,7 @@ module Mcp
           next if days < min_days_overdue.to_i
           {
             doc_number: inv.data['doc_number'],
-            customer: inv.customer_ref['name'],
+            customer: inv.customer_ref['name'] || 'Unknown',
             enterprise: ent.name,
             total: inv.total,
             balance: inv.balance,
@@ -40,7 +40,7 @@ module Mcp
         rescue StandardError
           nil # malformed synced row — skip it, never fail the whole report
         end
-      end.sort_by { |row| -row[:days_overdue] }
+      end.sort_by { |row| [-row[:days_overdue], row[:doc_number].to_s] }
 
       payload = { as_of: as_of.iso8601, count: invoices.length, invoices: invoices }
       MCP::Tool::Response.new([{ type: 'text', text: payload.to_json }])

--- a/app/services/mcp/list_overdue_invoices_tool.rb
+++ b/app/services/mcp/list_overdue_invoices_tool.rb
@@ -1,0 +1,49 @@
+module Mcp
+  class ListOverdueInvoicesTool < MCP::Tool
+    tool_name 'list_overdue_invoices'
+    description 'Overdue (unpaid or partially-paid) QBO invoices with days overdue, sorted ' \
+                'most-overdue first, from already-synced rows. Never calls QBO live. Late fees ' \
+                'are a per-client human decision — this tool exposes the data only.'
+    input_schema(
+      properties: {
+        enterprise: { type: 'string', description: 'Optional enterprise name filter, e.g. "Sanctuary Computer Inc"' },
+        min_days_overdue: { type: 'integer', description: 'Only invoices at least this many days overdue (default 1)' },
+      },
+      required: []
+    )
+    annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true)
+
+    OVERDUE_STATUSES = %i[unpaid_overdue partially_paid_overdue].freeze
+
+    def self.call(enterprise: nil, min_days_overdue: 1, server_context:)
+      enterprises, error = QboReceivables.resolve_enterprises(enterprise)
+      return QboReceivables.error_response(error) if error
+
+      as_of = Date.today
+      invoices = enterprises.flat_map do |ent|
+        QboReceivables.receivables(ent).filter_map do |inv|
+          next unless OVERDUE_STATUSES.include?(inv.status)
+          days = QboReceivables.days_overdue(inv, as_of)
+          next if days < min_days_overdue.to_i
+          {
+            doc_number: inv.data['doc_number'],
+            customer: inv.customer_ref['name'],
+            enterprise: ent.name,
+            total: inv.total,
+            balance: inv.balance,
+            due_date: inv.due_date.iso8601,
+            days_overdue: days,
+            status: inv.status,
+            qbo_invoice_link: inv.qbo_invoice_link,
+            display_name: inv.display_name,
+          }
+        rescue StandardError
+          nil # malformed synced row — skip it, never fail the whole report
+        end
+      end.sort_by { |row| -row[:days_overdue] }
+
+      payload = { as_of: as_of.iso8601, count: invoices.length, invoices: invoices }
+      MCP::Tool::Response.new([{ type: 'text', text: payload.to_json }])
+    end
+  end
+end

--- a/app/services/mcp/list_overdue_invoices_tool.rb
+++ b/app/services/mcp/list_overdue_invoices_tool.rb
@@ -21,12 +21,14 @@ module Mcp
       min_days = [min_days_overdue.to_i, 1].max
       enterprise_names = enterprises.index_by(&:id)
 
-      invoices = QboReceivables.receivables(enterprises, as_of: as_of, details: true)
-        .select { |r| r.days_overdue >= min_days }
+      rows = QboReceivables.receivables(enterprises, as_of: as_of, details: true, min_days_overdue: min_days)
+
+      invoices = rows
         .map do |r|
           {
             doc_number: r.doc_number,
             customer: r.customer,
+            customer_id: r.customer_id,
             enterprise: enterprise_names[r.enterprise_id].name,
             total: r.total,
             balance: r.balance,

--- a/app/services/mcp/list_overdue_invoices_tool.rb
+++ b/app/services/mcp/list_overdue_invoices_tool.rb
@@ -15,7 +15,7 @@ module Mcp
 
     def self.call(enterprise: nil, min_days_overdue: 1, server_context:)
       enterprises, error = QboReceivables.resolve_enterprises(enterprise)
-      return QboReceivables.error_response(error) if error
+      return Responses.error(error) if error
 
       as_of = Date.today
       min_days = [min_days_overdue.to_i, 1].max
@@ -27,7 +27,7 @@ module Mcp
         .map do |r|
           {
             doc_number: r.doc_number,
-            customer: r.customer,
+            customer: r.customer || 'Unknown',
             customer_id: r.customer_id,
             enterprise: enterprise_names[r.enterprise_id].name,
             total: r.total,
@@ -42,7 +42,7 @@ module Mcp
         .sort_by { |row| [-row[:days_overdue], row[:doc_number].to_s] }
 
       payload = { as_of: as_of.iso8601, count: invoices.length, invoices: invoices }
-      MCP::Tool::Response.new([{ type: 'text', text: payload.to_json }])
+      Responses.ok(payload)
     end
   end
 end

--- a/app/services/mcp/list_overdue_invoices_tool.rb
+++ b/app/services/mcp/list_overdue_invoices_tool.rb
@@ -28,7 +28,7 @@ module Mcp
           {
             doc_number: r.doc_number,
             customer: r.customer || 'Unknown',
-            customer_id: r.customer_id,
+            customer_id: r.customer_id.presence, # blank ids emit as null, matching get_ar_aging
             enterprise: enterprise_names[r.enterprise_id].name,
             total: r.total,
             balance: r.balance,

--- a/app/services/mcp/list_sources_tool.rb
+++ b/app/services/mcp/list_sources_tool.rb
@@ -7,7 +7,7 @@ module Mcp
 
     def self.call(server_context:)
       payload = SourceSync.all.map { |s| { source: s.source, last_run_at: s.last_run_at, status: s.status, stats: s.stats } }
-      MCP::Tool::Response.new([{ type: 'text', text: payload.to_json }])
+      Responses.ok(payload)
     end
   end
 end

--- a/app/services/mcp/qbo_receivables.rb
+++ b/app/services/mcp/qbo_receivables.rb
@@ -41,7 +41,22 @@ module Mcp
         .where(qbo_accounts: { enterprise_id: enterprises.map(&:id) })
         .pluck(:id, :qbo_id)
       if malformed.any?
-        Rails.logger.warn("[Mcp::QboReceivables] #{malformed.size} invoice(s) excluded as malformed (missing due_date/balance or non-numeric balance): #{malformed.map { |id, qbo_id| "id=#{id} qbo_id=#{qbo_id}" }.join(', ')}")
+        warn_pairs("#{malformed.size} invoice(s) excluded as malformed (missing due_date/balance or non-numeric balance)", malformed)
+      end
+
+      # Rows with NULL/empty jsonb data are excluded by open_receivables by
+      # design (the no-live-QBO rule above) but the malformed check above
+      # can't see them either — its email_status predicate reads the same
+      # missing jsonb, so it's NULL, not true, and the row never counts as
+      # malformed. Surface them separately so a mass-unsynced state (e.g. a
+      # broken sync job) doesn't silently read as "nothing outstanding".
+      unsynced = QboInvoice
+        .joins(:qbo_account)
+        .where(qbo_accounts: { enterprise_id: enterprises.map(&:id) })
+        .where("qbo_invoices.data IS NULL OR qbo_invoices.data = '{}'::jsonb")
+        .pluck(:id, :qbo_id)
+      if unsynced.any?
+        warn_pairs("#{unsynced.size} invoice row(s) have no synced data and are excluded (cannot evaluate)", unsynced)
       end
 
       QboInvoice
@@ -51,6 +66,16 @@ module Mcp
         .select('qbo_invoices.*, qbo_accounts.enterprise_id AS enterprise_id')
         .filter_map { |inv| build_receivable(inv, as_of, details: details, min_days_overdue: min_days_overdue) }
     end
+
+    # Logs prefix plus a colon-separated sample of at most the first 20
+    # id/qbo_id pairs — a bad sync can otherwise blow this up into an
+    # unbounded log line.
+    def self.warn_pairs(prefix, pairs)
+      sample = pairs.first(20).map { |id, qbo_id| "id=#{id} qbo_id=#{qbo_id}" }.join(', ')
+      suffix = pairs.size > 20 ? ' (showing first 20)' : ''
+      Rails.logger.warn("[Mcp::QboReceivables] #{prefix}: #{sample}#{suffix}")
+    end
+    private_class_method :warn_pairs
 
     BUCKETS = %w[current days_1_30 days_31_60 days_61_90 days_over_90].freeze
 
@@ -68,7 +93,7 @@ module Mcp
       balance = Float(inv.data['balance'])
       days_overdue = (as_of - due_date).to_i
       return nil if min_days_overdue && days_overdue < min_days_overdue
-      total = details ? (Float(inv.data['total']) rescue nil) : nil # total is display-only; a receivable with unknown total still owes its balance
+      total = details ? Float(inv.data['total'], exception: false) : nil # total is display-only; a receivable with unknown total still owes its balance
       ref = inv.customer_ref
       Receivable.new(
         invoice_id: inv.id,

--- a/app/services/mcp/qbo_receivables.rb
+++ b/app/services/mcp/qbo_receivables.rb
@@ -6,26 +6,6 @@ module Mcp
   # Receivable structs; malformed rows are dropped here, so consumers never
   # need their own rescue-and-skip.
   module QboReceivables
-    # Open, sent receivables only — filtered in SQL so years of paid/unsent
-    # history never leave Postgres. The balance cast is wrapped in a CASE
-    # (Postgres does not guarantee AND short-circuit order) so a non-numeric
-    # balance is excluded rather than raising.
-    #
-    # NOTE: uses a single-quoted heredoc terminator (<<~'SQL') so the \d and
-    # \. escapes below reach Postgres literally. A plain <<~SQL heredoc
-    # follows Ruby double-quoted-string escape rules, which silently strip
-    # the backslash from unrecognized escapes like \d (i.e. "\d" becomes
-    # "d"), corrupting the regex.
-    RECEIVABLE_ROWS_SQL = <<~'SQL'.squish.freeze
-      qbo_invoices.data IS NOT NULL
-      AND qbo_invoices.data <> '{}'::jsonb
-      AND qbo_invoices.data->>'due_date' IS NOT NULL
-      AND qbo_invoices.data->>'email_status' = 'EmailSent'
-      AND CASE WHEN qbo_invoices.data->>'balance' ~ '^-?\d+(\.\d+)?$'
-               THEN (qbo_invoices.data->>'balance')::numeric > 0
-               ELSE FALSE END
-    SQL
-
     Receivable = Struct.new(
       :enterprise_id, :doc_number, :customer, :total, :balance,
       :due_date, :days_overdue, :status, :qbo_invoice_link, :display_name,
@@ -43,15 +23,17 @@ module Mcp
     end
 
     # One query for all enterprises; one parse per row; malformed rows dropped.
-    def self.receivables(enterprises, as_of: Date.today)
-      QboInvoice
+    def self.receivables(enterprises, as_of: Date.today, details: false)
+      QboInvoice.open_receivables
         .joins(:qbo_account)
         .where(qbo_accounts: { enterprise_id: enterprises.map(&:id) })
-        .where(RECEIVABLE_ROWS_SQL)
         .select('qbo_invoices.*, qbo_accounts.enterprise_id AS enterprise_id')
-        .filter_map { |inv| build_receivable(inv, as_of) }
+        .filter_map { |inv| build_receivable(inv, as_of, details) }
     end
 
+    BUCKETS = %w[current days_1_30 days_31_60 days_61_90 days_over_90].freeze
+
+    # bucket_key must only ever return a member of BUCKETS.
     def self.bucket_key(days_overdue)
       return 'current' if days_overdue <= 0
       return 'days_1_30' if days_overdue <= 30
@@ -64,18 +46,11 @@ module Mcp
       MCP::Tool::Response.new([{ type: 'text', text: { error: message }.to_json }])
     end
 
-    def self.build_receivable(inv, as_of)
+    def self.build_receivable(inv, as_of, details)
       due_date = inv.due_date
-      balance = inv.balance
-      total = inv.total
+      balance = Float(inv.data['balance'])
+      total = Float(inv.data['total'])
       days_overdue = (as_of - due_date).to_i
-      partially_paid = balance != total
-      status =
-        if days_overdue.positive?
-          partially_paid ? :partially_paid_overdue : :unpaid_overdue
-        else
-          partially_paid ? :partially_paid : :unpaid
-        end
       Receivable.new(
         enterprise_id: inv[:enterprise_id],
         doc_number: inv.data['doc_number'],
@@ -84,9 +59,9 @@ module Mcp
         balance: balance,
         due_date: due_date,
         days_overdue: days_overdue,
-        status: status,
-        qbo_invoice_link: inv.qbo_invoice_link,
-        display_name: inv.display_name
+        status: inv.status,
+        qbo_invoice_link: details ? inv.qbo_invoice_link : nil,
+        display_name: details ? inv.display_name : nil
       )
     rescue StandardError
       nil # malformed synced row — drop it here, the single enforcement point

--- a/app/services/mcp/qbo_receivables.rb
+++ b/app/services/mcp/qbo_receivables.rb
@@ -7,28 +7,33 @@ module Mcp
   # need their own rescue-and-skip.
   module QboReceivables
     Receivable = Struct.new(
-      :enterprise_id, :doc_number, :customer, :total, :balance,
+      :enterprise_id, :doc_number, :customer_id, :customer, :total, :balance,
       :due_date, :days_overdue, :status, :qbo_invoice_link, :display_name,
       keyword_init: true
     )
 
     def self.resolve_enterprises(name)
       scope = Enterprise.joins(:qbo_account).distinct.order(:name)
+      name = name.to_s.strip # LLM callers pad names with whitespace
       return [scope.to_a, nil] if name.blank?
       # Match in Ruby (Unicode-aware casecmp?), not SQL LOWER(), so non-ASCII
       # names resolve regardless of the database collation. Tiny table.
-      matches = scope.to_a.select { |e| e.name.casecmp?(name.to_s) }
+      matches = scope.to_a.select { |e| e.name.casecmp?(name) }
       return [matches, nil] if matches.any?
       [nil, "Unknown enterprise '#{name}'. Valid enterprises: #{scope.pluck(:name).join(', ')}"]
     end
 
-    # One query for all enterprises; one parse per row; malformed rows dropped.
-    def self.receivables(enterprises, as_of: Date.today, details: false)
-      QboInvoice.open_receivables
+    # One query for all enterprises; one parse per row; malformed rows dropped
+    # (with a warn — a silent mass-drop must not read as "nothing outstanding").
+    # min_days_overdue filters BEFORE detail fields are computed so discarded
+    # rows never pay for currency formatting.
+    def self.receivables(enterprises, as_of: Date.today, details: false, min_days_overdue: nil)
+      QboInvoice
+        .open_receivables
         .joins(:qbo_account)
         .where(qbo_accounts: { enterprise_id: enterprises.map(&:id) })
         .select('qbo_invoices.*, qbo_accounts.enterprise_id AS enterprise_id')
-        .filter_map { |inv| build_receivable(inv, as_of, details) }
+        .filter_map { |inv| build_receivable(inv, as_of, details: details, min_days_overdue: min_days_overdue) }
     end
 
     BUCKETS = %w[current days_1_30 days_31_60 days_61_90 days_over_90].freeze
@@ -46,25 +51,33 @@ module Mcp
       MCP::Tool::Response.new([{ type: 'text', text: { error: message }.to_json }])
     end
 
-    def self.build_receivable(inv, as_of, details)
+    def self.build_receivable(inv, as_of, details:, min_days_overdue:)
       due_date = inv.due_date
       balance = Float(inv.data['balance'])
       total = Float(inv.data['total'])
       days_overdue = (as_of - due_date).to_i
+      return nil if min_days_overdue && days_overdue < min_days_overdue
+      ref = inv.customer_ref
+      ref = {} unless ref.is_a?(Hash) # a String customer_ref would substring-match ['name']
       Receivable.new(
         enterprise_id: inv[:enterprise_id],
         doc_number: inv.data['doc_number'],
-        customer: begin inv.customer_ref['name'].presence || 'Unknown' rescue 'Unknown' end,
+        customer_id: ref['value'],
+        customer: ref['name'].presence || 'Unknown',
         total: total,
         balance: balance,
         due_date: due_date,
         days_overdue: days_overdue,
-        status: inv.status,
+        # Detail fields only for consumers that emit them (the list tool).
+        # status stays delegated to the model (single source of truth);
+        # display_name recomputing it internally is the accepted cost of that.
+        status: details ? inv.status : nil,
         qbo_invoice_link: details ? inv.qbo_invoice_link : nil,
         display_name: details ? inv.display_name : nil
       )
-    rescue StandardError
-      nil # malformed synced row — drop it here, the single enforcement point
+    rescue StandardError => e
+      Rails.logger.warn("[Mcp::QboReceivables] skipping malformed invoice id=#{inv.id} qbo_id=#{inv.qbo_id}: #{e.class}: #{e.message}")
+      nil
     end
     private_class_method :build_receivable
   end

--- a/app/services/mcp/qbo_receivables.rb
+++ b/app/services/mcp/qbo_receivables.rb
@@ -28,23 +28,27 @@ module Mcp
     # min_days_overdue filters BEFORE detail fields are computed so discarded
     # rows never pay for currency formatting.
     def self.receivables(enterprises, as_of: Date.today, details: false, min_days_overdue: nil)
-      # The scope's balance regex silently excludes rows whose balance is
-      # present but non-plain-numeric (e.g. "1,200.00"). Rows dropped in
-      # Ruby (in build_receivable) warn; this SQL-side exclusion wouldn't
-      # otherwise — a cheap count-only query so a silent mass-drop can't
-      # read as "nothing outstanding".
+      # The scope's balance regex (and its due_date/balance NULL checks)
+      # silently exclude rows via SQL three-valued logic: NOT (NULL ~ regex)
+      # is NULL, not true, so a sent row missing due_date or balance (or with
+      # a non-numeric balance, e.g. "1,200.00") never reaches build_receivable
+      # to warn there. This SQL-side check catches all of those — a cheap
+      # count-only query so a silent mass-drop can't read as "nothing
+      # outstanding".
       malformed = QboInvoice
         .joins(:qbo_account)
         .where(qbo_accounts: { enterprise_id: enterprises.map(&:id) })
         .where(<<~'SQL'.squish)
-          qbo_invoices.data->>'due_date' IS NOT NULL
-          AND qbo_invoices.data->>'email_status' = 'EmailSent'
-          AND qbo_invoices.data->>'balance' IS NOT NULL
-          AND NOT (qbo_invoices.data->>'balance' ~ '^-?\d+(\.\d+)?$')
+          qbo_invoices.data->>'email_status' = 'EmailSent'
+          AND (
+            qbo_invoices.data->>'due_date' IS NULL
+            OR qbo_invoices.data->>'balance' IS NULL
+            OR NOT (qbo_invoices.data->>'balance' ~ '^-?\d+(\.\d+)?$')
+          )
         SQL
         .pluck(:id, :qbo_id)
       if malformed.any?
-        Rails.logger.warn("[Mcp::QboReceivables] #{malformed.size} invoice(s) excluded for non-numeric balance: #{malformed.map { |id, qbo_id| "id=#{id} qbo_id=#{qbo_id}" }.join(', ')}")
+        Rails.logger.warn("[Mcp::QboReceivables] #{malformed.size} invoice(s) excluded as malformed (missing due_date/balance or non-numeric balance): #{malformed.map { |id, qbo_id| "id=#{id} qbo_id=#{qbo_id}" }.join(', ')}")
       end
 
       QboInvoice

--- a/app/services/mcp/qbo_receivables.rb
+++ b/app/services/mcp/qbo_receivables.rb
@@ -28,6 +28,25 @@ module Mcp
     # min_days_overdue filters BEFORE detail fields are computed so discarded
     # rows never pay for currency formatting.
     def self.receivables(enterprises, as_of: Date.today, details: false, min_days_overdue: nil)
+      # The scope's balance regex silently excludes rows whose balance is
+      # present but non-plain-numeric (e.g. "1,200.00"). Rows dropped in
+      # Ruby (in build_receivable) warn; this SQL-side exclusion wouldn't
+      # otherwise — a cheap count-only query so a silent mass-drop can't
+      # read as "nothing outstanding".
+      malformed = QboInvoice
+        .joins(:qbo_account)
+        .where(qbo_accounts: { enterprise_id: enterprises.map(&:id) })
+        .where(<<~'SQL'.squish)
+          qbo_invoices.data->>'due_date' IS NOT NULL
+          AND qbo_invoices.data->>'email_status' = 'EmailSent'
+          AND qbo_invoices.data->>'balance' IS NOT NULL
+          AND NOT (qbo_invoices.data->>'balance' ~ '^-?\d+(\.\d+)?$')
+        SQL
+        .pluck(:id, :qbo_id)
+      if malformed.any?
+        Rails.logger.warn("[Mcp::QboReceivables] #{malformed.size} invoice(s) excluded for non-numeric balance: #{malformed.map { |id, qbo_id| "id=#{id} qbo_id=#{qbo_id}" }.join(', ')}")
+      end
+
       QboInvoice
         .open_receivables
         .joins(:qbo_account)
@@ -54,11 +73,14 @@ module Mcp
     def self.build_receivable(inv, as_of, details:, min_days_overdue:)
       due_date = inv.due_date
       balance = Float(inv.data['balance'])
-      total = Float(inv.data['total'])
+      total = begin
+        Float(inv.data['total'])
+      rescue StandardError
+        nil # total is display-only; a receivable with unknown total still owes its balance
+      end
       days_overdue = (as_of - due_date).to_i
       return nil if min_days_overdue && days_overdue < min_days_overdue
       ref = inv.customer_ref
-      ref = {} unless ref.is_a?(Hash) # a String customer_ref would substring-match ['name']
       Receivable.new(
         enterprise_id: inv[:enterprise_id],
         doc_number: inv.data['doc_number'],

--- a/app/services/mcp/qbo_receivables.rb
+++ b/app/services/mcp/qbo_receivables.rb
@@ -10,7 +10,18 @@ module Mcp
       :invoice_id, :enterprise_id, :doc_number, :customer_id, :customer, :total, :balance,
       :due_date, :days_overdue, :status, :qbo_invoice_link, :display_name,
       keyword_init: true
-    )
+    ) do
+      # Debtor-identity key for grouping: customer_id when present; raw name
+      # when id-less. Rows with neither aren't the same debtor just because
+      # they'd share the 'Unknown' emission placeholder, so key those
+      # per-invoice — by doc_number, falling back to the invoice id. The
+      # doc:/inv: prefixes are distinct so a doc_number that happens to match
+      # another row's invoice id can't collide on the same key.
+      def customer_key
+        customer_id.presence ||
+          (customer ? "name:#{customer}" : (doc_number.present? ? "doc:#{doc_number}" : "inv:#{invoice_id}"))
+      end
+    end
 
     def self.resolve_enterprises(name)
       scope = Enterprise.joins(:qbo_account).distinct.order(:name)
@@ -35,14 +46,13 @@ module Mcp
       # to warn there. This SQL-side check catches all of those — a cheap
       # count-only query so a silent mass-drop can't read as "nothing
       # outstanding".
-      malformed = QboInvoice
-        .malformed_sent_receivables
-        .joins(:qbo_account)
-        .where(qbo_accounts: { enterprise_id: enterprises.map(&:id) })
-        .pluck(:id, :qbo_id)
-      if malformed.any?
-        warn_pairs("#{malformed.size} invoice(s) excluded as malformed (missing due_date/balance or non-numeric balance)", malformed)
-      end
+      warn_excluded(
+        QboInvoice
+          .malformed_sent_receivables
+          .joins(:qbo_account)
+          .where(qbo_accounts: { enterprise_id: enterprises.map(&:id) }),
+        'invoice(s) excluded as malformed (missing due_date/balance or non-numeric balance)'
+      )
 
       # Rows with NULL/empty jsonb data are excluded by open_receivables by
       # design (the no-live-QBO rule above) but the malformed check above
@@ -50,14 +60,13 @@ module Mcp
       # missing jsonb, so it's NULL, not true, and the row never counts as
       # malformed. Surface them separately so a mass-unsynced state (e.g. a
       # broken sync job) doesn't silently read as "nothing outstanding".
-      unsynced = QboInvoice
-        .joins(:qbo_account)
-        .where(qbo_accounts: { enterprise_id: enterprises.map(&:id) })
-        .where("qbo_invoices.data IS NULL OR qbo_invoices.data = '{}'::jsonb")
-        .pluck(:id, :qbo_id)
-      if unsynced.any?
-        warn_pairs("#{unsynced.size} invoice row(s) have no synced data and are excluded (cannot evaluate)", unsynced)
-      end
+      warn_excluded(
+        QboInvoice
+          .joins(:qbo_account)
+          .where(qbo_accounts: { enterprise_id: enterprises.map(&:id) })
+          .where("qbo_invoices.data IS NULL OR qbo_invoices.data = '{}'::jsonb"),
+        'invoice row(s) have no synced data and are excluded (cannot evaluate)'
+      )
 
       QboInvoice
         .open_receivables
@@ -67,15 +76,18 @@ module Mcp
         .filter_map { |inv| build_receivable(inv, as_of, details: details, min_days_overdue: min_days_overdue) }
     end
 
-    # Logs prefix plus a colon-separated sample of at most the first 20
-    # id/qbo_id pairs — a bad sync can otherwise blow this up into an
-    # unbounded log line.
-    def self.warn_pairs(prefix, pairs)
-      sample = pairs.first(20).map { |id, qbo_id| "id=#{id} qbo_id=#{qbo_id}" }.join(', ')
-      suffix = pairs.size > 20 ? ' (showing first 20)' : ''
-      Rails.logger.warn("[Mcp::QboReceivables] #{prefix}: #{sample}#{suffix}")
+    # Warns with a count plus at most the first 20 id/qbo_id pairs. Both the
+    # fetch and the log line are bounded — a bad sync leaving thousands of
+    # broken rows must not make every tool call transfer them all just to
+    # log 20.
+    def self.warn_excluded(relation, reason)
+      count = relation.count
+      return if count.zero?
+      sample = relation.limit(20).pluck(:id, :qbo_id).map { |id, qbo_id| "id=#{id} qbo_id=#{qbo_id}" }.join(', ')
+      suffix = count > 20 ? ' (showing first 20)' : ''
+      Rails.logger.warn("[Mcp::QboReceivables] #{count} #{reason}: #{sample}#{suffix}")
     end
-    private_class_method :warn_pairs
+    private_class_method :warn_excluded
 
     BUCKETS = %w[current days_1_30 days_31_60 days_61_90 days_over_90].freeze
 

--- a/app/services/mcp/qbo_receivables.rb
+++ b/app/services/mcp/qbo_receivables.rb
@@ -1,0 +1,44 @@
+module Mcp
+  # Shared read-only scoping for the AR tools. CRITICAL: QboInvoice#data
+  # lazily re-fetches from the QBO API when the stored jsonb is empty, so
+  # every query here must exclude unsynced rows in SQL — a tool call must
+  # never trigger a live network request.
+  module QboReceivables
+    SYNCED_ROWS_SQL =
+      "qbo_invoices.data IS NOT NULL AND qbo_invoices.data <> '{}'::jsonb " \
+      "AND qbo_invoices.data->>'due_date' IS NOT NULL".freeze
+
+    def self.resolve_enterprises(name)
+      scope = Enterprise.joins(:qbo_account).distinct
+      return [scope.to_a, nil] if name.blank?
+      matches = scope.where('LOWER(enterprises.name) = ?', name.to_s.downcase).to_a
+      return [matches, nil] if matches.any?
+      valid = scope.pluck(:name).sort
+      [nil, "Unknown enterprise '#{name}'. Valid enterprises: #{valid.join(', ')}"]
+    end
+
+    def self.receivables(enterprise)
+      QboInvoice
+        .joins(:qbo_account)
+        .where(qbo_accounts: { enterprise_id: enterprise.id })
+        .where(SYNCED_ROWS_SQL)
+        .select { |inv| inv.email_status == 'EmailSent' && inv.balance.positive? }
+    end
+
+    def self.days_overdue(invoice, as_of = Date.today)
+      (as_of - invoice.due_date).to_i
+    end
+
+    def self.bucket_key(days_overdue)
+      return 'current' if days_overdue <= 0
+      return 'days_0_30' if days_overdue <= 30
+      return 'days_31_60' if days_overdue <= 60
+      return 'days_61_90' if days_overdue <= 90
+      'days_90_plus'
+    end
+
+    def self.error_response(message)
+      MCP::Tool::Response.new([{ type: 'text', text: { error: message }.to_json }])
+    end
+  end
+end

--- a/app/services/mcp/qbo_receivables.rb
+++ b/app/services/mcp/qbo_receivables.rb
@@ -7,7 +7,7 @@ module Mcp
   # need their own rescue-and-skip.
   module QboReceivables
     Receivable = Struct.new(
-      :enterprise_id, :doc_number, :customer_id, :customer, :total, :balance,
+      :invoice_id, :enterprise_id, :doc_number, :customer_id, :customer, :total, :balance,
       :due_date, :days_overdue, :status, :qbo_invoice_link, :display_name,
       keyword_init: true
     )
@@ -36,16 +36,9 @@ module Mcp
       # count-only query so a silent mass-drop can't read as "nothing
       # outstanding".
       malformed = QboInvoice
+        .malformed_sent_receivables
         .joins(:qbo_account)
         .where(qbo_accounts: { enterprise_id: enterprises.map(&:id) })
-        .where(<<~'SQL'.squish)
-          qbo_invoices.data->>'email_status' = 'EmailSent'
-          AND (
-            qbo_invoices.data->>'due_date' IS NULL
-            OR qbo_invoices.data->>'balance' IS NULL
-            OR NOT (qbo_invoices.data->>'balance' ~ '^-?\d+(\.\d+)?$')
-          )
-        SQL
         .pluck(:id, :qbo_id)
       if malformed.any?
         Rails.logger.warn("[Mcp::QboReceivables] #{malformed.size} invoice(s) excluded as malformed (missing due_date/balance or non-numeric balance): #{malformed.map { |id, qbo_id| "id=#{id} qbo_id=#{qbo_id}" }.join(', ')}")
@@ -70,26 +63,19 @@ module Mcp
       'days_over_90'
     end
 
-    def self.error_response(message)
-      MCP::Tool::Response.new([{ type: 'text', text: { error: message }.to_json }])
-    end
-
     def self.build_receivable(inv, as_of, details:, min_days_overdue:)
       due_date = inv.due_date
       balance = Float(inv.data['balance'])
-      total = begin
-        Float(inv.data['total'])
-      rescue StandardError
-        nil # total is display-only; a receivable with unknown total still owes its balance
-      end
       days_overdue = (as_of - due_date).to_i
       return nil if min_days_overdue && days_overdue < min_days_overdue
+      total = details ? (Float(inv.data['total']) rescue nil) : nil # total is display-only; a receivable with unknown total still owes its balance
       ref = inv.customer_ref
       Receivable.new(
+        invoice_id: inv.id,
         enterprise_id: inv[:enterprise_id],
         doc_number: inv.data['doc_number'],
         customer_id: ref['value'],
-        customer: ref['name'].presence || 'Unknown',
+        customer: ref['name'].presence,
         total: total,
         balance: balance,
         due_date: due_date,

--- a/app/services/mcp/qbo_receivables.rb
+++ b/app/services/mcp/qbo_receivables.rb
@@ -2,51 +2,95 @@ module Mcp
   # Shared read-only scoping for the AR tools. CRITICAL: QboInvoice#data
   # lazily re-fetches from the QBO API when the stored jsonb is empty, so
   # every query here must exclude unsynced rows in SQL — a tool call must
-  # never trigger a live network request.
+  # never trigger a live network request. Rows are parsed once into plain
+  # Receivable structs; malformed rows are dropped here, so consumers never
+  # need their own rescue-and-skip.
   module QboReceivables
-    SYNCED_ROWS_SQL =
-      "qbo_invoices.data IS NOT NULL AND qbo_invoices.data <> '{}'::jsonb " \
-      "AND qbo_invoices.data->>'due_date' IS NOT NULL".freeze
+    # Open, sent receivables only — filtered in SQL so years of paid/unsent
+    # history never leave Postgres. The balance cast is wrapped in a CASE
+    # (Postgres does not guarantee AND short-circuit order) so a non-numeric
+    # balance is excluded rather than raising.
+    #
+    # NOTE: uses a single-quoted heredoc terminator (<<~'SQL') so the \d and
+    # \. escapes below reach Postgres literally. A plain <<~SQL heredoc
+    # follows Ruby double-quoted-string escape rules, which silently strip
+    # the backslash from unrecognized escapes like \d (i.e. "\d" becomes
+    # "d"), corrupting the regex.
+    RECEIVABLE_ROWS_SQL = <<~'SQL'.squish.freeze
+      qbo_invoices.data IS NOT NULL
+      AND qbo_invoices.data <> '{}'::jsonb
+      AND qbo_invoices.data->>'due_date' IS NOT NULL
+      AND qbo_invoices.data->>'email_status' = 'EmailSent'
+      AND CASE WHEN qbo_invoices.data->>'balance' ~ '^-?\d+(\.\d+)?$'
+               THEN (qbo_invoices.data->>'balance')::numeric > 0
+               ELSE FALSE END
+    SQL
+
+    Receivable = Struct.new(
+      :enterprise_id, :doc_number, :customer, :total, :balance,
+      :due_date, :days_overdue, :status, :qbo_invoice_link, :display_name,
+      keyword_init: true
+    )
 
     def self.resolve_enterprises(name)
       scope = Enterprise.joins(:qbo_account).distinct.order(:name)
       return [scope.to_a, nil] if name.blank?
-      matches = scope.where('LOWER(enterprises.name) = ?', name.to_s.downcase).to_a
+      # Match in Ruby (Unicode-aware casecmp?), not SQL LOWER(), so non-ASCII
+      # names resolve regardless of the database collation. Tiny table.
+      matches = scope.to_a.select { |e| e.name.casecmp?(name.to_s) }
       return [matches, nil] if matches.any?
-      valid = scope.pluck(:name).sort
-      [nil, "Unknown enterprise '#{name}'. Valid enterprises: #{valid.join(', ')}"]
+      [nil, "Unknown enterprise '#{name}'. Valid enterprises: #{scope.pluck(:name).join(', ')}"]
     end
 
-    def self.receivables(enterprise)
+    # One query for all enterprises; one parse per row; malformed rows dropped.
+    def self.receivables(enterprises, as_of: Date.today)
       QboInvoice
         .joins(:qbo_account)
-        .where(qbo_accounts: { enterprise_id: enterprise.id })
-        .where(SYNCED_ROWS_SQL)
-        .select do |inv|
-          # A malformed synced row (e.g. non-scalar balance) must be skipped,
-          # never raise mid-report.
-          begin
-            inv.email_status == 'EmailSent' && inv.balance.positive?
-          rescue StandardError
-            false
-          end
-        end
-    end
-
-    def self.days_overdue(invoice, as_of = Date.today)
-      (as_of - invoice.due_date).to_i
+        .where(qbo_accounts: { enterprise_id: enterprises.map(&:id) })
+        .where(RECEIVABLE_ROWS_SQL)
+        .select('qbo_invoices.*, qbo_accounts.enterprise_id AS enterprise_id')
+        .filter_map { |inv| build_receivable(inv, as_of) }
     end
 
     def self.bucket_key(days_overdue)
       return 'current' if days_overdue <= 0
-      return 'days_0_30' if days_overdue <= 30
+      return 'days_1_30' if days_overdue <= 30
       return 'days_31_60' if days_overdue <= 60
       return 'days_61_90' if days_overdue <= 90
-      'days_90_plus'
+      'days_over_90'
     end
 
     def self.error_response(message)
       MCP::Tool::Response.new([{ type: 'text', text: { error: message }.to_json }])
     end
+
+    def self.build_receivable(inv, as_of)
+      due_date = inv.due_date
+      balance = inv.balance
+      total = inv.total
+      days_overdue = (as_of - due_date).to_i
+      partially_paid = balance != total
+      status =
+        if days_overdue.positive?
+          partially_paid ? :partially_paid_overdue : :unpaid_overdue
+        else
+          partially_paid ? :partially_paid : :unpaid
+        end
+      Receivable.new(
+        enterprise_id: inv[:enterprise_id],
+        doc_number: inv.data['doc_number'],
+        customer: begin inv.customer_ref['name'].presence || 'Unknown' rescue 'Unknown' end,
+        total: total,
+        balance: balance,
+        due_date: due_date,
+        days_overdue: days_overdue,
+        status: status,
+        qbo_invoice_link: inv.qbo_invoice_link,
+        display_name: inv.display_name
+      )
+    rescue StandardError
+      nil # malformed synced row — drop it here, the single enforcement point
+    end
+    private_class_method :build_receivable
   end
 end

--- a/app/services/mcp/qbo_receivables.rb
+++ b/app/services/mcp/qbo_receivables.rb
@@ -22,7 +22,15 @@ module Mcp
         .joins(:qbo_account)
         .where(qbo_accounts: { enterprise_id: enterprise.id })
         .where(SYNCED_ROWS_SQL)
-        .select { |inv| inv.email_status == 'EmailSent' && inv.balance.positive? }
+        .select do |inv|
+          # A malformed synced row (e.g. non-scalar balance) must be skipped,
+          # never raise mid-report.
+          begin
+            inv.email_status == 'EmailSent' && inv.balance.positive?
+          rescue StandardError
+            false
+          end
+        end
     end
 
     def self.days_overdue(invoice, as_of = Date.today)

--- a/app/services/mcp/qbo_receivables.rb
+++ b/app/services/mcp/qbo_receivables.rb
@@ -9,7 +9,7 @@ module Mcp
       "AND qbo_invoices.data->>'due_date' IS NOT NULL".freeze
 
     def self.resolve_enterprises(name)
-      scope = Enterprise.joins(:qbo_account).distinct
+      scope = Enterprise.joins(:qbo_account).distinct.order(:name)
       return [scope.to_a, nil] if name.blank?
       matches = scope.where('LOWER(enterprises.name) = ?', name.to_s.downcase).to_a
       return [matches, nil] if matches.any?

--- a/app/services/mcp/responses.rb
+++ b/app/services/mcp/responses.rb
@@ -1,0 +1,11 @@
+module Mcp
+  module Responses
+    def self.error(message)
+      MCP::Tool::Response.new([{ type: 'text', text: { error: message }.to_json }])
+    end
+
+    def self.ok(payload)
+      MCP::Tool::Response.new([{ type: 'text', text: payload.to_json }])
+    end
+  end
+end

--- a/app/services/mcp/search_tool.rb
+++ b/app/services/mcp/search_tool.rb
@@ -26,7 +26,7 @@ module Mcp
         { document_id: r[:document].id, title: r[:document].title, occurred_at: r[:document].occurred_at,
           speaker: r[:chunk].speaker_name, text: r[:chunk].content }
       end
-      MCP::Tool::Response.new([{ type: 'text', text: payload.to_json }])
+      Responses.ok(payload)
     end
   end
 end

--- a/app/services/mcp/server.rb
+++ b/app/services/mcp/server.rb
@@ -16,6 +16,7 @@ module Mcp
       Mcp::ListDocumentsTool,
       Mcp::ListSourcesTool,
       Mcp::GetDocumentTool,
+      Mcp::GetArAgingTool,
     ].freeze
 
     def self.build

--- a/app/services/mcp/server.rb
+++ b/app/services/mcp/server.rb
@@ -17,6 +17,7 @@ module Mcp
       Mcp::ListSourcesTool,
       Mcp::GetDocumentTool,
       Mcp::GetArAgingTool,
+      Mcp::ListOverdueInvoicesTool,
     ].freeze
 
     def self.build

--- a/docs/superpowers/plans/2026-07-02-mcp-finance-tools.md
+++ b/docs/superpowers/plans/2026-07-02-mcp-finance-tools.md
@@ -1,0 +1,503 @@
+# MCP Finance Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two read-only MCP tools — `get_ar_aging` and `list_overdue_invoices` — to Stacks' `/api/mcp` surface, unblocking the Stacksbot Ops pre-read automation.
+
+**Architecture:** Two tool classes following the existing one-file-per-tool pattern in `app/services/mcp/`, sharing a small `Mcp::QboReceivables` scoping module, registered in `Mcp::Server::TOOLS`. All reads come from already-synced `QboInvoice` jsonb rows; aging buckets and overdue status are computed at call time.
+
+**Tech Stack:** Rails, `mcp` Ruby gem v0.22.0, Minitest + mocha, PostgreSQL jsonb.
+
+**Spec:** `docs/superpowers/specs/2026-07-02-mcp-finance-tools-design.md`
+
+## Global Constraints
+
+- `/api/mcp` is read-only forever: every tool sets `annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true)`.
+- **A tool call must NEVER trigger a live QBO request.** `QboInvoice#data` lazily calls `sync!` when the stored jsonb is empty (`app/models/qbo_invoice.rb:50-54`), so every query must exclude unsynced rows **in SQL** before any model accessor touches `data`.
+- No schema changes, no new syncs, no new gems, no new auth.
+- Response convention (match the four existing tools): one content item, `MCP::Tool::Response.new([{ type: 'text', text: payload.to_json }])`.
+- Late fees are a per-client human decision — expose `days_overdue` + `status`, never a policy flag.
+- Malformed synced rows are skipped, never raise mid-report. Unknown `enterprise` param returns an error payload (not an exception) listing valid names.
+- Tests run with `bin/rails test <path>`. mocha is available via `test/test_helper.rb`.
+
+---
+
+### Task 1: `Mcp::QboReceivables` + `get_ar_aging` tool
+
+**Files:**
+- Create: `app/services/mcp/qbo_receivables.rb`
+- Create: `app/services/mcp/get_ar_aging_tool.rb`
+- Create: `test/services/mcp/finance_tools_test.rb`
+- Modify: `app/services/mcp/server.rb` (TOOLS array, currently 4 entries)
+- Modify: `test/integration/mcp_endpoint_test.rb:48-49` (hard-coded sorted tool-name array)
+
+**Interfaces:**
+- Consumes: `QboInvoice` (accessors `#email_status`, `#balance`, `#total`, `#due_date`, `#customer_ref`, `#status`, `#display_name`, `#qbo_invoice_link`), `Enterprise.joins(:qbo_account)` (qbo_accounts has `enterprise_id`), fixtures `enterprises(:sanctuary)` ("Sanctuary Computer Inc") and `qbo_accounts(:one)`/`qbo_accounts(:two)` (both belong to sanctuary).
+- Produces (Task 2 relies on these exact signatures):
+  - `Mcp::QboReceivables.resolve_enterprises(name) → [enterprises_array, nil] | [nil, error_string]`
+  - `Mcp::QboReceivables.receivables(enterprise) → Array<QboInvoice>` (synced + EmailSent + balance > 0)
+  - `Mcp::QboReceivables.days_overdue(invoice, as_of) → Integer`
+  - `Mcp::QboReceivables.bucket_key(days_overdue) → String` ("current" | "days_0_30" | "days_31_60" | "days_61_90" | "days_90_plus")
+  - `Mcp::QboReceivables.error_response(message) → MCP::Tool::Response`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/services/mcp/finance_tools_test.rb`:
+
+```ruby
+require 'test_helper'
+
+class Mcp::FinanceToolsTest < ActiveSupport::TestCase
+  setup do
+    @sanctuary = enterprises(:sanctuary)
+    @account = qbo_accounts(:one)
+  end
+
+  # Minimal synced-invoice factory mirroring the jsonb shape QboInvoice
+  # accessors read (see app/models/qbo_invoice.rb).
+  def invoice!(doc:, due:, balance:, total: nil, customer: 'Acme Co',
+               email_status: 'EmailSent', account: @account)
+    QboInvoice.create!(
+      qbo_account: account,
+      qbo_id: "inv-#{doc}",
+      data: {
+        'doc_number' => doc,
+        'email_status' => email_status,
+        'due_date' => due.iso8601,
+        'balance' => balance,
+        'total' => total || balance,
+        'customer_ref' => { 'name' => customer },
+      }
+    )
+  end
+
+  def payload_for(resp)
+    JSON.parse(resp.content.first[:text])
+  end
+
+  # --- get_ar_aging ---
+
+  test 'get_ar_aging buckets balances by days overdue with correct boundaries' do
+    today = Date.today
+    invoice!(doc: 'a', due: today, balance: 10.0)           # 0 days  -> current
+    invoice!(doc: 'b', due: today - 30, balance: 20.0)      # 30 days -> days_0_30
+    invoice!(doc: 'c', due: today - 31, balance: 40.0)      # 31 days -> days_31_60
+    invoice!(doc: 'd', due: today - 90, balance: 80.0)      # 90 days -> days_61_90
+    invoice!(doc: 'e', due: today - 91, balance: 160.0)     # 91 days -> days_90_plus
+
+    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    ent = payload['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
+    acme = ent['customers'].find { |c| c['customer'] == 'Acme Co' }
+
+    assert_equal 10.0, acme['current']
+    assert_equal 20.0, acme['days_0_30']
+    assert_equal 40.0, acme['days_31_60']
+    assert_equal 80.0, acme['days_61_90']
+    assert_equal 160.0, acme['days_90_plus']
+    assert_equal 310.0, acme['total']
+    assert_equal 310.0, ent['total_ar']
+    assert_equal 310.0, payload['total_ar']
+    assert_equal Date.today.iso8601, payload['as_of']
+  end
+
+  test 'get_ar_aging sums outstanding balance, not invoice total' do
+    invoice!(doc: 'p', due: Date.today - 10, balance: 500.0, total: 1000.0)
+    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    acme = payload['enterprises'].first['customers'].first
+    assert_equal 500.0, acme['days_0_30']
+    assert_equal 500.0, acme['total']
+  end
+
+  test 'get_ar_aging excludes paid, unsent, and unsynced invoices — and never syncs' do
+    invoice!(doc: 'live', due: Date.today - 5, balance: 100.0)
+    invoice!(doc: 'paid', due: Date.today - 5, balance: 0.0, total: 300.0)
+    invoice!(doc: 'draft', due: Date.today - 5, balance: 50.0, email_status: 'NotSet')
+    QboInvoice.create!(qbo_account: @account, qbo_id: 'inv-unsynced', data: nil)
+
+    QboInvoice.any_instance.expects(:sync!).never
+    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    assert_equal 100.0, payload['total_ar']
+  end
+
+  test 'get_ar_aging groups by enterprise and scopes by the enterprise param' do
+    other = QboAccount.create!(enterprise: enterprises(:one), client_id: 'x',
+                               client_secret: 'x', realm_id: 'realm-other')
+    invoice!(doc: 's1', due: Date.today - 5, balance: 100.0)
+    invoice!(doc: 'o1', due: Date.today - 5, balance: 999.0, account: other,
+             customer: 'Other Client')
+
+    all = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    assert_equal 1099.0, all['total_ar']
+    assert_equal 2, all['enterprises'].length
+
+    scoped = payload_for(Mcp::GetArAgingTool.call(
+      enterprise: 'sanctuary computer inc', server_context: {}))
+    assert_equal 100.0, scoped['total_ar']
+    assert_equal [@sanctuary.name], scoped['enterprises'].map { |e| e['enterprise'] }
+  end
+
+  test 'get_ar_aging returns an error payload for an unknown enterprise' do
+    payload = payload_for(Mcp::GetArAgingTool.call(enterprise: 'Nope Inc', server_context: {}))
+    assert_includes payload['error'], "Unknown enterprise 'Nope Inc'"
+    assert_includes payload['error'], @sanctuary.name
+  end
+
+  test 'get_ar_aging returns an empty report when there are no receivables' do
+    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    assert_equal 0, payload['total_ar']
+  end
+end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bin/rails test test/services/mcp/finance_tools_test.rb`
+Expected: FAIL — every test errors with `NameError: uninitialized constant Mcp::GetArAgingTool`.
+
+- [ ] **Step 3: Implement the shared module and the tool**
+
+Create `app/services/mcp/qbo_receivables.rb`:
+
+```ruby
+module Mcp
+  # Shared read-only scoping for the AR tools. CRITICAL: QboInvoice#data
+  # lazily re-fetches from the QBO API when the stored jsonb is empty, so
+  # every query here must exclude unsynced rows in SQL — a tool call must
+  # never trigger a live network request.
+  module QboReceivables
+    SYNCED_ROWS_SQL =
+      "qbo_invoices.data IS NOT NULL AND qbo_invoices.data <> '{}'::jsonb " \
+      "AND qbo_invoices.data->>'due_date' IS NOT NULL".freeze
+
+    def self.resolve_enterprises(name)
+      scope = Enterprise.joins(:qbo_account).distinct
+      return [scope.to_a, nil] if name.blank?
+      matches = scope.where('LOWER(enterprises.name) = ?', name.to_s.downcase).to_a
+      return [matches, nil] if matches.any?
+      valid = scope.pluck(:name).sort
+      [nil, "Unknown enterprise '#{name}'. Valid enterprises: #{valid.join(', ')}"]
+    end
+
+    def self.receivables(enterprise)
+      QboInvoice
+        .joins(:qbo_account)
+        .where(qbo_accounts: { enterprise_id: enterprise.id })
+        .where(SYNCED_ROWS_SQL)
+        .select { |inv| inv.email_status == 'EmailSent' && inv.balance.positive? }
+    end
+
+    def self.days_overdue(invoice, as_of = Date.today)
+      (as_of - invoice.due_date).to_i
+    end
+
+    def self.bucket_key(days_overdue)
+      return 'current' if days_overdue <= 0
+      return 'days_0_30' if days_overdue <= 30
+      return 'days_31_60' if days_overdue <= 60
+      return 'days_61_90' if days_overdue <= 90
+      'days_90_plus'
+    end
+
+    def self.error_response(message)
+      MCP::Tool::Response.new([{ type: 'text', text: { error: message }.to_json }])
+    end
+  end
+end
+```
+
+Create `app/services/mcp/get_ar_aging_tool.rb`:
+
+```ruby
+module Mcp
+  class GetArAgingTool < MCP::Tool
+    tool_name 'get_ar_aging'
+    description 'AR aging buckets (current/0-30/31-60/61-90/90+ days overdue) per customer ' \
+                'per enterprise, computed from already-synced QBO invoices. Never calls QBO live.'
+    input_schema(
+      properties: {
+        enterprise: { type: 'string', description: 'Optional enterprise name filter, e.g. "Sanctuary Computer Inc"' },
+      },
+      required: []
+    )
+    annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true)
+
+    BUCKETS = %w[current days_0_30 days_31_60 days_61_90 days_90_plus].freeze
+
+    def self.call(enterprise: nil, server_context:)
+      enterprises, error = QboReceivables.resolve_enterprises(enterprise)
+      return QboReceivables.error_response(error) if error
+
+      as_of = Date.today
+      enterprise_payloads = enterprises.map do |ent|
+        customers = Hash.new { |h, k| h[k] = BUCKETS.index_with { 0.0 }.merge('total' => 0.0) }
+        QboReceivables.receivables(ent).each do |inv|
+          bucket = QboReceivables.bucket_key(QboReceivables.days_overdue(inv, as_of))
+          row = customers[inv.customer_ref['name'] || 'Unknown']
+          row[bucket] += inv.balance
+          row['total'] += inv.balance
+        rescue StandardError
+          next # malformed synced row — skip it, never fail the whole report
+        end
+        rows = customers.map do |name, row|
+          { 'customer' => name }.merge(row.transform_values { |v| v.round(2) })
+        end
+        {
+          enterprise: ent.name,
+          customers: rows.sort_by { |r| -r['total'] },
+          total_ar: rows.sum { |r| r['total'] }.round(2),
+        }
+      end
+
+      payload = {
+        as_of: as_of.iso8601,
+        enterprises: enterprise_payloads,
+        total_ar: enterprise_payloads.sum { |e| e[:total_ar] }.round(2),
+      }
+      MCP::Tool::Response.new([{ type: 'text', text: payload.to_json }])
+    end
+  end
+end
+```
+
+Modify `app/services/mcp/server.rb` — add the tool to the registry:
+
+```ruby
+    TOOLS = [
+      Mcp::SearchTool,
+      Mcp::ListDocumentsTool,
+      Mcp::ListSourcesTool,
+      Mcp::GetDocumentTool,
+      Mcp::GetArAgingTool,
+    ].freeze
+```
+
+- [ ] **Step 4: Run the unit tests to verify they pass**
+
+Run: `bin/rails test test/services/mcp/finance_tools_test.rb`
+Expected: PASS (7 tests). If `QboAccount.create!` in the scoping test fails a validation, mirror the attributes used in `test/fixtures/qbo_accounts.yml` (`client_id`, `client_secret`, `realm_id`, `enterprise`) — those are the only fixture attributes.
+
+- [ ] **Step 5: Update the integration test's hard-coded tool list**
+
+In `test/integration/mcp_endpoint_test.rb` (~line 48), change:
+
+```ruby
+    assert_equal %w[get_document list_documents list_sources search], tool_names.sort,
+      "Expected all four tools registered, got: #{tool_names.inspect}"
+```
+
+to:
+
+```ruby
+    assert_equal %w[get_ar_aging get_document list_documents list_sources search], tool_names.sort,
+      "Expected all registered tools, got: #{tool_names.inspect}"
+```
+
+Run: `bin/rails test test/integration/mcp_endpoint_test.rb`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/mcp/qbo_receivables.rb app/services/mcp/get_ar_aging_tool.rb \
+        app/services/mcp/server.rb test/services/mcp/finance_tools_test.rb \
+        test/integration/mcp_endpoint_test.rb
+git commit -m "Add get_ar_aging MCP tool (AR buckets from synced QBO invoices)"
+```
+
+---
+
+### Task 2: `list_overdue_invoices` tool
+
+**Files:**
+- Create: `app/services/mcp/list_overdue_invoices_tool.rb`
+- Modify: `test/services/mcp/finance_tools_test.rb` (append tests; `invoice!`/`payload_for` helpers already exist there)
+- Modify: `app/services/mcp/server.rb` (TOOLS array, 5 entries after Task 1)
+- Modify: `test/integration/mcp_endpoint_test.rb` (tool-name array, 5 names after Task 1)
+
+**Interfaces:**
+- Consumes (from Task 1): `Mcp::QboReceivables.resolve_enterprises(name)`, `.receivables(enterprise)`, `.days_overdue(invoice, as_of)`, `.error_response(message)`; test helpers `invoice!(doc:, due:, balance:, total:, customer:, email_status:, account:)` and `payload_for(resp)` in `Mcp::FinanceToolsTest`.
+- Produces: the `list_overdue_invoices` MCP tool. Payload: `{ as_of:, count:, invoices: [{ doc_number, customer, enterprise, total, balance, due_date, days_overdue, status, qbo_invoice_link, display_name }] }`, sorted most-overdue first.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside `class Mcp::FinanceToolsTest` in `test/services/mcp/finance_tools_test.rb`:
+
+```ruby
+  # --- list_overdue_invoices ---
+
+  test 'list_overdue_invoices returns overdue rows sorted most-overdue first' do
+    invoice!(doc: '10', due: Date.today - 5, balance: 100.0)
+    invoice!(doc: '11', due: Date.today - 45, balance: 200.0, customer: 'Beta LLC')
+    invoice!(doc: '12', due: Date.today + 5, balance: 300.0)   # not overdue
+    invoice!(doc: '13', due: Date.today - 20, balance: 150.0, total: 400.0) # partially paid overdue
+
+    payload = payload_for(Mcp::ListOverdueInvoicesTool.call(server_context: {}))
+    assert_equal 3, payload['count']
+    assert_equal %w[11 13 10], payload['invoices'].map { |i| i['doc_number'] }
+
+    top = payload['invoices'].first
+    assert_equal 'Beta LLC', top['customer']
+    assert_equal @sanctuary.name, top['enterprise']
+    assert_equal 45, top['days_overdue']
+    assert_equal 'unpaid_overdue', top['status']
+    assert_equal (Date.today - 45).iso8601, top['due_date']
+    assert_match %r{https://app\.qbo\.intuit\.com/app/invoice\?txnId=}, top['qbo_invoice_link']
+    assert top['display_name'].present?
+
+    partial = payload['invoices'].find { |i| i['doc_number'] == '13' }
+    assert_equal 'partially_paid_overdue', partial['status']
+    assert_equal 150.0, partial['balance']
+    assert_equal 400.0, partial['total']
+  end
+
+  test 'list_overdue_invoices honors min_days_overdue' do
+    invoice!(doc: '20', due: Date.today - 5, balance: 100.0)
+    invoice!(doc: '21', due: Date.today - 40, balance: 200.0)
+
+    payload = payload_for(Mcp::ListOverdueInvoicesTool.call(min_days_overdue: 30, server_context: {}))
+    assert_equal %w[21], payload['invoices'].map { |i| i['doc_number'] }
+  end
+
+  test 'list_overdue_invoices scopes by enterprise and rejects unknown names' do
+    other = QboAccount.create!(enterprise: enterprises(:one), client_id: 'x',
+                               client_secret: 'x', realm_id: 'realm-other2')
+    invoice!(doc: '30', due: Date.today - 5, balance: 100.0)
+    invoice!(doc: '31', due: Date.today - 5, balance: 200.0, account: other)
+
+    scoped = payload_for(Mcp::ListOverdueInvoicesTool.call(
+      enterprise: @sanctuary.name, server_context: {}))
+    assert_equal %w[30], scoped['invoices'].map { |i| i['doc_number'] }
+
+    err = payload_for(Mcp::ListOverdueInvoicesTool.call(enterprise: 'Nope Inc', server_context: {}))
+    assert_includes err['error'], "Unknown enterprise 'Nope Inc'"
+  end
+
+  test 'list_overdue_invoices skips unsynced rows without syncing' do
+    QboInvoice.create!(qbo_account: @account, qbo_id: 'inv-unsynced-2', data: nil)
+    QboInvoice.any_instance.expects(:sync!).never
+    payload = payload_for(Mcp::ListOverdueInvoicesTool.call(server_context: {}))
+    assert_equal 0, payload['count']
+    assert_equal [], payload['invoices']
+  end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bin/rails test test/services/mcp/finance_tools_test.rb`
+Expected: the 4 new tests FAIL with `NameError: uninitialized constant Mcp::ListOverdueInvoicesTool`; the 7 Task-1 tests still PASS.
+
+- [ ] **Step 3: Implement the tool**
+
+Create `app/services/mcp/list_overdue_invoices_tool.rb`:
+
+```ruby
+module Mcp
+  class ListOverdueInvoicesTool < MCP::Tool
+    tool_name 'list_overdue_invoices'
+    description 'Overdue (unpaid or partially-paid) QBO invoices with days overdue, sorted ' \
+                'most-overdue first, from already-synced rows. Never calls QBO live. Late fees ' \
+                'are a per-client human decision — this tool exposes the data only.'
+    input_schema(
+      properties: {
+        enterprise: { type: 'string', description: 'Optional enterprise name filter, e.g. "Sanctuary Computer Inc"' },
+        min_days_overdue: { type: 'integer', description: 'Only invoices at least this many days overdue (default 1)' },
+      },
+      required: []
+    )
+    annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true)
+
+    OVERDUE_STATUSES = %i[unpaid_overdue partially_paid_overdue].freeze
+
+    def self.call(enterprise: nil, min_days_overdue: 1, server_context:)
+      enterprises, error = QboReceivables.resolve_enterprises(enterprise)
+      return QboReceivables.error_response(error) if error
+
+      as_of = Date.today
+      invoices = enterprises.flat_map do |ent|
+        QboReceivables.receivables(ent).filter_map do |inv|
+          next unless OVERDUE_STATUSES.include?(inv.status)
+          days = QboReceivables.days_overdue(inv, as_of)
+          next if days < min_days_overdue.to_i
+          {
+            doc_number: inv.data['doc_number'],
+            customer: inv.customer_ref['name'],
+            enterprise: ent.name,
+            total: inv.total,
+            balance: inv.balance,
+            due_date: inv.due_date.iso8601,
+            days_overdue: days,
+            status: inv.status,
+            qbo_invoice_link: inv.qbo_invoice_link,
+            display_name: inv.display_name,
+          }
+        rescue StandardError
+          nil # malformed synced row — skip it, never fail the whole report
+        end
+      end.sort_by { |row| -row[:days_overdue] }
+
+      payload = { as_of: as_of.iso8601, count: invoices.length, invoices: invoices }
+      MCP::Tool::Response.new([{ type: 'text', text: payload.to_json }])
+    end
+  end
+end
+```
+
+Modify `app/services/mcp/server.rb`:
+
+```ruby
+    TOOLS = [
+      Mcp::SearchTool,
+      Mcp::ListDocumentsTool,
+      Mcp::ListSourcesTool,
+      Mcp::GetDocumentTool,
+      Mcp::GetArAgingTool,
+      Mcp::ListOverdueInvoicesTool,
+    ].freeze
+```
+
+Modify `test/integration/mcp_endpoint_test.rb` tool-name assertion:
+
+```ruby
+    assert_equal %w[get_ar_aging get_document list_documents list_overdue_invoices list_sources search], tool_names.sort,
+      "Expected all registered tools, got: #{tool_names.inspect}"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bin/rails test test/services/mcp/finance_tools_test.rb test/integration/mcp_endpoint_test.rb`
+Expected: PASS (11 unit tests + integration).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/mcp/list_overdue_invoices_tool.rb app/services/mcp/server.rb \
+        test/services/mcp/finance_tools_test.rb test/integration/mcp_endpoint_test.rb
+git commit -m "Add list_overdue_invoices MCP tool (backs Ops pre-read late-fee review)"
+```
+
+---
+
+### Task 3: Full-suite verification
+
+**Files:**
+- No new files. Fix any fallout the full suite surfaces (most likely: none — the change is additive).
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–2.
+- Produces: a green suite; the branch is ready for review/merge.
+
+- [ ] **Step 1: Run the MCP-adjacent suites**
+
+Run: `bin/rails test test/services/mcp test/integration/mcp_endpoint_test.rb`
+Expected: PASS.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `bin/rails test`
+Expected: PASS with no new failures relative to `main` (if pre-existing failures exist on `main`, note them; do not fix unrelated failures).
+
+- [ ] **Step 3: Commit any fixes (only if Step 1/2 required changes)**
+
+```bash
+git add -A && git commit -m "Fix test fallout from MCP finance tools"
+```

--- a/docs/superpowers/specs/2026-07-02-mcp-finance-tools-design.md
+++ b/docs/superpowers/specs/2026-07-02-mcp-finance-tools-design.md
@@ -60,10 +60,12 @@ like the four corpus tools.
 
 - **File:** `app/services/mcp/get_ar_aging_tool.rb`
 - **Params:** `enterprise` (optional string)
-- **Buckets:** `current` (not yet due) + `0_30` / `31_60` / `61_90` / `90_plus` days overdue,
+- **Buckets:** `current` (not yet due) + `1-30` / `31-60` / `61-90` / `over-90` days overdue,
   computed from `Date.today - due_date`. The spec names the four overdue buckets; `current`
   is added because an AR aging report without outstanding-but-not-due balances understates
-  total AR and the Ops pre-read logs "AR total" as a trend.
+  total AR and the Ops pre-read logs "AR total" as a trend. Bucket names were made truthful
+  (day 0 = current; day 90 = 61-90; over_90 is strictly >90), matching QBO's own
+  "91 and over" convention.
 - **Grouping:** per enterprise → per customer (`customer_ref["name"]`), bucket sums of
   `#balance` (not `#total` — aging is about what's still owed), plus per-customer and
   per-enterprise totals and an overall `total_ar`.
@@ -76,8 +78,8 @@ like the four corpus tools.
     {
       "enterprise": "Sanctuary Computer",
       "customers": [
-        { "customer": "Acme Co", "current": 0.0, "days_0_30": 1200.0,
-          "days_31_60": 0.0, "days_61_90": 0.0, "days_90_plus": 500.0, "total": 1700.0 }
+        { "customer": "Acme Co", "current": 0.0, "days_1_30": 1200.0,
+          "days_31_60": 0.0, "days_61_90": 0.0, "days_over_90": 500.0, "total": 1700.0 }
       ],
       "total_ar": 1700.0
     }

--- a/docs/superpowers/specs/2026-07-02-mcp-finance-tools-design.md
+++ b/docs/superpowers/specs/2026-07-02-mcp-finance-tools-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-02
 **Source:** [Stacksbot ROADMAP](https://www.notion.so/garden3d/ROADMAP-md-391131fea2c7801485e0d767177e0da3) Phase 1a + [SPEC — Stacks MCP upgrades](https://www.notion.so/garden3d/SPEC-Stacks-MCP-upgrades-391131fea2c78147a3aff77c7a6a5493)
-**Status:** Draft — awaiting Hugh's review. Open decisions flagged inline as ⚖️.
+**Status:** Approved by Hugh 2026-07-02. Late fees confirmed per-client/human-judged — tools expose data, not policy.
 
 ## Why this slice
 
@@ -11,10 +11,9 @@ depends on exactly two P1a tools: `get_ar_aging` and `list_overdue_invoices`. Bo
 already-synced `QboInvoice` rows — no schema changes, no new syncs, no new auth. Smallest
 slice that unblocks the top-ranked automation.
 
-⚖️ **Open decision — slice choice.** Chosen over (a) shipping all eight P1a tools at once
+**Slice choice (confirmed).** Chosen over (a) shipping all eight P1a tools at once
 (bigger review surface, no automation needs the rest yet) and (b) privacy hardening G1–G4
-first (prerequisite only to *widening the corpus*, which this slice doesn't do). Say the word
-and we re-scope.
+first (prerequisite only to *widening the corpus*, which this slice doesn't do).
 
 ## Approaches considered
 
@@ -96,11 +95,10 @@ like the four corpus tools.
   first.
 - **Fields per invoice:** `doc_number`, `customer`, `enterprise`, `total`, `balance`,
   `due_date`, `days_overdue`, `status`, `qbo_invoice_link`, `display_name`.
-- ⚖️ **Open decision — late-fee flags.** The roadmap asks for "late-fee flags", but no
-  late-fee policy exists anywhere in the Stacks codebase (grep confirms). This design
-  **exposes data, not policy**: `days_overdue` + `status` are the flags, and the Ops
-  pre-read applies whatever late-fee SOP humans use. If a real rule exists (e.g. "late fee
-  after 30 days"), we add a `late_fee_eligible` boolean — tell me the rule and it's one line.
+- **Late-fee flags (resolved).** Late fees are decided per-client by humans — there is no
+  automated rule (confirmed by Hugh, 2026-07-02). The tools therefore **expose data, not
+  policy**: `days_overdue` + `status` are the flags, and the Ops pre-read surfaces them for
+  the per-client human call. No `late_fee_eligible` field.
 
 ## Error handling
 

--- a/docs/superpowers/specs/2026-07-02-mcp-finance-tools-design.md
+++ b/docs/superpowers/specs/2026-07-02-mcp-finance-tools-design.md
@@ -66,9 +66,11 @@ like the four corpus tools.
   total AR and the Ops pre-read logs "AR total" as a trend. Bucket names were made truthful
   (day 0 = current; day 90 = 61-90; over_90 is strictly >90), matching QBO's own
   "91 and over" convention.
-- **Grouping:** per enterprise → per customer (`customer_ref["name"]`), bucket sums of
-  `#balance` (not `#total` — aging is about what's still owed), plus per-customer and
-  per-enterprise totals and an overall `total_ar`.
+- **Grouping:** per enterprise → per customer, grouped by QBO customer id + name (not name
+  alone) so same-named customers stay distinct; balances accumulate in integer cents so
+  buckets always cross-foot exactly with totals. Bucket sums are of `#balance` (not `#total`
+  — aging is about what's still owed), plus per-customer and per-enterprise totals and an
+  overall `total_ar`.
 - **Payload shape:**
 
 ```json
@@ -78,7 +80,7 @@ like the four corpus tools.
     {
       "enterprise": "Sanctuary Computer",
       "customers": [
-        { "customer": "Acme Co", "current": 0.0, "days_1_30": 1200.0,
+        { "customer": "Acme Co", "customer_id": null, "current": 0.0, "days_1_30": 1200.0,
           "days_31_60": 0.0, "days_61_90": 0.0, "days_over_90": 500.0, "total": 1700.0 }
       ],
       "total_ar": 1700.0

--- a/docs/superpowers/specs/2026-07-02-mcp-finance-tools-design.md
+++ b/docs/superpowers/specs/2026-07-02-mcp-finance-tools-design.md
@@ -1,0 +1,128 @@
+# Design: MCP finance tools — `get_ar_aging` + `list_overdue_invoices`
+
+**Date:** 2026-07-02
+**Source:** [Stacksbot ROADMAP](https://www.notion.so/garden3d/ROADMAP-md-391131fea2c7801485e0d767177e0da3) Phase 1a + [SPEC — Stacks MCP upgrades](https://www.notion.so/garden3d/SPEC-Stacks-MCP-upgrades-391131fea2c78147a3aff77c7a6a5493)
+**Status:** Draft — awaiting Hugh's review. Open decisions flagged inline as ⚖️.
+
+## Why this slice
+
+The roadmap's ranked delivery order puts the **Operations pre-read** automation first, and it
+depends on exactly two P1a tools: `get_ar_aging` and `list_overdue_invoices`. Both read
+already-synced `QboInvoice` rows — no schema changes, no new syncs, no new auth. Smallest
+slice that unblocks the top-ranked automation.
+
+⚖️ **Open decision — slice choice.** Chosen over (a) shipping all eight P1a tools at once
+(bigger review surface, no automation needs the rest yet) and (b) privacy hardening G1–G4
+first (prerequisite only to *widening the corpus*, which this slice doesn't do). Say the word
+and we re-scope.
+
+## Approaches considered
+
+1. **Two standalone tools, computed in-tool (chosen).** One file per tool following the
+   existing `app/services/mcp/*_tool.rb` pattern; buckets and overdue status computed at call
+   time from synced rows. Matches the spec's naming (automations reference the tools by
+   name) and the "no persisted aggregate exists — that's fine" guidance.
+2. **One combined `get_ar_report` tool.** Fewer round trips, but diverges from the spec's
+   named tool contract and couples two different consumers (aging trend vs. chase list).
+   Rejected.
+3. **Persist a nightly AR-aging aggregate, tool reads it.** Faster reads, but the spec
+   explicitly forbids new syncs, and the dataset (hundreds of invoices) doesn't need it.
+   Rejected.
+
+## Architecture
+
+Two new tool classes registered in `Mcp::Server::TOOLS` (`app/services/mcp/server.rb`),
+riding the existing `/api/mcp` route, shared `X-Api-Key` auth, and stateless transport.
+Read-only annotations (`read_only_hint: true, destructive_hint: false, idempotent_hint: true`)
+like the four corpus tools.
+
+```
+/api/mcp ──► Mcp::Server::TOOLS ──► GetArAgingTool ──┐
+                                └──► ListOverdueInvoicesTool ──┤
+                                                               ▼
+                              QboInvoice (synced rows only) ── qbo_account ── enterprise
+```
+
+### Shared scoping + safety (both tools)
+
+- **Synced-rows-only guard (critical).** `QboInvoice#data` lazily calls `sync!` (a live QBO
+  API call) when the stored jsonb is empty (`app/models/qbo_invoice.rb:50-54`). Both tools
+  filter in SQL — `WHERE data IS NOT NULL AND data != '{}' AND data->>'due_date' IS NOT NULL`
+  — so the lazy fetch can never fire. A tool call must never trigger N live QBO requests.
+- **Enterprise scoping.** `Enterprise has_one :qbo_account`; `QboInvoice belongs_to
+  :qbo_account`. Optional `enterprise` string param (name match); default = all enterprises,
+  grouped per enterprise in the payload.
+- **Population.** Only invoices that are really receivables: `email_status == "EmailSent"`
+  and `balance > 0`. Excludes `not_sent`, `voided`, and paid invoices. Filtering happens in
+  Ruby via the existing model accessors (`#status`, `#balance`, `#due_date`) after the SQL
+  synced-rows guard — dataset is small (agency-scale invoice counts), so no jsonb index work.
+
+## Tool 1: `get_ar_aging`
+
+- **File:** `app/services/mcp/get_ar_aging_tool.rb`
+- **Params:** `enterprise` (optional string)
+- **Buckets:** `current` (not yet due) + `0_30` / `31_60` / `61_90` / `90_plus` days overdue,
+  computed from `Date.today - due_date`. The spec names the four overdue buckets; `current`
+  is added because an AR aging report without outstanding-but-not-due balances understates
+  total AR and the Ops pre-read logs "AR total" as a trend.
+- **Grouping:** per enterprise → per customer (`customer_ref["name"]`), bucket sums of
+  `#balance` (not `#total` — aging is about what's still owed), plus per-customer and
+  per-enterprise totals and an overall `total_ar`.
+- **Payload shape:**
+
+```json
+{
+  "as_of": "2026-07-02",
+  "enterprises": [
+    {
+      "enterprise": "Sanctuary Computer",
+      "customers": [
+        { "customer": "Acme Co", "current": 0.0, "days_0_30": 1200.0,
+          "days_31_60": 0.0, "days_61_90": 0.0, "days_90_plus": 500.0, "total": 1700.0 }
+      ],
+      "total_ar": 1700.0
+    }
+  ],
+  "total_ar": 1700.0
+}
+```
+
+## Tool 2: `list_overdue_invoices`
+
+- **File:** `app/services/mcp/list_overdue_invoices_tool.rb`
+- **Params:** `enterprise` (optional string), `min_days_overdue` (optional integer, default 1)
+- **Rows:** invoices whose `#status` is `:unpaid_overdue` or `:partially_paid_overdue` (the
+  model already computes these), with `days_overdue >= min_days_overdue`, sorted most-overdue
+  first.
+- **Fields per invoice:** `doc_number`, `customer`, `enterprise`, `total`, `balance`,
+  `due_date`, `days_overdue`, `status`, `qbo_invoice_link`, `display_name`.
+- ⚖️ **Open decision — late-fee flags.** The roadmap asks for "late-fee flags", but no
+  late-fee policy exists anywhere in the Stacks codebase (grep confirms). This design
+  **exposes data, not policy**: `days_overdue` + `status` are the flags, and the Ops
+  pre-read applies whatever late-fee SOP humans use. If a real rule exists (e.g. "late fee
+  after 30 days"), we add a `late_fee_eligible` boolean — tell me the rule and it's one line.
+
+## Error handling
+
+- Unknown `enterprise` name → `MCP::Tool::Response` with a clear error text (not an
+  exception), listing valid enterprise names.
+- Rows with malformed `data` (missing `due_date` after the SQL guard shouldn't happen, but
+  jsonb is untyped) → skipped defensively, never raise mid-report.
+- No matching invoices → valid empty payload (`total_ar: 0`, `invoices: []`), not an error.
+
+## Testing
+
+- **Unit** (`test/services/mcp/tools_test.rb`): add `qbo_invoices.yml` fixtures covering
+  paid / unpaid / unpaid-overdue / partially-paid-overdue / not-sent / voided / **empty-data
+  (unsynced)** rows. Assert: bucket math at boundaries (day 30/31, 60/61, 90/91), balance-not-
+  total summing, enterprise scoping, `min_days_overdue` filter, unknown-enterprise error, and
+  — most importantly — that an unsynced row is excluded **without any network call** (stub
+  `QboInvoice#sync!` to raise; suite must stay green).
+- **Integration** (`test/integration/mcp_endpoint_test.rb:48`): the hard-coded sorted
+  tool-name array becomes
+  `%w[get_ar_aging get_document list_documents list_overdue_invoices list_sources search]`.
+
+## Out of scope
+
+The other six P1a tools, privacy hardening G1–G4, the Ops pre-read automation itself
+(lives in Stacksbot config, not Stacks), any write surface, any new sync or schema change.

--- a/test/integration/mcp_endpoint_test.rb
+++ b/test/integration/mcp_endpoint_test.rb
@@ -45,8 +45,8 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
     assert body.key?("result"), "Expected JSON-RPC result key, got: #{body.inspect}"
     tool_names = body["result"]["tools"].map { |t| t["name"] }
     assert_includes tool_names, "search", "Expected 'search' tool in: #{tool_names.inspect}"
-    assert_equal %w[get_document list_documents list_sources search], tool_names.sort,
-      "Expected all four tools registered, got: #{tool_names.inspect}"
+    assert_equal %w[get_ar_aging get_document list_documents list_sources search], tool_names.sort,
+      "Expected all registered tools, got: #{tool_names.inspect}"
   end
 
   test "POST returns 403 when MCP API key is not configured" do

--- a/test/integration/mcp_endpoint_test.rb
+++ b/test/integration/mcp_endpoint_test.rb
@@ -49,6 +49,25 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
       "Expected all registered tools, got: #{tool_names.inspect}"
   end
 
+  test "POST tools/call for get_ar_aging returns a parseable report" do
+    post "/api/mcp",
+      headers: api_key_headers,
+      params: {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "get_ar_aging", arguments: {} }
+      }.to_json
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert body.key?("result"), "Expected JSON-RPC result key, got: #{body.inspect}"
+    text = body["result"]["content"][0]["text"]
+    payload = JSON.parse(text)
+    assert payload.key?("as_of"), "Expected 'as_of' key in payload, got: #{payload.inspect}"
+    assert_equal 0, payload["total_ar"]
+  end
+
   test "POST returns 403 when MCP API key is not configured" do
     Stacks::Utils.stub(:config, { stacks: { private_api_key: '' } }) do
       post "/api/mcp",

--- a/test/integration/mcp_endpoint_test.rb
+++ b/test/integration/mcp_endpoint_test.rb
@@ -45,7 +45,7 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
     assert body.key?("result"), "Expected JSON-RPC result key, got: #{body.inspect}"
     tool_names = body["result"]["tools"].map { |t| t["name"] }
     assert_includes tool_names, "search", "Expected 'search' tool in: #{tool_names.inspect}"
-    assert_equal %w[get_ar_aging get_document list_documents list_sources search], tool_names.sort,
+    assert_equal %w[get_ar_aging get_document list_documents list_overdue_invoices list_sources search], tool_names.sort,
       "Expected all registered tools, got: #{tool_names.inspect}"
   end
 

--- a/test/integration/mcp_endpoint_test.rb
+++ b/test/integration/mcp_endpoint_test.rb
@@ -64,8 +64,9 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
     assert body.key?("result"), "Expected JSON-RPC result key, got: #{body.inspect}"
     text = body["result"]["content"][0]["text"]
     payload = JSON.parse(text)
-    assert payload.key?("as_of"), "Expected 'as_of' key in payload, got: #{payload.inspect}"
-    assert_equal 0, payload["total_ar"]
+    assert payload.key?("total_ar"), "Expected 'total_ar' key in payload, got: #{payload.inspect}"
+    assert payload.key?("enterprises"), "Expected 'enterprises' key in payload, got: #{payload.inspect}"
+    assert_equal Date.today.iso8601, payload["as_of"]
   end
 
   test "POST returns 403 when MCP API key is not configured" do

--- a/test/integration/mcp_endpoint_test.rb
+++ b/test/integration/mcp_endpoint_test.rb
@@ -66,7 +66,7 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
     payload = JSON.parse(text)
     assert payload.key?("total_ar"), "Expected 'total_ar' key in payload, got: #{payload.inspect}"
     assert payload.key?("enterprises"), "Expected 'enterprises' key in payload, got: #{payload.inspect}"
-    assert_equal Date.today.iso8601, payload["as_of"]
+    assert_match(/\A\d{4}-\d{2}-\d{2}\z/, payload["as_of"])
   end
 
   test "POST returns 403 when MCP API key is not configured" do

--- a/test/services/mcp/finance_tools_test.rb
+++ b/test/services/mcp/finance_tools_test.rb
@@ -10,8 +10,10 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
 
   # Minimal synced-invoice factory mirroring the jsonb shape QboInvoice
   # accessors read (see app/models/qbo_invoice.rb).
-  def invoice!(doc:, due:, balance:, total: nil, customer: 'Acme Co',
+  def invoice!(doc:, due:, balance:, total: nil, customer: 'Acme Co', customer_id: nil,
                email_status: 'EmailSent', account: @account)
+    customer_ref = { 'name' => customer }
+    customer_ref['value'] = customer_id if customer_id
     QboInvoice.create!(
       qbo_account: account,
       qbo_id: "inv-#{doc}",
@@ -21,7 +23,7 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
         'due_date' => due.iso8601,
         'balance' => balance,
         'total' => total || balance,
-        'customer_ref' => { 'name' => customer },
+        'customer_ref' => customer_ref,
       }
     )
   end
@@ -52,6 +54,21 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     assert_equal 310.0, ent['total_ar']
     assert_equal 310.0, payload['total_ar']
     assert_equal @today.iso8601, payload['as_of']
+  end
+
+  test 'get_ar_aging cross-foots exactly across buckets despite fractional-cent balances' do
+    invoice!(doc: 'cf1', due: @today, balance: 10.01, customer: 'Cent Co', customer_id: 'cc')
+    invoice!(doc: 'cf2', due: @today - 30, balance: 20.02, customer: 'Cent Co', customer_id: 'cc')
+    invoice!(doc: 'cf3', due: @today - 31, balance: 0.99, customer: 'Cent Co', customer_id: 'cc')
+
+    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    ent = payload['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
+    row = ent['customers'].find { |c| c['customer'] == 'Cent Co' }
+
+    bucket_sum = Mcp::QboReceivables::BUCKETS.sum { |b| row[b] }
+    assert_equal row['total'], bucket_sum
+    assert_in_delta 31.02, row['total'], 0.0001
+    assert_equal row['total'], ent['total_ar']
   end
 
   test 'get_ar_aging sums outstanding balance, not invoice total' do
@@ -88,6 +105,29 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
       enterprise: 'sanctuary computer inc', server_context: {}))
     assert_equal 100.0, scoped['total_ar']
     assert_equal [@sanctuary.name], scoped['enterprises'].map { |e| e['enterprise'] }
+  end
+
+  test 'get_ar_aging resolves an enterprise name padded with whitespace' do
+    invoice!(doc: 's2', due: @today - 5, balance: 100.0)
+
+    scoped = payload_for(Mcp::GetArAgingTool.call(
+      enterprise: '  sanctuary computer inc  ', server_context: {}))
+    assert_equal 100.0, scoped['total_ar']
+    assert_equal [@sanctuary.name], scoped['enterprises'].map { |e| e['enterprise'] }
+  end
+
+  test 'get_ar_aging keeps same-named customers with different customer_id as distinct rows' do
+    invoice!(doc: 'dup1', due: @today - 5, balance: 100.0, customer: 'Studio LLC', customer_id: 'c1')
+    invoice!(doc: 'dup2', due: @today - 10, balance: 200.0, customer: 'Studio LLC', customer_id: 'c2')
+
+    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    ent = payload['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
+    studios = ent['customers'].select { |c| c['customer'] == 'Studio LLC' }
+
+    assert_equal 2, studios.length
+    assert_equal %w[c1 c2].sort, studios.map { |c| c['customer_id'] }.sort
+    totals = studios.map { |c| c['total'] }.sort
+    assert_equal [100.0, 200.0], totals
   end
 
   test 'get_ar_aging returns an error payload for an unknown enterprise' do
@@ -152,6 +192,24 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     unknown = ent['customers'].find { |c| c['customer'] == 'Unknown' }
     assert unknown, "Expected an 'Unknown' customer row, got: #{ent['customers'].inspect}"
     assert_equal 100.0, unknown['total']
+
+    overdue = payload_for(Mcp::ListOverdueInvoicesTool.call(server_context: {}))
+    assert_equal ['Unknown'], overdue['invoices'].map { |i| i['customer'] }
+  end
+
+  test 'a String customer_ref falls back to Unknown in both tools instead of substring-matching name' do
+    QboInvoice.create!(qbo_account: @account, qbo_id: 'inv-string-ref', data: {
+      'doc_number' => 'str-ref',
+      'email_status' => 'EmailSent',
+      'due_date' => (@today - 5).iso8601,
+      'balance' => 100.0,
+      'total' => 100.0,
+      'customer_ref' => 'Acme (trade name)',
+    })
+
+    aging = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    ent = aging['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
+    assert_equal ['Unknown'], ent['customers'].map { |c| c['customer'] }
 
     overdue = payload_for(Mcp::ListOverdueInvoicesTool.call(server_context: {}))
     assert_equal ['Unknown'], overdue['invoices'].map { |i| i['customer'] }

--- a/test/services/mcp/finance_tools_test.rb
+++ b/test/services/mcp/finance_tools_test.rb
@@ -95,6 +95,22 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     assert_includes payload['error'], @sanctuary.name
   end
 
+  test 'get_ar_aging skips malformed synced rows instead of raising' do
+    invoice!(doc: 'good', due: Date.today - 5, balance: 100.0)
+    QboInvoice.create!(qbo_account: @account, qbo_id: 'inv-malformed', data: {
+      'due_date' => (Date.today - 5).iso8601,
+      'balance' => { 'weird' => 'shape' },
+      'email_status' => 'EmailSent',
+      'customer_ref' => { 'name' => 'Broken' },
+      'doc_number' => 'bad1',
+    })
+
+    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    assert_equal 100.0, payload['total_ar']
+    ent = payload['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
+    assert_equal ['Acme Co'], ent['customers'].map { |c| c['customer'] }
+  end
+
   test 'get_ar_aging returns an empty report when there are no receivables' do
     payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
     assert_equal 0, payload['total_ar']

--- a/test/services/mcp/finance_tools_test.rb
+++ b/test/services/mcp/finance_tools_test.rb
@@ -232,6 +232,40 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     assert_equal [100.0, 200.0], unknown_rows.map { |r| r['total'] }.sort
   end
 
+  test 'get_ar_aging keeps identity-less, doc-number-less debtors as separate rows via invoice-id fallback' do
+    QboInvoice.create!(qbo_account: @account, qbo_id: 'inv-nodoc1', data: {
+      'email_status' => 'EmailSent',
+      'due_date' => (@today - 5).iso8601,
+      'balance' => 100.0,
+      'total' => 100.0,
+    })
+    QboInvoice.create!(qbo_account: @account, qbo_id: 'inv-nodoc2', data: {
+      'email_status' => 'EmailSent',
+      'due_date' => (@today - 10).iso8601,
+      'balance' => 200.0,
+      'total' => 200.0,
+    })
+
+    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    ent = payload['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
+    unknown_rows = ent['customers'].select { |c| c['customer'] == 'Unknown' }
+
+    assert_equal 2, unknown_rows.length, "nil doc_numbers must not collide on a shared 'doc:' key"
+    assert_equal [100.0, 200.0], unknown_rows.map { |r| r['total'] }.sort
+  end
+
+  test 'get_ar_aging aggregates two invoices for a customer literally named Unknown into one row' do
+    invoice!(doc: 'lit1', due: @today - 5, balance: 100.0, customer: 'Unknown')
+    invoice!(doc: 'lit2', due: @today - 10, balance: 200.0, customer: 'Unknown')
+
+    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    ent = payload['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
+    rows = ent['customers'].select { |c| c['customer'] == 'Unknown' }
+
+    assert_equal 1, rows.length, 'a customer literally named Unknown must aggregate by name, not fragment per invoice'
+    assert_equal 300.0, rows.first['total']
+  end
+
   test 'get_ar_aging returns an empty report when there are no receivables' do
     payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
     assert_equal 0, payload['total_ar']
@@ -259,6 +293,12 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
       'total' => 100.0,
       'customer_ref' => 'Acme (trade name)',
     })
+
+    # The accessor now warns whenever it hands back a malformed customer_ref;
+    # not asserted strictly (both tools re-fetch, so it fires more than
+    # once) — the behavior that matters is 'Unknown', not dropped, below.
+    Rails.logger.stubs(:warn)
+    Rails.logger.expects(:warn).with { |msg| msg.include?('malformed customer_ref') }.at_least_once
 
     aging = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
     ent = aging['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }

--- a/test/services/mcp/finance_tools_test.rb
+++ b/test/services/mcp/finance_tools_test.rb
@@ -115,4 +115,61 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
     assert_equal 0, payload['total_ar']
   end
+
+  # --- list_overdue_invoices ---
+
+  test 'list_overdue_invoices returns overdue rows sorted most-overdue first' do
+    invoice!(doc: '10', due: Date.today - 5, balance: 100.0)
+    invoice!(doc: '11', due: Date.today - 45, balance: 200.0, customer: 'Beta LLC')
+    invoice!(doc: '12', due: Date.today + 5, balance: 300.0)   # not overdue
+    invoice!(doc: '13', due: Date.today - 20, balance: 150.0, total: 400.0) # partially paid overdue
+
+    payload = payload_for(Mcp::ListOverdueInvoicesTool.call(server_context: {}))
+    assert_equal 3, payload['count']
+    assert_equal %w[11 13 10], payload['invoices'].map { |i| i['doc_number'] }
+
+    top = payload['invoices'].first
+    assert_equal 'Beta LLC', top['customer']
+    assert_equal @sanctuary.name, top['enterprise']
+    assert_equal 45, top['days_overdue']
+    assert_equal 'unpaid_overdue', top['status']
+    assert_equal (Date.today - 45).iso8601, top['due_date']
+    assert_match %r{https://app\.qbo\.intuit\.com/app/invoice\?txnId=}, top['qbo_invoice_link']
+    assert top['display_name'].present?
+
+    partial = payload['invoices'].find { |i| i['doc_number'] == '13' }
+    assert_equal 'partially_paid_overdue', partial['status']
+    assert_equal 150.0, partial['balance']
+    assert_equal 400.0, partial['total']
+  end
+
+  test 'list_overdue_invoices honors min_days_overdue' do
+    invoice!(doc: '20', due: Date.today - 5, balance: 100.0)
+    invoice!(doc: '21', due: Date.today - 40, balance: 200.0)
+
+    payload = payload_for(Mcp::ListOverdueInvoicesTool.call(min_days_overdue: 30, server_context: {}))
+    assert_equal %w[21], payload['invoices'].map { |i| i['doc_number'] }
+  end
+
+  test 'list_overdue_invoices scopes by enterprise and rejects unknown names' do
+    other = QboAccount.create!(enterprise: enterprises(:one), client_id: 'x',
+                               client_secret: 'x', realm_id: 'realm-other2')
+    invoice!(doc: '30', due: Date.today - 5, balance: 100.0)
+    invoice!(doc: '31', due: Date.today - 5, balance: 200.0, account: other)
+
+    scoped = payload_for(Mcp::ListOverdueInvoicesTool.call(
+      enterprise: @sanctuary.name, server_context: {}))
+    assert_equal %w[30], scoped['invoices'].map { |i| i['doc_number'] }
+
+    err = payload_for(Mcp::ListOverdueInvoicesTool.call(enterprise: 'Nope Inc', server_context: {}))
+    assert_includes err['error'], "Unknown enterprise 'Nope Inc'"
+  end
+
+  test 'list_overdue_invoices skips unsynced rows without syncing' do
+    QboInvoice.create!(qbo_account: @account, qbo_id: 'inv-unsynced-2', data: nil)
+    QboInvoice.any_instance.expects(:sync!).never
+    payload = payload_for(Mcp::ListOverdueInvoicesTool.call(server_context: {}))
+    assert_equal 0, payload['count']
+    assert_equal [], payload['invoices']
+  end
 end

--- a/test/services/mcp/finance_tools_test.rb
+++ b/test/services/mcp/finance_tools_test.rb
@@ -219,6 +219,18 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     assert_equal ['Acme Co'], ent['customers'].map { |c| c['customer'] }
   end
 
+  test 'get_ar_aging excludes and warns about a row with no synced data at all' do
+    invoice!(doc: 'good', due: @today - 5, balance: 100.0)
+    QboInvoice.create!(qbo_account: @account, qbo_id: 'inv-unsynced-warn', data: nil)
+
+    Rails.logger.expects(:warn).with { |msg| msg.include?('no synced data and are excluded') }
+
+    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    assert_equal 100.0, payload['total_ar']
+    ent = payload['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
+    assert_equal ['Acme Co'], ent['customers'].map { |c| c['customer'] }
+  end
+
   test 'get_ar_aging keeps identity-less debtors (no customer_id, no customer name) as separate rows' do
     invoice!(doc: 'anon1', due: @today - 5, balance: 100.0, omit_customer_ref: true)
     invoice!(doc: 'anon2', due: @today - 10, balance: 200.0, omit_customer_ref: true)
@@ -232,8 +244,12 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     assert_equal [100.0, 200.0], unknown_rows.map { |r| r['total'] }.sort
   end
 
-  test 'get_ar_aging keeps identity-less, doc-number-less debtors as separate rows via invoice-id fallback' do
+  test 'get_ar_aging keeps identity-less debtors separate whether or not they have a doc_number' do
+    # One row falls back to a "doc:<doc_number>" key, the other to an
+    # "inv:<invoice_id>" key — distinct prefixes, so they never collide even
+    # if a doc_number happened to match another row's invoice id.
     QboInvoice.create!(qbo_account: @account, qbo_id: 'inv-nodoc1', data: {
+      'doc_number' => '999999',
       'email_status' => 'EmailSent',
       'due_date' => (@today - 5).iso8601,
       'balance' => 100.0,
@@ -250,7 +266,8 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     ent = payload['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
     unknown_rows = ent['customers'].select { |c| c['customer'] == 'Unknown' }
 
-    assert_equal 2, unknown_rows.length, "nil doc_numbers must not collide on a shared 'doc:' key"
+    assert_equal 2, unknown_rows.length,
+                 "a doc_number and an invoice id must not collide on a shared 'doc:' key"
     assert_equal [100.0, 200.0], unknown_rows.map { |r| r['total'] }.sort
   end
 

--- a/test/services/mcp/finance_tools_test.rb
+++ b/test/services/mcp/finance_tools_test.rb
@@ -33,20 +33,20 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
   test 'get_ar_aging buckets balances by days overdue with correct boundaries' do
     today = Date.today
     invoice!(doc: 'a', due: today, balance: 10.0)           # 0 days  -> current
-    invoice!(doc: 'b', due: today - 30, balance: 20.0)      # 30 days -> days_0_30
+    invoice!(doc: 'b', due: today - 30, balance: 20.0)      # 30 days -> days_1_30
     invoice!(doc: 'c', due: today - 31, balance: 40.0)      # 31 days -> days_31_60
     invoice!(doc: 'd', due: today - 90, balance: 80.0)      # 90 days -> days_61_90
-    invoice!(doc: 'e', due: today - 91, balance: 160.0)     # 91 days -> days_90_plus
+    invoice!(doc: 'e', due: today - 91, balance: 160.0)     # 91 days -> days_over_90
 
     payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
     ent = payload['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
     acme = ent['customers'].find { |c| c['customer'] == 'Acme Co' }
 
     assert_equal 10.0, acme['current']
-    assert_equal 20.0, acme['days_0_30']
+    assert_equal 20.0, acme['days_1_30']
     assert_equal 40.0, acme['days_31_60']
     assert_equal 80.0, acme['days_61_90']
-    assert_equal 160.0, acme['days_90_plus']
+    assert_equal 160.0, acme['days_over_90']
     assert_equal 310.0, acme['total']
     assert_equal 310.0, ent['total_ar']
     assert_equal 310.0, payload['total_ar']
@@ -57,7 +57,7 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     invoice!(doc: 'p', due: Date.today - 10, balance: 500.0, total: 1000.0)
     payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
     acme = payload['enterprises'].first['customers'].first
-    assert_equal 500.0, acme['days_0_30']
+    assert_equal 500.0, acme['days_1_30']
     assert_equal 500.0, acme['total']
   end
 
@@ -116,6 +116,39 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     assert_equal 0, payload['total_ar']
   end
 
+  test 'an empty-string customer name falls back to Unknown in both tools' do
+    invoice!(doc: 'nc1', due: Date.today - 5, balance: 100.0, customer: '')
+
+    aging = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    ent = aging['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
+    unknown = ent['customers'].find { |c| c['customer'] == 'Unknown' }
+    assert unknown, "Expected an 'Unknown' customer row, got: #{ent['customers'].inspect}"
+    assert_equal 100.0, unknown['total']
+
+    overdue = payload_for(Mcp::ListOverdueInvoicesTool.call(server_context: {}))
+    assert_equal ['Unknown'], overdue['invoices'].map { |i| i['customer'] }
+  end
+
+  test 'both tools drop a row whose due_date passes the SQL filter but fails to parse' do
+    invoice!(doc: 'ok', due: Date.today - 5, balance: 100.0)
+    QboInvoice.create!(qbo_account: @account, qbo_id: 'inv-bad-date', data: {
+      'doc_number' => 'bad-date',
+      'email_status' => 'EmailSent',
+      'due_date' => 'not-a-date',
+      'balance' => 50.0,
+      'total' => 50.0,
+      'customer_ref' => { 'name' => 'Broken Dates Inc' },
+    })
+
+    aging = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    assert_equal 100.0, aging['total_ar']
+    ent = aging['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
+    assert_equal ['Acme Co'], ent['customers'].map { |c| c['customer'] }
+
+    overdue = payload_for(Mcp::ListOverdueInvoicesTool.call(server_context: {}))
+    assert_equal %w[ok], overdue['invoices'].map { |i| i['doc_number'] }
+  end
+
   # --- list_overdue_invoices ---
 
   test 'list_overdue_invoices returns overdue rows sorted most-overdue first' do
@@ -149,6 +182,14 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
 
     payload = payload_for(Mcp::ListOverdueInvoicesTool.call(min_days_overdue: 30, server_context: {}))
     assert_equal %w[21], payload['invoices'].map { |i| i['doc_number'] }
+  end
+
+  test 'list_overdue_invoices clamps min_days_overdue below 1 to 1' do
+    invoice!(doc: '25', due: Date.today, balance: 100.0)      # due today, 0 days overdue
+    invoice!(doc: '26', due: Date.today - 3, balance: 200.0)  # 3 days overdue
+
+    payload = payload_for(Mcp::ListOverdueInvoicesTool.call(min_days_overdue: 0, server_context: {}))
+    assert_equal %w[26], payload['invoices'].map { |i| i['doc_number'] }
   end
 
   test 'list_overdue_invoices scopes by enterprise and rejects unknown names' do

--- a/test/services/mcp/finance_tools_test.rb
+++ b/test/services/mcp/finance_tools_test.rb
@@ -130,6 +130,19 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     assert_equal [100.0, 200.0], totals
   end
 
+  test 'get_ar_aging groups same customer_id into one row even if the display name drifted between syncs' do
+    invoice!(doc: 'rn1', due: @today - 20, balance: 100.0, customer: 'Acme', customer_id: 'c1')
+    invoice!(doc: 'rn2', due: @today - 5, balance: 200.0, customer: 'Acme Co', customer_id: 'c1')
+
+    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    ent = payload['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
+    rows = ent['customers'].select { |c| c['customer_id'] == 'c1' }
+
+    assert_equal 1, rows.length
+    assert_equal 'Acme Co', rows.first['customer']
+    assert_equal 300.0, rows.first['total']
+  end
+
   test 'get_ar_aging returns an error payload for an unknown enterprise' do
     payload = payload_for(Mcp::GetArAgingTool.call(enterprise: 'Nope Inc', server_context: {}))
     assert_includes payload['error'], "Unknown enterprise 'Nope Inc'"
@@ -152,7 +165,7 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     assert_equal ['Acme Co'], ent['customers'].map { |c| c['customer'] }
   end
 
-  test 'both tools drop a row that passes the SQL filter but has an invalid total' do
+  test 'both tools keep a row with a missing or unparseable total, emitting total: nil' do
     invoice!(doc: 'good', due: @today - 5, balance: 100.0)
     QboInvoice.create!(qbo_account: @account, qbo_id: 'inv-no-total', data: {
       'doc_number' => 'no-total',
@@ -170,13 +183,23 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
       'customer_ref' => { 'name' => 'Comma Total Inc' },
     })
 
+    # A missing/unparseable total is display-only — the row still owes its
+    # balance, so it must not be dropped from AR: both the missing-total and
+    # comma-total balances still show up in the aging buckets/total.
     aging = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
-    assert_equal 100.0, aging['total_ar']
+    assert_equal 200.0, aging['total_ar']
     ent = aging['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
-    assert_equal ['Acme Co'], ent['customers'].map { |c| c['customer'] }
+    assert_equal ['Acme Co', 'Comma Total Inc', 'Missing Total Inc'].sort,
+                 ent['customers'].map { |c| c['customer'] }.sort
 
     overdue = payload_for(Mcp::ListOverdueInvoicesTool.call(server_context: {}))
-    assert_equal %w[good], overdue['invoices'].map { |i| i['doc_number'] }
+    assert_equal %w[comma-total good no-total].sort, overdue['invoices'].map { |i| i['doc_number'] }.sort
+    no_total_row = overdue['invoices'].find { |i| i['doc_number'] == 'no-total' }
+    comma_total_row = overdue['invoices'].find { |i| i['doc_number'] == 'comma-total' }
+    assert_nil no_total_row['total']
+    assert_nil comma_total_row['total']
+    assert_equal 50.0, no_total_row['balance']
+    assert_equal 50.0, comma_total_row['balance']
   end
 
   test 'get_ar_aging returns an empty report when there are no receivables' do

--- a/test/services/mcp/finance_tools_test.rb
+++ b/test/services/mcp/finance_tools_test.rb
@@ -11,21 +11,20 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
   # Minimal synced-invoice factory mirroring the jsonb shape QboInvoice
   # accessors read (see app/models/qbo_invoice.rb).
   def invoice!(doc:, due:, balance:, total: nil, customer: 'Acme Co', customer_id: nil,
-               email_status: 'EmailSent', account: @account)
-    customer_ref = { 'name' => customer }
-    customer_ref['value'] = customer_id if customer_id
-    QboInvoice.create!(
-      qbo_account: account,
-      qbo_id: "inv-#{doc}",
-      data: {
-        'doc_number' => doc,
-        'email_status' => email_status,
-        'due_date' => due.iso8601,
-        'balance' => balance,
-        'total' => total || balance,
-        'customer_ref' => customer_ref,
-      }
-    )
+               email_status: 'EmailSent', account: @account, omit_customer_ref: false)
+    data = {
+      'doc_number' => doc,
+      'email_status' => email_status,
+      'due_date' => due.iso8601,
+      'balance' => balance,
+      'total' => total || balance,
+    }
+    unless omit_customer_ref
+      customer_ref = { 'name' => customer }
+      customer_ref['value'] = customer_id if customer_id
+      data['customer_ref'] = customer_ref
+    end
+    QboInvoice.create!(qbo_account: account, qbo_id: "inv-#{doc}", data: data)
   end
 
   def payload_for(resp)
@@ -200,6 +199,37 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     assert_nil comma_total_row['total']
     assert_equal 50.0, no_total_row['balance']
     assert_equal 50.0, comma_total_row['balance']
+  end
+
+  test 'get_ar_aging excludes and warns about a sent invoice with no balance key at all' do
+    invoice!(doc: 'good', due: @today - 5, balance: 100.0)
+    QboInvoice.create!(qbo_account: @account, qbo_id: 'inv-no-balance', data: {
+      'doc_number' => 'no-balance',
+      'email_status' => 'EmailSent',
+      'due_date' => (@today - 5).iso8601,
+      'total' => 50.0,
+      'customer_ref' => { 'name' => 'No Balance Inc' },
+    })
+
+    Rails.logger.expects(:warn).with { |msg| msg.include?('excluded as malformed') }
+
+    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    assert_equal 100.0, payload['total_ar']
+    ent = payload['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
+    assert_equal ['Acme Co'], ent['customers'].map { |c| c['customer'] }
+  end
+
+  test 'get_ar_aging keeps identity-less debtors (no customer_id, no customer name) as separate rows' do
+    invoice!(doc: 'anon1', due: @today - 5, balance: 100.0, omit_customer_ref: true)
+    invoice!(doc: 'anon2', due: @today - 10, balance: 200.0, omit_customer_ref: true)
+
+    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    ent = payload['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
+    unknown_rows = ent['customers'].select { |c| c['customer'] == 'Unknown' }
+
+    assert_equal 2, unknown_rows.length
+    assert unknown_rows.all? { |r| r['customer_id'].nil? }
+    assert_equal [100.0, 200.0], unknown_rows.map { |r| r['total'] }.sort
   end
 
   test 'get_ar_aging returns an empty report when there are no receivables' do

--- a/test/services/mcp/finance_tools_test.rb
+++ b/test/services/mcp/finance_tools_test.rb
@@ -4,6 +4,8 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
   setup do
     @sanctuary = enterprises(:sanctuary)
     @account = qbo_accounts(:one)
+    @today = Date.today
+    Date.stubs(:today).returns(@today)
   end
 
   # Minimal synced-invoice factory mirroring the jsonb shape QboInvoice
@@ -31,12 +33,11 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
   # --- get_ar_aging ---
 
   test 'get_ar_aging buckets balances by days overdue with correct boundaries' do
-    today = Date.today
-    invoice!(doc: 'a', due: today, balance: 10.0)           # 0 days  -> current
-    invoice!(doc: 'b', due: today - 30, balance: 20.0)      # 30 days -> days_1_30
-    invoice!(doc: 'c', due: today - 31, balance: 40.0)      # 31 days -> days_31_60
-    invoice!(doc: 'd', due: today - 90, balance: 80.0)      # 90 days -> days_61_90
-    invoice!(doc: 'e', due: today - 91, balance: 160.0)     # 91 days -> days_over_90
+    invoice!(doc: 'a', due: @today, balance: 10.0)           # 0 days  -> current
+    invoice!(doc: 'b', due: @today - 30, balance: 20.0)      # 30 days -> days_1_30
+    invoice!(doc: 'c', due: @today - 31, balance: 40.0)      # 31 days -> days_31_60
+    invoice!(doc: 'd', due: @today - 90, balance: 80.0)      # 90 days -> days_61_90
+    invoice!(doc: 'e', due: @today - 91, balance: 160.0)     # 91 days -> days_over_90
 
     payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
     ent = payload['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
@@ -50,11 +51,11 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     assert_equal 310.0, acme['total']
     assert_equal 310.0, ent['total_ar']
     assert_equal 310.0, payload['total_ar']
-    assert_equal Date.today.iso8601, payload['as_of']
+    assert_equal @today.iso8601, payload['as_of']
   end
 
   test 'get_ar_aging sums outstanding balance, not invoice total' do
-    invoice!(doc: 'p', due: Date.today - 10, balance: 500.0, total: 1000.0)
+    invoice!(doc: 'p', due: @today - 10, balance: 500.0, total: 1000.0)
     payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
     acme = payload['enterprises'].first['customers'].first
     assert_equal 500.0, acme['days_1_30']
@@ -62,9 +63,9 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
   end
 
   test 'get_ar_aging excludes paid, unsent, and unsynced invoices — and never syncs' do
-    invoice!(doc: 'live', due: Date.today - 5, balance: 100.0)
-    invoice!(doc: 'paid', due: Date.today - 5, balance: 0.0, total: 300.0)
-    invoice!(doc: 'draft', due: Date.today - 5, balance: 50.0, email_status: 'NotSet')
+    invoice!(doc: 'live', due: @today - 5, balance: 100.0)
+    invoice!(doc: 'paid', due: @today - 5, balance: 0.0, total: 300.0)
+    invoice!(doc: 'draft', due: @today - 5, balance: 50.0, email_status: 'NotSet')
     QboInvoice.create!(qbo_account: @account, qbo_id: 'inv-unsynced', data: nil)
 
     QboInvoice.any_instance.expects(:sync!).never
@@ -75,8 +76,8 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
   test 'get_ar_aging groups by enterprise and scopes by the enterprise param' do
     other = QboAccount.create!(enterprise: enterprises(:one), client_id: 'x',
                                client_secret: 'x', realm_id: 'realm-other')
-    invoice!(doc: 's1', due: Date.today - 5, balance: 100.0)
-    invoice!(doc: 'o1', due: Date.today - 5, balance: 999.0, account: other,
+    invoice!(doc: 's1', due: @today - 5, balance: 100.0)
+    invoice!(doc: 'o1', due: @today - 5, balance: 999.0, account: other,
              customer: 'Other Client')
 
     all = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
@@ -96,9 +97,9 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
   end
 
   test 'get_ar_aging skips malformed synced rows instead of raising' do
-    invoice!(doc: 'good', due: Date.today - 5, balance: 100.0)
+    invoice!(doc: 'good', due: @today - 5, balance: 100.0)
     QboInvoice.create!(qbo_account: @account, qbo_id: 'inv-malformed', data: {
-      'due_date' => (Date.today - 5).iso8601,
+      'due_date' => (@today - 5).iso8601,
       'balance' => { 'weird' => 'shape' },
       'email_status' => 'EmailSent',
       'customer_ref' => { 'name' => 'Broken' },
@@ -111,13 +112,40 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     assert_equal ['Acme Co'], ent['customers'].map { |c| c['customer'] }
   end
 
+  test 'both tools drop a row that passes the SQL filter but has an invalid total' do
+    invoice!(doc: 'good', due: @today - 5, balance: 100.0)
+    QboInvoice.create!(qbo_account: @account, qbo_id: 'inv-no-total', data: {
+      'doc_number' => 'no-total',
+      'email_status' => 'EmailSent',
+      'due_date' => (@today - 5).iso8601,
+      'balance' => 50.0,
+      'customer_ref' => { 'name' => 'Missing Total Inc' },
+    })
+    QboInvoice.create!(qbo_account: @account, qbo_id: 'inv-comma-total', data: {
+      'doc_number' => 'comma-total',
+      'email_status' => 'EmailSent',
+      'due_date' => (@today - 5).iso8601,
+      'balance' => 50.0,
+      'total' => '1,200.00',
+      'customer_ref' => { 'name' => 'Comma Total Inc' },
+    })
+
+    aging = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    assert_equal 100.0, aging['total_ar']
+    ent = aging['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
+    assert_equal ['Acme Co'], ent['customers'].map { |c| c['customer'] }
+
+    overdue = payload_for(Mcp::ListOverdueInvoicesTool.call(server_context: {}))
+    assert_equal %w[good], overdue['invoices'].map { |i| i['doc_number'] }
+  end
+
   test 'get_ar_aging returns an empty report when there are no receivables' do
     payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
     assert_equal 0, payload['total_ar']
   end
 
   test 'an empty-string customer name falls back to Unknown in both tools' do
-    invoice!(doc: 'nc1', due: Date.today - 5, balance: 100.0, customer: '')
+    invoice!(doc: 'nc1', due: @today - 5, balance: 100.0, customer: '')
 
     aging = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
     ent = aging['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
@@ -130,7 +158,7 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
   end
 
   test 'both tools drop a row whose due_date passes the SQL filter but fails to parse' do
-    invoice!(doc: 'ok', due: Date.today - 5, balance: 100.0)
+    invoice!(doc: 'ok', due: @today - 5, balance: 100.0)
     QboInvoice.create!(qbo_account: @account, qbo_id: 'inv-bad-date', data: {
       'doc_number' => 'bad-date',
       'email_status' => 'EmailSent',
@@ -152,10 +180,10 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
   # --- list_overdue_invoices ---
 
   test 'list_overdue_invoices returns overdue rows sorted most-overdue first' do
-    invoice!(doc: '10', due: Date.today - 5, balance: 100.0)
-    invoice!(doc: '11', due: Date.today - 45, balance: 200.0, customer: 'Beta LLC')
-    invoice!(doc: '12', due: Date.today + 5, balance: 300.0)   # not overdue
-    invoice!(doc: '13', due: Date.today - 20, balance: 150.0, total: 400.0) # partially paid overdue
+    invoice!(doc: '10', due: @today - 5, balance: 100.0)
+    invoice!(doc: '11', due: @today - 45, balance: 200.0, customer: 'Beta LLC')
+    invoice!(doc: '12', due: @today + 5, balance: 300.0)   # not overdue
+    invoice!(doc: '13', due: @today - 20, balance: 150.0, total: 400.0) # partially paid overdue
 
     payload = payload_for(Mcp::ListOverdueInvoicesTool.call(server_context: {}))
     assert_equal 3, payload['count']
@@ -166,7 +194,7 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     assert_equal @sanctuary.name, top['enterprise']
     assert_equal 45, top['days_overdue']
     assert_equal 'unpaid_overdue', top['status']
-    assert_equal (Date.today - 45).iso8601, top['due_date']
+    assert_equal (@today - 45).iso8601, top['due_date']
     assert_match %r{https://app\.qbo\.intuit\.com/app/invoice\?txnId=}, top['qbo_invoice_link']
     assert top['display_name'].present?
 
@@ -177,16 +205,16 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
   end
 
   test 'list_overdue_invoices honors min_days_overdue' do
-    invoice!(doc: '20', due: Date.today - 5, balance: 100.0)
-    invoice!(doc: '21', due: Date.today - 40, balance: 200.0)
+    invoice!(doc: '20', due: @today - 5, balance: 100.0)
+    invoice!(doc: '21', due: @today - 40, balance: 200.0)
 
     payload = payload_for(Mcp::ListOverdueInvoicesTool.call(min_days_overdue: 30, server_context: {}))
     assert_equal %w[21], payload['invoices'].map { |i| i['doc_number'] }
   end
 
   test 'list_overdue_invoices clamps min_days_overdue below 1 to 1' do
-    invoice!(doc: '25', due: Date.today, balance: 100.0)      # due today, 0 days overdue
-    invoice!(doc: '26', due: Date.today - 3, balance: 200.0)  # 3 days overdue
+    invoice!(doc: '25', due: @today, balance: 100.0)      # due today, 0 days overdue
+    invoice!(doc: '26', due: @today - 3, balance: 200.0)  # 3 days overdue
 
     payload = payload_for(Mcp::ListOverdueInvoicesTool.call(min_days_overdue: 0, server_context: {}))
     assert_equal %w[26], payload['invoices'].map { |i| i['doc_number'] }
@@ -195,8 +223,8 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
   test 'list_overdue_invoices scopes by enterprise and rejects unknown names' do
     other = QboAccount.create!(enterprise: enterprises(:one), client_id: 'x',
                                client_secret: 'x', realm_id: 'realm-other2')
-    invoice!(doc: '30', due: Date.today - 5, balance: 100.0)
-    invoice!(doc: '31', due: Date.today - 5, balance: 200.0, account: other)
+    invoice!(doc: '30', due: @today - 5, balance: 100.0)
+    invoice!(doc: '31', due: @today - 5, balance: 200.0, account: other)
 
     scoped = payload_for(Mcp::ListOverdueInvoicesTool.call(
       enterprise: @sanctuary.name, server_context: {}))

--- a/test/services/mcp/finance_tools_test.rb
+++ b/test/services/mcp/finance_tools_test.rb
@@ -1,0 +1,102 @@
+require 'test_helper'
+
+class Mcp::FinanceToolsTest < ActiveSupport::TestCase
+  setup do
+    @sanctuary = enterprises(:sanctuary)
+    @account = qbo_accounts(:one)
+  end
+
+  # Minimal synced-invoice factory mirroring the jsonb shape QboInvoice
+  # accessors read (see app/models/qbo_invoice.rb).
+  def invoice!(doc:, due:, balance:, total: nil, customer: 'Acme Co',
+               email_status: 'EmailSent', account: @account)
+    QboInvoice.create!(
+      qbo_account: account,
+      qbo_id: "inv-#{doc}",
+      data: {
+        'doc_number' => doc,
+        'email_status' => email_status,
+        'due_date' => due.iso8601,
+        'balance' => balance,
+        'total' => total || balance,
+        'customer_ref' => { 'name' => customer },
+      }
+    )
+  end
+
+  def payload_for(resp)
+    JSON.parse(resp.content.first[:text])
+  end
+
+  # --- get_ar_aging ---
+
+  test 'get_ar_aging buckets balances by days overdue with correct boundaries' do
+    today = Date.today
+    invoice!(doc: 'a', due: today, balance: 10.0)           # 0 days  -> current
+    invoice!(doc: 'b', due: today - 30, balance: 20.0)      # 30 days -> days_0_30
+    invoice!(doc: 'c', due: today - 31, balance: 40.0)      # 31 days -> days_31_60
+    invoice!(doc: 'd', due: today - 90, balance: 80.0)      # 90 days -> days_61_90
+    invoice!(doc: 'e', due: today - 91, balance: 160.0)     # 91 days -> days_90_plus
+
+    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    ent = payload['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
+    acme = ent['customers'].find { |c| c['customer'] == 'Acme Co' }
+
+    assert_equal 10.0, acme['current']
+    assert_equal 20.0, acme['days_0_30']
+    assert_equal 40.0, acme['days_31_60']
+    assert_equal 80.0, acme['days_61_90']
+    assert_equal 160.0, acme['days_90_plus']
+    assert_equal 310.0, acme['total']
+    assert_equal 310.0, ent['total_ar']
+    assert_equal 310.0, payload['total_ar']
+    assert_equal Date.today.iso8601, payload['as_of']
+  end
+
+  test 'get_ar_aging sums outstanding balance, not invoice total' do
+    invoice!(doc: 'p', due: Date.today - 10, balance: 500.0, total: 1000.0)
+    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    acme = payload['enterprises'].first['customers'].first
+    assert_equal 500.0, acme['days_0_30']
+    assert_equal 500.0, acme['total']
+  end
+
+  test 'get_ar_aging excludes paid, unsent, and unsynced invoices — and never syncs' do
+    invoice!(doc: 'live', due: Date.today - 5, balance: 100.0)
+    invoice!(doc: 'paid', due: Date.today - 5, balance: 0.0, total: 300.0)
+    invoice!(doc: 'draft', due: Date.today - 5, balance: 50.0, email_status: 'NotSet')
+    QboInvoice.create!(qbo_account: @account, qbo_id: 'inv-unsynced', data: nil)
+
+    QboInvoice.any_instance.expects(:sync!).never
+    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    assert_equal 100.0, payload['total_ar']
+  end
+
+  test 'get_ar_aging groups by enterprise and scopes by the enterprise param' do
+    other = QboAccount.create!(enterprise: enterprises(:one), client_id: 'x',
+                               client_secret: 'x', realm_id: 'realm-other')
+    invoice!(doc: 's1', due: Date.today - 5, balance: 100.0)
+    invoice!(doc: 'o1', due: Date.today - 5, balance: 999.0, account: other,
+             customer: 'Other Client')
+
+    all = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    assert_equal 1099.0, all['total_ar']
+    assert_equal 2, all['enterprises'].length
+
+    scoped = payload_for(Mcp::GetArAgingTool.call(
+      enterprise: 'sanctuary computer inc', server_context: {}))
+    assert_equal 100.0, scoped['total_ar']
+    assert_equal [@sanctuary.name], scoped['enterprises'].map { |e| e['enterprise'] }
+  end
+
+  test 'get_ar_aging returns an error payload for an unknown enterprise' do
+    payload = payload_for(Mcp::GetArAgingTool.call(enterprise: 'Nope Inc', server_context: {}))
+    assert_includes payload['error'], "Unknown enterprise 'Nope Inc'"
+    assert_includes payload['error'], @sanctuary.name
+  end
+
+  test 'get_ar_aging returns an empty report when there are no receivables' do
+    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    assert_equal 0, payload['total_ar']
+  end
+end


### PR DESCRIPTION
## What

Two new read-only tools on the existing \`/api/mcp\` surface, from Phase 1a of the [Stacksbot roadmap](https://www.notion.so/garden3d/ROADMAP-md-391131fea2c7801485e0d767177e0da3) / [MCP upgrades spec](https://www.notion.so/garden3d/SPEC-Stacks-MCP-upgrades-391131fea2c78147a3aff77c7a6a5493). These unblock the top-ranked automation (**Ops pre-read**: weekly AR aging + newly-overdue invoices).

- **\`get_ar_aging\`** — AR buckets (current / 1-30 / 31-60 / 61-90 / over-90 days overdue) per customer per enterprise, computed from already-synced \`QboInvoice\` rows. Grouped by QBO customer id (name-keyed only for id-less rows), accumulated in integer cents so buckets always cross-foot exactly with totals in decimal.
- **\`list_overdue_invoices\`** — overdue invoices with \`days_overdue\`, sorted most-overdue first, \`min_days_overdue\` filter (clamped ≥ 1). Late fees are a per-client human decision: the tool exposes \`days_overdue\` + \`status\`, never a policy flag.
- **\`Mcp::QboReceivables\`** — shared module: one SQL-filtered query (\`QboInvoice.open_receivables\` scope), rows parsed once into validated \`Receivable\` structs, malformed rows dropped at a single enforcement point with capped log warnings.
- **\`Mcp::Responses\`** — shared MCP response envelope, now used by all five tools.

## Safety

- \`QboInvoice#data\` lazily re-fetches from QBO when its jsonb is empty. All reads go through model scopes that exclude unsynced rows **in SQL**; mocha \`sync!.never\` tests enforce that a tool call can never trigger a live QBO request. Observability queries are \`.pluck\`-only.
- Malformed synced rows are skipped, never crash a report — and never silently: exclusions (malformed, unsynced) are counted and warned with a capped sample, so a broken sync can't read as "nothing outstanding".
- \`QboInvoice#customer_ref\` hardened to always return a Hash (warns on malformed data) — also fixes a pre-existing unguarded caller in the invoice-trackers admin view.
- Read-only annotations on both tools; no schema changes, no new syncs, no new gems, no auth changes.

## Review process

Built spec-first (design doc + implementation plan in \`docs/superpowers/\`), executed via subagent-driven development with per-task and whole-branch reviews, then hardened through **eight rounds of high-effort multi-agent adversarial review** (each round: 4 finder angles + independent verification per finding). ~30 findings found and fixed across 9 commits, including real bugs: a malformed-row crash path, unvalidated invoice totals misclassifying partial payment, bucket-name off-by-ones, silent exclusion classes, and customer-identity grouping collisions.

Accepted deferrals (documented, deliberate): \`Date.today\` app-wide convention (shared with \`QboInvoice#status\`); status computed by the model (single source of truth) even for nil-total rows; per-call observability queries.

## Tests

MCP suites: **38 runs, 118 assertions, 0 failures**. Full suite: **555 runs, 1254 assertions, 0 branch-caused failures** (one pre-existing \`AdminUserTest\` date-boundary flake, verified failing identically on \`main\`). Coverage includes: bucket boundaries (30/31, 60/61, 90/91), balance-vs-total semantics, cents cross-footing, enterprise scoping + whitespace/Unicode name matching, unknown-enterprise errors, malformed rows (String customer_ref, missing/comma totals, missing balance keys, bad due dates), unsynced-row exclusion without network, identity-less debtor grouping, renamed-customer aggregation, and an HTTP \`tools/call\` round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)