### PR TITLE
Add list_open_admin_tasks MCP tool (TaskBuilder queue, amounts redacted)

### DIFF
--- a/app/models/stacks_task.rb
+++ b/app/models/stacks_task.rb
@@ -88,9 +88,11 @@ class StacksTask
   # reads as something a person can recognize (project name, lead title, contributor
   # email, etc.) rather than a generic Object#to_s.
   #
-  # redact_amounts: true omits dollar amounts (and free-text that can embed
-  # them) for surfaces outside the admin dashboard — the MCP read layer must
-  # expose task existence, not comp-adjacent figures.
+  # redact_amounts: true omits compensation-adjacent figures (reimbursement
+  # details, contributor ledger adjustment amounts) and gives unknown subject
+  # types a conservative generic name. Operational free-text (project names,
+  # survey titles, lead titles) passes through — those are business data the
+  # MCP layer exposes elsewhere by design.
   def subject_display_name(redact_amounts: false)
     case subject
     when ProjectTracker then subject.name.presence || "Project Tracker ##{subject.id}"

--- a/app/models/stacks_task.rb
+++ b/app/models/stacks_task.rb
@@ -87,14 +87,23 @@ class StacksTask
   # Display name shown in the Subject column — chosen per-class so each subject
   # reads as something a person can recognize (project name, lead title, contributor
   # email, etc.) rather than a generic Object#to_s.
-  def subject_display_name
+  #
+  # redact_amounts: true omits dollar amounts (and free-text that can embed
+  # them) for surfaces outside the admin dashboard — the MCP read layer must
+  # expose task existence, not comp-adjacent figures.
+  def subject_display_name(redact_amounts: false)
     case subject
     when ProjectTracker then subject.name.presence || "Project Tracker ##{subject.id}"
     when ForecastProject then subject.try(:display_name).presence || subject.name.presence || "Forecast Project ##{subject.forecast_id}"
     when ForecastPerson then subject.try(:display_name).presence || subject.try(:name).presence || subject.try(:email).presence || "Forecast Person ##{subject.forecast_id}"
     when ForecastAssignment then subject.try(:name).presence || "Forecast Assignment ##{subject.forecast_id}"
     when AdminUser then subject.email
-    when Reimbursement then (subject.try(:display_name).presence || "Reimbursement ##{subject.id}").truncate(50)
+    when Reimbursement
+      if redact_amounts
+        "Reimbursement ##{subject.id}"
+      else
+        (subject.try(:display_name).presence || "Reimbursement ##{subject.id}").truncate(50)
+      end
     when Survey then subject.try(:title).presence || "Survey ##{subject.id}"
     when ProjectSatisfactionSurvey
       pt_name = subject.try(:project_capsule).try(:project_tracker).try(:name)
@@ -102,7 +111,13 @@ class StacksTask
     when Stacks::Notion::Lead then subject.try(:page_title).presence || "Notion Lead"
     when PayCycle then "#{subject.enterprise.name} — #{subject.starts_at.to_s(:long)} to #{subject.ends_at.to_s(:long)}"
     when Ledger then "#{subject.contributor.forecast_person&.email || "Contributor ##{subject.contributor_id}"} on #{subject.enterprise.name}"
-    when RecurringLedgerAdjustment then "#{subject.ledger.contributor.forecast_person&.email || "Contributor ##{subject.ledger.contributor_id}"} on #{subject.ledger.enterprise.name} — #{subject.cadence} $#{format("%.2f", subject.amount)}"
+    when RecurringLedgerAdjustment
+      base = "#{subject.ledger.contributor.forecast_person&.email || "Contributor ##{subject.ledger.contributor_id}"} on #{subject.ledger.enterprise.name}"
+      if redact_amounts
+        "#{base} — #{subject.cadence} recurring adjustment"
+      else
+        "#{base} — #{subject.cadence} $#{format("%.2f", subject.amount)}"
+      end
     else
       subject.try(:display_name).presence || subject.try(:name).presence || subject.to_s
     end

--- a/app/models/stacks_task.rb
+++ b/app/models/stacks_task.rb
@@ -119,7 +119,14 @@ class StacksTask
         "#{base} — #{subject.cadence} $#{format("%.2f", subject.amount)}"
       end
     else
-      subject.try(:display_name).presence || subject.try(:name).presence || subject.to_s
+      if redact_amounts
+        # New monetary subject types must add an explicit redacting branch
+        # above. Until they do, this conservative fallback keeps free-text
+        # display names (which can embed amounts) out of redacted surfaces.
+        "#{subject.class.name.demodulize.titleize} ##{subject.try(:id) || '?'}"
+      else
+        subject.try(:display_name).presence || subject.try(:name).presence || subject.to_s
+      end
     end
   end
 

--- a/app/services/mcp/list_open_admin_tasks_tool.rb
+++ b/app/services/mcp/list_open_admin_tasks_tool.rb
@@ -20,10 +20,13 @@ module Mcp
       builder = Stacks::TaskBuilder.new
       tasks =
         if owner.present?
-          candidates = AdminUser.active.distinct.order(:email).to_a
+          # Owner-eligible = currently-active admins plus role-admins — the same set
+          # TaskBuilder routes ownership to (its fallback is AdminUser.admin), so every
+          # owners[] email the tool emits is resolvable as a filter.
+          candidates = (AdminUser.active.distinct.to_a | AdminUser.admin.to_a)
           admin = candidates.find { |a| a.email.casecmp?(owner.to_s.strip) }
           unless admin
-            return Responses.error("Unknown owner '#{owner}'. Valid owners: #{candidates.map(&:email).join(', ')}")
+            return Responses.error("Unknown owner '#{owner}'. Valid owners: #{candidates.map(&:email).sort.join(', ')}")
           end
           builder.tasks_for(admin)
         else

--- a/app/services/mcp/list_open_admin_tasks_tool.rb
+++ b/app/services/mcp/list_open_admin_tasks_tool.rb
@@ -26,11 +26,13 @@ module Mcp
           admin = AdminUser.all.to_a.find { |a| a.email.casecmp?(owner.to_s.strip) }
           unless admin
             # Suggest emails of CURRENT queue owners, derived from the same
-            # hydrated tasks the unfiltered call emits — so suggestions are
-            # always followable and nothing beyond already-emitted emails is
-            # disclosed (raw cached owner_ids could name owners of tasks
-            # hydration skips, e.g. a deleted subject). Error path only, so
-            # the hydration cost doesn't touch the happy path.
+            # hydrated tasks the unfiltered call renders (raw cached owner_ids
+            # could also name owners of tasks hydration skips, e.g. a deleted
+            # subject). One narrow caveat: if an owner's only task is being
+            # dropped by the mapping rescue below, their email can appear here
+            # without appearing in payloads — acceptable, these are internal
+            # admin emails behind the same API key. Error path only, so the
+            # hydration cost doesn't touch the happy path.
             valid = builder.tasks.flat_map(&:owners).map(&:email).uniq.sort
             roster = valid.any? ? " Current task owners: #{valid.join(', ')}" : ' The task queue is currently empty.'
             return Responses.error("Unknown owner '#{owner}'.#{roster}")

--- a/app/services/mcp/list_open_admin_tasks_tool.rb
+++ b/app/services/mcp/list_open_admin_tasks_tool.rb
@@ -1,0 +1,50 @@
+module Mcp
+  class ListOpenAdminTasksTool < MCP::Tool
+    tool_name 'list_open_admin_tasks'
+    description 'Stacks system-administration tasks needing attention (data hygiene, approvals, ' \
+                'sync debt) from the owner-routed TaskBuilder queue (24h cache). Distinct from ' \
+                'Notion Tasks, which are day-to-day work tasks. Relative urls are paths on the ' \
+                'Stacks admin host; url_external true means an absolute Forecast/Notion link. ' \
+                'Dollar amounts are redacted from display strings.'
+    input_schema(
+      properties: {
+        owner: { type: 'string', description: 'Optional AdminUser email filter (case-insensitive)' },
+      },
+      required: []
+    )
+    annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true)
+
+    def self.call(owner: nil, server_context:)
+      builder = Stacks::TaskBuilder.new
+      tasks =
+        if owner.present?
+          admin = AdminUser.find_by('LOWER(email) = ?', owner.to_s.strip.downcase)
+          unless admin
+            valid = AdminUser.order(:email).pluck(:email)
+            return Responses.error("Unknown owner '#{owner}'. Valid owners: #{valid.join(', ')}")
+          end
+          builder.tasks_for(admin)
+        else
+          builder.tasks
+        end
+
+      rows = tasks.filter_map do |t|
+        {
+          type: t.type,
+          task: t.humanized_type,
+          subject_class: t.subject_class_key,
+          subject: t.subject_display_name(redact_amounts: true),
+          url: t.subject_url,
+          url_external: t.subject_url_external?,
+          owners: t.owners.map(&:email),
+        }
+      rescue StandardError => e
+        Rails.logger.warn("[Mcp::ListOpenAdminTasksTool] skipping task #{t.type}: #{e.class}: #{e.message}")
+        nil
+      end
+      rows = rows.sort_by { |r| [r[:subject_class], r[:type].to_s, r[:subject].to_s] }
+
+      Responses.ok({ count: rows.length, tasks: rows })
+    end
+  end
+end

--- a/app/services/mcp/list_open_admin_tasks_tool.rb
+++ b/app/services/mcp/list_open_admin_tasks_tool.rb
@@ -8,7 +8,7 @@ module Mcp
                 'Dollar amounts are redacted from display strings.'
     input_schema(
       properties: {
-        owner: { type: 'string', description: 'Optional AdminUser email filter (case-insensitive)' },
+        owner: { type: 'string', description: 'Optional AdminUser email filter (case-insensitive; blank/whitespace means no filter)' },
       },
       required: []
     )

--- a/app/services/mcp/list_open_admin_tasks_tool.rb
+++ b/app/services/mcp/list_open_admin_tasks_tool.rb
@@ -2,7 +2,7 @@ module Mcp
   class ListOpenAdminTasksTool < MCP::Tool
     tool_name 'list_open_admin_tasks'
     description 'Stacks system-administration tasks needing attention (data hygiene, approvals, ' \
-                'sync debt) from the owner-routed TaskBuilder queue (24h cache). Distinct from ' \
+                "sync debt) from the owner-routed TaskBuilder queue (#{Stacks::TaskBuilder::CACHE_TTL.inspect} cache). Distinct from " \
                 'Notion Tasks, which are day-to-day work tasks. Relative urls are paths on the ' \
                 'Stacks admin host; url_external true means an absolute Forecast/Notion link. ' \
                 'Compensation-adjacent amounts (reimbursements, contributor ledger adjustments) ' \
@@ -20,7 +20,7 @@ module Mcp
       builder = Stacks::TaskBuilder.new
       tasks =
         if owner.present?
-          candidates = AdminUser.active.order(:email).to_a
+          candidates = AdminUser.active.distinct.order(:email).to_a
           admin = candidates.find { |a| a.email.casecmp?(owner.to_s.strip) }
           unless admin
             return Responses.error("Unknown owner '#{owner}'. Valid owners: #{candidates.map(&:email).join(', ')}")
@@ -42,6 +42,7 @@ module Mcp
         }
       rescue StandardError => e
         Rails.logger.warn("[Mcp::ListOpenAdminTasksTool] skipping task #{t.type}: #{e.class}: #{e.message}")
+        Sentry.capture_exception(e) if defined?(Sentry)
         nil
       end
       rows = rows.sort_by { |r| [r[:subject_class], r[:type].to_s, r[:subject].to_s] }

--- a/app/services/mcp/list_open_admin_tasks_tool.rb
+++ b/app/services/mcp/list_open_admin_tasks_tool.rb
@@ -5,7 +5,9 @@ module Mcp
                 'sync debt) from the owner-routed TaskBuilder queue (24h cache). Distinct from ' \
                 'Notion Tasks, which are day-to-day work tasks. Relative urls are paths on the ' \
                 'Stacks admin host; url_external true means an absolute Forecast/Notion link. ' \
-                'Dollar amounts are redacted from display strings.'
+                'Compensation-adjacent amounts (reimbursements, contributor ledger adjustments) ' \
+                'are redacted from display strings; operational names (projects, leads, surveys) ' \
+                'pass through as-is.'
     input_schema(
       properties: {
         owner: { type: 'string', description: 'Optional AdminUser email filter (case-insensitive; blank/whitespace means no filter)' },
@@ -18,10 +20,10 @@ module Mcp
       builder = Stacks::TaskBuilder.new
       tasks =
         if owner.present?
-          admin = AdminUser.find_by('LOWER(email) = ?', owner.to_s.strip.downcase)
+          candidates = AdminUser.active.order(:email).to_a
+          admin = candidates.find { |a| a.email.casecmp?(owner.to_s.strip) }
           unless admin
-            valid = AdminUser.order(:email).pluck(:email)
-            return Responses.error("Unknown owner '#{owner}'. Valid owners: #{valid.join(', ')}")
+            return Responses.error("Unknown owner '#{owner}'. Valid owners: #{candidates.map(&:email).join(', ')}")
           end
           builder.tasks_for(admin)
         else

--- a/app/services/mcp/list_open_admin_tasks_tool.rb
+++ b/app/services/mcp/list_open_admin_tasks_tool.rb
@@ -25,11 +25,15 @@ module Mcp
           # Unicode-safe regardless of DB collation; the admin table is small.
           admin = AdminUser.all.to_a.find { |a| a.email.casecmp?(owner.to_s.strip) }
           unless admin
-            # Suggest emails of CURRENT queue owners — exactly the set this
-            # tool emits in owners[], so suggestions are always followable
-            # and nothing beyond already-exposed emails is disclosed.
-            valid = AdminUser.where(id: builder.owner_ids).pluck(:email).sort
-            return Responses.error("Unknown owner '#{owner}'. Current task owners: #{valid.join(', ')}")
+            # Suggest emails of CURRENT queue owners, derived from the same
+            # hydrated tasks the unfiltered call emits — so suggestions are
+            # always followable and nothing beyond already-emitted emails is
+            # disclosed (raw cached owner_ids could name owners of tasks
+            # hydration skips, e.g. a deleted subject). Error path only, so
+            # the hydration cost doesn't touch the happy path.
+            valid = builder.tasks.flat_map(&:owners).map(&:email).uniq.sort
+            roster = valid.any? ? " Current task owners: #{valid.join(', ')}" : ' The task queue is currently empty.'
+            return Responses.error("Unknown owner '#{owner}'.#{roster}")
           end
           builder.tasks_for(admin)
         else

--- a/app/services/mcp/list_open_admin_tasks_tool.rb
+++ b/app/services/mcp/list_open_admin_tasks_tool.rb
@@ -20,13 +20,16 @@ module Mcp
       builder = Stacks::TaskBuilder.new
       tasks =
         if owner.present?
-          # Owner-eligible = currently-active admins plus role-admins — the same set
-          # TaskBuilder routes ownership to (its fallback is AdminUser.admin), so every
-          # owners[] email the tool emits is resolvable as a filter.
-          candidates = (AdminUser.active.distinct.to_a | AdminUser.admin.to_a)
-          admin = candidates.find { |a| a.email.casecmp?(owner.to_s.strip) }
+          # Any real admin's email resolves — a taskless admin gets an honest
+          # empty list, not an error. Ruby-side casecmp? keeps matching
+          # Unicode-safe regardless of DB collation; the admin table is small.
+          admin = AdminUser.all.to_a.find { |a| a.email.casecmp?(owner.to_s.strip) }
           unless admin
-            return Responses.error("Unknown owner '#{owner}'. Valid owners: #{candidates.map(&:email).sort.join(', ')}")
+            # Suggest emails of CURRENT queue owners — exactly the set this
+            # tool emits in owners[], so suggestions are always followable
+            # and nothing beyond already-exposed emails is disclosed.
+            valid = AdminUser.where(id: builder.owner_ids).pluck(:email).sort
+            return Responses.error("Unknown owner '#{owner}'. Current task owners: #{valid.join(', ')}")
           end
           builder.tasks_for(admin)
         else

--- a/app/services/mcp/server.rb
+++ b/app/services/mcp/server.rb
@@ -18,6 +18,7 @@ module Mcp
       Mcp::GetDocumentTool,
       Mcp::GetArAgingTool,
       Mcp::ListOverdueInvoicesTool,
+      Mcp::ListOpenAdminTasksTool,
     ].freeze
 
     def self.build

--- a/docs/superpowers/plans/2026-07-04-mcp-admin-tasks.md
+++ b/docs/superpowers/plans/2026-07-04-mcp-admin-tasks.md
@@ -1,0 +1,399 @@
+# list_open_admin_tasks MCP Tool Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose the Stacks TaskBuilder attention queue as a read-only MCP tool, `list_open_admin_tasks`, with dollar amounts redacted from display strings.
+
+**Architecture:** A `redact_amounts:` keyword on `StacksTask#subject_display_name` (model stays the single source of display truth; admin dashboard behavior unchanged), then a thin presenter tool over `Stacks::TaskBuilder#tasks` / `#tasks_for`, registered on the existing `/api/mcp` surface with the shared `Mcp::Responses` envelope.
+
+**Tech Stack:** Rails, `mcp` Ruby gem, Minitest + mocha.
+
+**Spec:** `docs/superpowers/specs/2026-07-04-mcp-admin-tasks-design.md`
+
+## Global Constraints
+
+- `/api/mcp` is read-only: `annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true)` on the tool.
+- Response envelope: `Mcp::Responses.ok(payload)` / `Mcp::Responses.error(message)` (exists at `app/services/mcp/responses.rb`).
+- Dollar amounts never appear in the MCP payload: the tool always calls `subject_display_name(redact_amounts: true)`.
+- A task whose payload mapping raises is skipped with a `Rails.logger.warn`, never fails the list.
+- Unknown `owner` email → error payload listing valid admin emails.
+- Default behavior of `subject_display_name` (no keyword) is byte-identical to today — the admin dashboard must not change.
+- No schema changes, no new gems, no cache changes.
+- Tests: `bin/rails test <path>`; mocha available. AdminUser is a Devise model: `AdminUser.create!(email: ..., password: "password123", password_confirmation: "password123", roles: ["admin"])`.
+
+---
+
+### Task 1: `StacksTask#subject_display_name(redact_amounts:)` + missing requires
+
+**Files:**
+- Modify: `app/models/stacks_task.rb:90-109` (subject_display_name)
+- Modify: `lib/stacks/task_builder.rb:1-11` (require_relative list)
+- Create: `test/models/stacks_task_test.rb`
+
+**Interfaces:**
+- Consumes: `RecurringLedgerAdjustment` (belongs_to :ledger; validates amount, cadence in `%w[monthly twice_monthly quarterly]`, next_due_on), `Ledger` (belongs_to :enterprise, :contributor), `Contributor` (belongs_to :forecast_person via forecast_person_id → ForecastPerson.forecast_id), `Reimbursement#display_name` (embeds free-text description), fixtures `enterprises(:sanctuary)`.
+- Produces: `StacksTask#subject_display_name(redact_amounts: false) → String` — Task 2 calls it with `redact_amounts: true`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/models/stacks_task_test.rb`:
+
+```ruby
+require 'test_helper'
+
+class StacksTaskTest < ActiveSupport::TestCase
+  setup do
+    @admin = AdminUser.create!(email: "st#{SecureRandom.hex(2)}@example.com",
+                               password: 'password123', password_confirmation: 'password123',
+                               roles: ['admin'])
+  end
+
+  def recurring_adjustment!
+    fp = ForecastPerson.create!(forecast_id: rand(1..2_000_000_000),
+                                email: "rla#{SecureRandom.hex(2)}@example.com", data: {})
+    contributor = Contributor.create!(forecast_person: fp)
+    ledger = Ledger.create!(enterprise: enterprises(:sanctuary), contributor: contributor)
+    RecurringLedgerAdjustment.create!(ledger: ledger, amount: 250.0, cadence: 'monthly',
+                                      next_due_on: Date.today + 7)
+  end
+
+  test 'subject_display_name for RecurringLedgerAdjustment includes the amount by default' do
+    task = StacksTask.new(type: :auto_paused_recurring_on_qbo_bound,
+                          subject: recurring_adjustment!, owners: [@admin])
+    assert_includes task.subject_display_name, '$250.00'
+    assert_includes task.subject_display_name, 'monthly'
+  end
+
+  test 'subject_display_name redacts the amount when redact_amounts is true' do
+    task = StacksTask.new(type: :auto_paused_recurring_on_qbo_bound,
+                          subject: recurring_adjustment!, owners: [@admin])
+    redacted = task.subject_display_name(redact_amounts: true)
+    refute_includes redacted, '$'
+    assert_includes redacted, 'monthly'
+    assert_includes redacted, 'recurring adjustment'
+    assert_includes redacted, enterprises(:sanctuary).name
+  end
+
+  test 'subject_display_name for Reimbursement is generic when redacted' do
+    fp = ForecastPerson.create!(forecast_id: rand(1..2_000_000_000),
+                                email: "rb#{SecureRandom.hex(2)}@example.com", data: {})
+    contributor = Contributor.create!(forecast_person: fp)
+    ledger = Ledger.create!(enterprise: enterprises(:sanctuary), contributor: contributor)
+    reimbursement = Reimbursement.create!(ledger: ledger, description: 'Team dinner $840',
+                                          amount: 840.0)
+    task = StacksTask.new(type: :pending_acceptance, subject: reimbursement, owners: [@admin])
+    assert_equal "Reimbursement ##{reimbursement.id}", task.subject_display_name(redact_amounts: true)
+    assert_includes task.subject_display_name, 'Team dinner' # default unchanged
+  end
+
+  test 'redact_amounts leaves non-monetary subjects untouched' do
+    task = StacksTask.new(type: :missing_skill_tree, subject: @admin, owners: [@admin])
+    assert_equal task.subject_display_name, task.subject_display_name(redact_amounts: true)
+    assert_equal @admin.email, task.subject_display_name
+  end
+end
+```
+
+NOTE: if `Reimbursement.create!` fails validation, check `app/models/reimbursement.rb` for
+required fields and add the minimal missing attributes (its `display_name` reads
+`contributor.forecast_person.email`, `created_at`, and `description` — the associations above
+supply those). Do not change the model.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bin/rails test test/models/stacks_task_test.rb`
+Expected: FAIL — `ArgumentError: wrong number of arguments` / `unknown keyword: :redact_amounts` on the redaction tests (the default-behavior assertions may already pass).
+
+- [ ] **Step 3: Implement the keyword**
+
+In `app/models/stacks_task.rb`, change the `subject_display_name` signature and the two
+monetary branches (leave every other branch exactly as-is):
+
+```ruby
+  # Display name shown in the Subject column — chosen per-class so each subject
+  # reads as something a person can recognize (project name, lead title, contributor
+  # email, etc.) rather than a generic Object#to_s.
+  #
+  # redact_amounts: true omits dollar amounts (and free-text that can embed
+  # them) for surfaces outside the admin dashboard — the MCP read layer must
+  # expose task existence, not comp-adjacent figures.
+  def subject_display_name(redact_amounts: false)
+```
+
+Reimbursement branch:
+
+```ruby
+    when Reimbursement
+      if redact_amounts
+        "Reimbursement ##{subject.id}"
+      else
+        (subject.try(:display_name).presence || "Reimbursement ##{subject.id}").truncate(50)
+      end
+```
+
+RecurringLedgerAdjustment branch:
+
+```ruby
+    when RecurringLedgerAdjustment
+      base = "#{subject.ledger.contributor.forecast_person&.email || "Contributor ##{subject.ledger.contributor_id}"} on #{subject.ledger.enterprise.name}"
+      if redact_amounts
+        "#{base} — #{subject.cadence} recurring adjustment"
+      else
+        "#{base} — #{subject.cadence} $#{format("%.2f", subject.amount)}"
+      end
+```
+
+In `lib/stacks/task_builder.rb`, add the two missing requires after the existing
+`require_relative "task_builder/discoveries/missing_qbo_vendors"` line (the classes are in
+`DISCOVERY_CLASSES` but were never required — they currently load only if something else
+gets there first):
+
+```ruby
+require_relative "task_builder/discoveries/legacy_ledgers_pending_qbo_migration"
+require_relative "task_builder/discoveries/auto_paused_recurring_ledger_adjustments"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bin/rails test test/models/stacks_task_test.rb`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/models/stacks_task.rb lib/stacks/task_builder.rb test/models/stacks_task_test.rb
+git commit -m "Add redact_amounts to StacksTask display names; require missing discoveries"
+```
+
+---
+
+### Task 2: `list_open_admin_tasks` tool
+
+**Files:**
+- Create: `app/services/mcp/list_open_admin_tasks_tool.rb`
+- Create: `test/services/mcp/admin_tasks_tool_test.rb`
+- Modify: `app/services/mcp/server.rb` (TOOLS array, currently 6 entries)
+- Modify: `test/integration/mcp_endpoint_test.rb:48` (tool-name array) + add one `tools/call` round-trip test
+
+**Interfaces:**
+- Consumes (from Task 1): `StacksTask#subject_display_name(redact_amounts: true)`. Also `Stacks::TaskBuilder#tasks → Array<StacksTask>`, `#tasks_for(admin_user) → Array<StacksTask>`, `StacksTask#type/#humanized_type/#subject_class_key/#subject_url/#subject_url_external?/#owners`, `Mcp::Responses.ok/.error`.
+- Produces: the `list_open_admin_tasks` MCP tool. Payload:
+  `{ count:, tasks: [{ type, task, subject_class, subject, url, url_external, owners: [emails] }] }`,
+  sorted by `[subject_class, type, subject]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/services/mcp/admin_tasks_tool_test.rb`:
+
+```ruby
+require 'test_helper'
+
+class Mcp::AdminTasksToolTest < ActiveSupport::TestCase
+  setup do
+    @admin = AdminUser.create!(email: "at#{SecureRandom.hex(2)}@example.com",
+                               password: 'password123', password_confirmation: 'password123',
+                               roles: ['admin'])
+    @other = AdminUser.create!(email: "ot#{SecureRandom.hex(2)}@example.com",
+                               password: 'password123', password_confirmation: 'password123',
+                               roles: ['admin'])
+  end
+
+  def task_for(admin, type: :missing_skill_tree)
+    StacksTask.new(type: type, subject: admin, owners: [admin])
+  end
+
+  def payload_for(resp)
+    JSON.parse(resp.content.first[:text])
+  end
+
+  test 'returns mapped, sorted tasks with owner emails' do
+    Stacks::TaskBuilder.any_instance.stubs(:tasks).returns(
+      [task_for(@other, type: :no_full_time_periods_set), task_for(@admin)]
+    )
+    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(server_context: {}))
+    assert_equal 2, payload['count']
+    row = payload['tasks'].find { |t| t['type'] == 'missing_skill_tree' }
+    assert_equal 'Admin user needs skill tree set', row['task']
+    assert_equal 'admin_users', row['subject_class']
+    assert_equal @admin.email, row['subject']
+    assert_equal false, row['url_external']
+    assert_match %r{/admin/admin_users/#{@admin.id}}, row['url']
+    assert_equal [@admin.email], row['owners']
+    types = payload['tasks'].map { |t| t['type'] }
+    assert_equal types.sort, types, 'tasks sorted within subject_class by type'
+  end
+
+  test 'owner param filters via tasks_for with case-insensitive email' do
+    Stacks::TaskBuilder.any_instance.expects(:tasks_for).with(@admin).returns([task_for(@admin)])
+    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(owner: @admin.email.upcase, server_context: {}))
+    assert_equal 1, payload['count']
+  end
+
+  test 'unknown owner returns an error payload listing valid emails' do
+    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(owner: 'nobody@nowhere.dev', server_context: {}))
+    assert_includes payload['error'], "Unknown owner 'nobody@nowhere.dev'"
+    assert_includes payload['error'], @admin.email
+  end
+
+  test 'a task whose mapping raises is skipped with a warning, not fatal' do
+    Stacks::TaskBuilder.any_instance.stubs(:tasks).returns([task_for(@admin)])
+    StacksTask.any_instance.stubs(:subject_url).raises(RuntimeError, 'boom')
+    Rails.logger.expects(:warn).with { |msg| msg.include?('skipping task') }
+    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(server_context: {}))
+    assert_equal 0, payload['count']
+    assert_equal [], payload['tasks']
+  end
+
+  test 'empty queue returns a valid empty payload' do
+    Stacks::TaskBuilder.any_instance.stubs(:tasks).returns([])
+    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(server_context: {}))
+    assert_equal 0, payload['count']
+    assert_equal [], payload['tasks']
+  end
+end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bin/rails test test/services/mcp/admin_tasks_tool_test.rb`
+Expected: FAIL — `NameError: uninitialized constant Mcp::ListOpenAdminTasksTool`.
+
+- [ ] **Step 3: Implement the tool and register it**
+
+Create `app/services/mcp/list_open_admin_tasks_tool.rb`:
+
+```ruby
+module Mcp
+  class ListOpenAdminTasksTool < MCP::Tool
+    tool_name 'list_open_admin_tasks'
+    description 'Stacks system-administration tasks needing attention (data hygiene, approvals, ' \
+                'sync debt) from the owner-routed TaskBuilder queue (24h cache). Distinct from ' \
+                'Notion Tasks, which are day-to-day work tasks. Relative urls are paths on the ' \
+                'Stacks admin host; url_external true means an absolute Forecast/Notion link. ' \
+                'Dollar amounts are redacted from display strings.'
+    input_schema(
+      properties: {
+        owner: { type: 'string', description: 'Optional AdminUser email filter (case-insensitive)' },
+      },
+      required: []
+    )
+    annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true)
+
+    def self.call(owner: nil, server_context:)
+      builder = Stacks::TaskBuilder.new
+      tasks =
+        if owner.present?
+          admin = AdminUser.find_by('LOWER(email) = ?', owner.to_s.strip.downcase)
+          unless admin
+            valid = AdminUser.order(:email).pluck(:email)
+            return Responses.error("Unknown owner '#{owner}'. Valid owners: #{valid.join(', ')}")
+          end
+          builder.tasks_for(admin)
+        else
+          builder.tasks
+        end
+
+      rows = tasks.filter_map do |t|
+        {
+          type: t.type,
+          task: t.humanized_type,
+          subject_class: t.subject_class_key,
+          subject: t.subject_display_name(redact_amounts: true),
+          url: t.subject_url,
+          url_external: t.subject_url_external?,
+          owners: t.owners.map(&:email),
+        }
+      rescue StandardError => e
+        Rails.logger.warn("[Mcp::ListOpenAdminTasksTool] skipping task #{t.type}: #{e.class}: #{e.message}")
+        nil
+      end
+      rows = rows.sort_by { |r| [r[:subject_class], r[:type].to_s, r[:subject].to_s] }
+
+      Responses.ok({ count: rows.length, tasks: rows })
+    end
+  end
+end
+```
+
+Append to `TOOLS` in `app/services/mcp/server.rb`:
+
+```ruby
+      Mcp::ListOpenAdminTasksTool,
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bin/rails test test/services/mcp/admin_tasks_tool_test.rb`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Update the integration test**
+
+In `test/integration/mcp_endpoint_test.rb` (~line 48):
+
+```ruby
+    assert_equal %w[get_ar_aging get_document list_documents list_open_admin_tasks list_overdue_invoices list_sources search], tool_names.sort,
+      "Expected all registered tools, got: #{tool_names.inspect}"
+```
+
+Add a round-trip test (mirror the existing `get_ar_aging` `tools/call` test in the same file
+for headers / api-key setup / JSON-RPC envelope). Stub the queue so the test exercises
+dispatch and envelope, not the discovery sweep over an empty DB:
+
+```ruby
+  test "tools/call round-trip for list_open_admin_tasks returns a valid payload" do
+    Stacks::TaskBuilder.any_instance.stubs(:tasks).returns([])
+    post "/api/mcp",
+      headers: api_key_headers,
+      params: {
+        jsonrpc: "2.0", id: 9, method: "tools/call",
+        params: { name: "list_open_admin_tasks", arguments: {} },
+      }.to_json
+    assert_response :success
+    text = JSON.parse(response.body).dig("result", "content", 0, "text")
+    payload = JSON.parse(text)
+    assert_equal 0, payload["count"]
+    assert_equal [], payload["tasks"]
+  end
+```
+
+(If mocha `any_instance` stubbing does not take effect through the integration stack, run the
+real sweep instead and assert only `payload.key?("count") && payload.key?("tasks")` — note
+which variant you shipped in your report.)
+
+Run: `bin/rails test test/integration/mcp_endpoint_test.rb`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/mcp/list_open_admin_tasks_tool.rb app/services/mcp/server.rb \
+        test/services/mcp/admin_tasks_tool_test.rb test/integration/mcp_endpoint_test.rb
+git commit -m "Add list_open_admin_tasks MCP tool (TaskBuilder queue, amounts redacted)"
+```
+
+---
+
+### Task 3: Full-suite verification
+
+**Files:** none new — fix only branch-caused fallout.
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–2.
+- Produces: a green suite (modulo the known pre-existing `AdminUserTest` date-boundary flake, which fails identically on `main` — report it, don't fix it).
+
+- [ ] **Step 1: Run the MCP + models suites**
+
+Run: `bin/rails test test/services/mcp test/models/stacks_task_test.rb test/integration/mcp_endpoint_test.rb`
+Expected: PASS.
+
+- [ ] **Step 2: Run the full suite**
+
+Run: `bin/rails test`
+Expected: no new failures relative to `main`. The pre-existing `AdminUserTest` salary-window
+date flake may appear — classify, do not fix.
+
+- [ ] **Step 3: Commit (only if fixes were needed)**
+
+```bash
+git add -A && git commit -m "Fix test fallout from list_open_admin_tasks"
+```

--- a/docs/superpowers/specs/2026-07-04-mcp-admin-tasks-design.md
+++ b/docs/superpowers/specs/2026-07-04-mcp-admin-tasks-design.md
@@ -1,0 +1,134 @@
+# Design: MCP tool — `list_open_admin_tasks`
+
+**Date:** 2026-07-04
+**Source:** [Stacksbot ROADMAP](https://www.notion.so/garden3d/ROADMAP-md-391131fea2c7801485e0d767177e0da3) Phase 1a + [SPEC — Stacks MCP upgrades](https://www.notion.so/garden3d/SPEC-Stacks-MCP-upgrades-391131fea2c78147a3aff77c7a6a5493) (`list_open_tasks` row)
+**Status:** Draft — awaiting Hugh's review. One boundary decision defaulted while he was away, flagged ⚖️ below.
+
+## Naming (decided by Hugh, 2026-07-04)
+
+`list_open_admin_tasks`, not the spec's `list_open_tasks`: these are **Stacks system-administration
+tasks** (the TaskBuilder "what needs attention" queue — data hygiene, approvals, sync debt),
+distinct from Notion **Tasks** (day-to-day work tasks for the whole company) which will become
+their own source in P1a's Datazone work. The name carries the distinction so Recall and future
+Sources rows can't confuse them.
+
+## Why this slice
+
+The engineering spec calls the TaskBuilder queue "the single most agent-ready dataset in the
+whole company": 12 discovery classes, already owner-routed, cached with a 24h TTL (rebuilt on first read after expiry or a cache bust), with
+display names, fix-it URLs, and humanized labels already computed by `StacksTask`
+(`app/models/stacks_task.rb`). Feeds the Director-of-Delivery role and the Stewardship sweep.
+
+## Approaches considered
+
+1. **Thin presenter over `Stacks::TaskBuilder` (chosen).** One tool file; call
+   `TaskBuilder.new.tasks` (or `#tasks_for(admin_user)` when filtering by owner — it filters
+   descriptors *before* hydration, so the per-owner path never loads unrelated subjects); map
+   each `StacksTask` through its existing accessors. No new queries beyond TaskBuilder's own
+   bounded hydration (one SELECT per unique subject class + one for AdminUsers).
+2. **Raw descriptor dump (no hydration).** Cheapest read, but descriptors are
+   `{subject_type, subject_id, type, owner_ids}` — no display names, no URLs, no humanized
+   labels. The agent would need N follow-up lookups. Rejected.
+3. **Group-by-owner payload.** Pre-shapes for the per-PL digest, but the flat list + `owner`
+   param serves both that and the whole-queue stewardship view. Rejected (YAGNI).
+
+## Tool contract
+
+- **File:** `app/services/mcp/list_open_admin_tasks_tool.rb`, registered in
+  `Mcp::Server::TOOLS` (7th tool).
+- **Params:**
+  - `owner` (optional string) — AdminUser email, case-insensitive. Uses
+    `TaskBuilder#tasks_for`. Unknown email → `Mcp::Responses.error` listing valid owner
+    emails (mirrors the enterprise-param pattern; roster is internal-only data behind the
+    same key).
+- **Payload:**
+
+```json
+{
+  "count": 42,
+  "tasks": [
+    {
+      "type": "project_capsule_incomplete",
+      "task": "Project capsule needs completion",
+      "subject_class": "project_trackers",
+      "subject": "Acme Website Rebuild",
+      "url": "/admin/project_trackers/123",
+      "url_external": false,
+      "owners": ["someone@sanctuary.computer"]
+    }
+  ]
+}
+```
+
+  Field sources: `type` / `humanized_type` (as `task`) / `subject_class_key` /
+  `subject_display_name(redact_amounts: true)` / `subject_url` / `subject_url_external?` /
+  `owners.map(&:email)`. Internal `url`s are relative paths on the Stacks admin host
+  (`url_external: false`); Forecast/Notion links are absolute (`url_external: true`) — the
+  tool description says so.
+- **Ordering:** grouped stable — sorted by `subject_class`, then `type`, then `subject` —
+  so diffs between runs read cleanly.
+- **Annotations:** `read_only_hint: true, destructive_hint: false, idempotent_hint: true`
+  (idempotent within the 24h cache window).
+- **Envelope:** `Mcp::Responses.ok` / `.error`.
+
+## ⚖️ Comp boundary (defaulted — Hugh to confirm)
+
+The queue includes comp-adjacent task types (pay-cycle approvals, reimbursements, contributor
+ledger adjustments). Chosen default, consistent with the late-fee "expose data, not policy /
+wall out comp content" doctrine: **expose every task type — the nudge is the point — but
+redact dollar amounts from MCP display strings.** Mechanism keeps the model the single source
+of truth:
+
+- `StacksTask#subject_display_name` gains a keyword: `subject_display_name(redact_amounts: false)`.
+  Default `false` → existing behavior, zero change for the admin dashboard.
+- With `redact_amounts: true`:
+  - `RecurringLedgerAdjustment` renders `"<contributor email> on <enterprise> — <cadence>
+    recurring adjustment"` (drops `$<amount>`).
+  - `Reimbursement` renders `"Reimbursement #<id>"` (its free-text display_name can embed
+    amounts).
+  - All other branches unchanged (PayCycle shows enterprise + date range — no amounts;
+    verified).
+- The MCP tool always passes `redact_amounts: true`.
+
+Alternatives Hugh can pick instead: expose verbatim (drop the keyword), or exclude the
+comp-adjacent types entirely (filter by type list in the tool).
+
+## Cache behavior (accepted)
+
+The tool reads through TaskBuilder's 24h descriptor cache. A call landing on a cold cache
+triggers the full discovery sweep — the same cost the `/admin/tasks` dashboard pays on first
+load today, accepted as-is. No cache changes in this slice.
+
+## Drive-by fix (from the engineering spec §7)
+
+`DISCOVERY_CLASSES` lists 12 classes but `lib/stacks/task_builder.rb` only `require_relative`s
+10 — `legacy_ledgers_pending_qbo_migration` and `auto_paused_recurring_ledger_adjustments`
+exist on disk but aren't required at the top. Add the two `require_relative` lines (verify
+first whether autoloading already covers them; add regardless for consistency with the
+file's own convention).
+
+## Error handling
+
+- Unknown `owner` email → error payload listing valid admin emails.
+- A `StacksTask` whose payload mapping raises (exotic subject state) → skipped with a
+  `Rails.logger.warn`, never fails the whole list (same doctrine as `QboReceivables`).
+- Empty queue → `{ count: 0, tasks: [] }`.
+
+## Testing
+
+- Unit (`test/services/mcp/admin_tasks_tool_test.rb`): stub `Stacks::TaskBuilder#tasks` /
+  `#tasks_for` (mocha) to return constructed `StacksTask` objects over light fixture-backed
+  subjects — asserts field mapping, ordering, owner filter + unknown-owner error, empty
+  payload, and the skip-on-raise path.
+- Unit (`test/models/stacks_task_test.rb` or existing home): `subject_display_name`
+  redaction — `RecurringLedgerAdjustment` with amount renders without `$` under
+  `redact_amounts: true`, unchanged without; `Reimbursement` generic form; default arg
+  changes nothing.
+- Integration: tool-name array in `test/integration/mcp_endpoint_test.rb` gains
+  `list_open_admin_tasks`; one `tools/call` round-trip (empty-queue fixture state is fine —
+  assert structure).
+
+## Out of scope
+
+Notion Tasks (separate Datazone source), cache tuning, any write path, per-owner digest
+formatting (that's the Stacksbot job's concern), remaining P1a tools.

--- a/docs/superpowers/specs/2026-07-04-mcp-admin-tasks-design.md
+++ b/docs/superpowers/specs/2026-07-04-mcp-admin-tasks-design.md
@@ -90,6 +90,11 @@ of truth:
     verified).
 - The MCP tool always passes `redact_amounts: true`.
 
+Scope note (review round 1): redaction targets compensation-adjacent figures only;
+operational free-text names (projects, leads, survey titles) pass through unredacted —
+they are business data already exposed via list_pipeline/get_pnl/the corpus, and generic
+labels would gut the tool's usefulness.
+
 Alternatives Hugh can pick instead: expose verbatim (drop the keyword), or exclude the
 comp-adjacent types entirely (filter by type list in the tool).
 

--- a/docs/superpowers/specs/2026-07-04-mcp-admin-tasks-design.md
+++ b/docs/superpowers/specs/2026-07-04-mcp-admin-tasks-design.md
@@ -37,10 +37,14 @@ display names, fix-it URLs, and humanized labels already computed by `StacksTask
 - **File:** `app/services/mcp/list_open_admin_tasks_tool.rb`, registered in
   `Mcp::Server::TOOLS` (7th tool).
 - **Params:**
-  - `owner` (optional string) — AdminUser email, case-insensitive. Uses
-    `TaskBuilder#tasks_for`. Unknown email → `Mcp::Responses.error` listing valid owner
-    emails (mirrors the enterprise-param pattern; roster is internal-only data behind the
-    same key).
+  - `owner` (optional string) — AdminUser email, case-insensitive. Any real AdminUser's
+    email resolves (no active/role allowlist — discoveries route ownership to arbitrary
+    AdminUsers, so no attribute scope can enumerate them); a resolved admin with no open
+    tasks gets an honest empty payload, not an error. Uses `TaskBuilder#tasks_for`. Unknown
+    email → `Mcp::Responses.error` listing the emails of admins who currently own at least
+    one task (`TaskBuilder#owner_ids`) — exactly the set already exposed via `owners[]`, so
+    suggestions are always followable and nothing beyond already-exposed emails is
+    disclosed.
 - **Payload:**
 
 ```json
@@ -114,7 +118,8 @@ file's own convention).
 
 ## Error handling
 
-- Unknown `owner` email → error payload listing valid admin emails.
+- Unknown `owner` email → error payload listing current queue owners' emails
+  (`TaskBuilder#owner_ids`), not a general admin roster.
 - A `StacksTask` whose payload mapping raises (exotic subject state) → skipped with a
   `Rails.logger.warn`, never fails the whole list (same doctrine as `QboReceivables`).
 - Empty queue → `{ count: 0, tasks: [] }`.

--- a/lib/stacks/task_builder.rb
+++ b/lib/stacks/task_builder.rb
@@ -140,7 +140,7 @@ module Stacks
       "RecurringLedgerAdjustment" => { ledger: [:enterprise, { contributor: :forecast_person }] },
       "PayCycle" => [:enterprise],
       "ProjectSatisfactionSurvey" => { project_capsule: :project_tracker },
-      "Reimbursement" => [:ledger],
+      "Reimbursement" => { ledger: { contributor: :forecast_person } },
     }.freeze
 
     def batch_load_subjects(descriptors)

--- a/lib/stacks/task_builder.rb
+++ b/lib/stacks/task_builder.rb
@@ -74,6 +74,15 @@ module Stacks
       cached_descriptors.length
     end
 
+    # Every AdminUser id that currently owns at least one task — from the
+    # cached descriptors, no hydration. The MCP owner filter uses this to
+    # suggest valid owners without an attribute-based allowlist (discoveries
+    # route ownership to arbitrary AdminUsers, so no active/role scope can
+    # enumerate them).
+    def owner_ids
+      cached_descriptors.flat_map { |d| d[:owner_ids] }.uniq
+    end
+
     def refresh!
       Rails.cache.delete(CACHE_KEY)
       cached_descriptors

--- a/lib/stacks/task_builder.rb
+++ b/lib/stacks/task_builder.rb
@@ -74,15 +74,6 @@ module Stacks
       cached_descriptors.length
     end
 
-    # Every AdminUser id that currently owns at least one task — from the
-    # cached descriptors, no hydration. The MCP owner filter uses this to
-    # suggest valid owners without an attribute-based allowlist (discoveries
-    # route ownership to arbitrary AdminUsers, so no active/role scope can
-    # enumerate them).
-    def owner_ids
-      cached_descriptors.flat_map { |d| d[:owner_ids] }.uniq
-    end
-
     def refresh!
       Rails.cache.delete(CACHE_KEY)
       cached_descriptors

--- a/lib/stacks/task_builder.rb
+++ b/lib/stacks/task_builder.rb
@@ -9,6 +9,8 @@ require_relative "task_builder/discoveries/notion_leads"
 require_relative "task_builder/discoveries/surveys"
 require_relative "task_builder/discoveries/pay_cycles"
 require_relative "task_builder/discoveries/missing_qbo_vendors"
+require_relative "task_builder/discoveries/legacy_ledgers_pending_qbo_migration"
+require_relative "task_builder/discoveries/auto_paused_recurring_ledger_adjustments"
 
 module Stacks
   # Single source of truth for "what needs attention right now" across the system.

--- a/lib/stacks/task_builder.rb
+++ b/lib/stacks/task_builder.rb
@@ -133,6 +133,16 @@ module Stacks
       end.compact
     end
 
+    # Associations each subject class needs for StacksTask display/url rendering —
+    # preloaded at hydrate time so rendering N tasks stays O(classes), not O(tasks).
+    SUBJECT_PRELOADS = {
+      "Ledger" => [:enterprise, { contributor: :forecast_person }],
+      "RecurringLedgerAdjustment" => { ledger: [:enterprise, { contributor: :forecast_person }] },
+      "PayCycle" => [:enterprise],
+      "ProjectSatisfactionSurvey" => { project_capsule: :project_tracker },
+      "Reimbursement" => [:ledger],
+    }.freeze
+
     def batch_load_subjects(descriptors)
       descriptors.group_by { |d| d[:subject_type] }.each_with_object({}) do |(type_name, ds), acc|
         ids = ds.map { |d| d[:subject_id] }.uniq
@@ -147,7 +157,9 @@ module Stacks
           else
             # Use the model's declared primary_key so this works for models
             # with non-default PKs (ForecastProject uses forecast_id, etc.).
-            klass.where(klass.primary_key => ids).index_by(&:id)
+            records = klass.where(klass.primary_key => ids)
+            records = records.preload(SUBJECT_PRELOADS[type_name]) if SUBJECT_PRELOADS[type_name]
+            records.index_by(&:id)
           end
         acc[type_name] = records
       end

--- a/test/integration/mcp_endpoint_test.rb
+++ b/test/integration/mcp_endpoint_test.rb
@@ -45,7 +45,7 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
     assert body.key?("result"), "Expected JSON-RPC result key, got: #{body.inspect}"
     tool_names = body["result"]["tools"].map { |t| t["name"] }
     assert_includes tool_names, "search", "Expected 'search' tool in: #{tool_names.inspect}"
-    assert_equal %w[get_ar_aging get_document list_documents list_overdue_invoices list_sources search], tool_names.sort,
+    assert_equal %w[get_ar_aging get_document list_documents list_open_admin_tasks list_overdue_invoices list_sources search], tool_names.sort,
       "Expected all registered tools, got: #{tool_names.inspect}"
   end
 
@@ -67,6 +67,21 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
     assert payload.key?("total_ar"), "Expected 'total_ar' key in payload, got: #{payload.inspect}"
     assert payload.key?("enterprises"), "Expected 'enterprises' key in payload, got: #{payload.inspect}"
     assert_match(/\A\d{4}-\d{2}-\d{2}\z/, payload["as_of"])
+  end
+
+  test "tools/call round-trip for list_open_admin_tasks returns a valid payload" do
+    Stacks::TaskBuilder.any_instance.stubs(:tasks).returns([])
+    post "/api/mcp",
+      headers: api_key_headers,
+      params: {
+        jsonrpc: "2.0", id: 9, method: "tools/call",
+        params: { name: "list_open_admin_tasks", arguments: {} },
+      }.to_json
+    assert_response :success
+    text = JSON.parse(response.body).dig("result", "content", 0, "text")
+    payload = JSON.parse(text)
+    assert_equal 0, payload["count"]
+    assert_equal [], payload["tasks"]
   end
 
   test "POST returns 403 when MCP API key is not configured" do

--- a/test/models/stacks_task_test.rb
+++ b/test/models/stacks_task_test.rb
@@ -1,0 +1,54 @@
+require 'test_helper'
+
+class StacksTaskTest < ActiveSupport::TestCase
+  setup do
+    @admin = AdminUser.create!(email: "st#{SecureRandom.hex(4)}@example.com",
+                               password: 'password123', password_confirmation: 'password123',
+                               roles: ['admin'])
+    @enterprise = Enterprise.create!(name: "Enterprise #{SecureRandom.hex(4)}")
+  end
+
+  def recurring_adjustment!
+    fp = ForecastPerson.create!(forecast_id: rand(1..2_000_000_000),
+                                email: "rla#{SecureRandom.hex(4)}@example.com", data: {})
+    contributor = Contributor.create!(forecast_person: fp)
+    ledger = Ledger.find_or_create_for(enterprise: @enterprise, contributor: contributor)
+    RecurringLedgerAdjustment.create!(ledger: ledger, amount: 250.0, cadence: 'monthly',
+                                      next_due_on: Date.today + 7)
+  end
+
+  test 'subject_display_name for RecurringLedgerAdjustment includes the amount by default' do
+    task = StacksTask.new(type: :auto_paused_recurring_on_qbo_bound,
+                          subject: recurring_adjustment!, owners: [@admin])
+    assert_includes task.subject_display_name, '$250.00'
+    assert_includes task.subject_display_name, 'monthly'
+  end
+
+  test 'subject_display_name redacts the amount when redact_amounts is true' do
+    task = StacksTask.new(type: :auto_paused_recurring_on_qbo_bound,
+                          subject: recurring_adjustment!, owners: [@admin])
+    redacted = task.subject_display_name(redact_amounts: true)
+    refute_includes redacted, '$'
+    assert_includes redacted, 'monthly'
+    assert_includes redacted, 'recurring adjustment'
+    assert_includes redacted, @enterprise.name
+  end
+
+  test 'subject_display_name for Reimbursement is generic when redacted' do
+    fp = ForecastPerson.create!(forecast_id: rand(1..2_000_000_000),
+                                email: "rb@ex.co", data: {})
+    contributor = Contributor.create!(forecast_person: fp)
+    ledger = Ledger.find_or_create_for(enterprise: @enterprise, contributor: contributor)
+    reimbursement = Reimbursement.create!(ledger: ledger, description: 'Team dinner $840',
+                                          amount: 840.0, receipts: 'receipt.pdf')
+    task = StacksTask.new(type: :pending_acceptance, subject: reimbursement, owners: [@admin])
+    assert_equal "Reimbursement ##{reimbursement.id}", task.subject_display_name(redact_amounts: true)
+    assert_includes task.subject_display_name, 'Team dinner' # default unchanged
+  end
+
+  test 'redact_amounts leaves non-monetary subjects untouched' do
+    task = StacksTask.new(type: :missing_skill_tree, subject: @admin, owners: [@admin])
+    assert_equal task.subject_display_name, task.subject_display_name(redact_amounts: true)
+    assert_equal @admin.email, task.subject_display_name
+  end
+end

--- a/test/models/stacks_task_test.rb
+++ b/test/models/stacks_task_test.rb
@@ -2,9 +2,7 @@ require 'test_helper'
 
 class StacksTaskTest < ActiveSupport::TestCase
   setup do
-    @admin = AdminUser.create!(email: "st#{SecureRandom.hex(4)}@example.com",
-                               password: 'password123', password_confirmation: 'password123',
-                               roles: ['admin'])
+    @admin = active_admin!(email_prefix: 'st', with_period: false)
     @enterprise = Enterprise.create!(name: "Enterprise #{SecureRandom.hex(4)}")
   end
 

--- a/test/models/stacks_task_test.rb
+++ b/test/models/stacks_task_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class StacksTaskTest < ActiveSupport::TestCase
   setup do
-    @admin = active_admin!(email_prefix: 'st', with_period: false)
+    @admin = build_admin!(email_prefix: 'st', with_period: false)
     @enterprise = Enterprise.create!(name: "Enterprise #{SecureRandom.hex(4)}")
   end
 

--- a/test/models/stacks_task_test.rb
+++ b/test/models/stacks_task_test.rb
@@ -8,12 +8,14 @@ class StacksTaskTest < ActiveSupport::TestCase
     @enterprise = Enterprise.create!(name: "Enterprise #{SecureRandom.hex(4)}")
   end
 
-  def recurring_adjustment!
-    fp = ForecastPerson.create!(forecast_id: rand(1..2_000_000_000),
-                                email: "rla#{SecureRandom.hex(4)}@example.com", data: {})
+  def ledger!(email: "rla#{SecureRandom.hex(4)}@example.com")
+    fp = ForecastPerson.create!(forecast_id: rand(1..2_000_000_000), email: email, data: {})
     contributor = Contributor.create!(forecast_person: fp)
-    ledger = Ledger.find_or_create_for(enterprise: @enterprise, contributor: contributor)
-    RecurringLedgerAdjustment.create!(ledger: ledger, amount: 250.0, cadence: 'monthly',
+    Ledger.find_or_create_for(enterprise: @enterprise, contributor: contributor)
+  end
+
+  def recurring_adjustment!
+    RecurringLedgerAdjustment.create!(ledger: ledger!, amount: 250.0, cadence: 'monthly',
                                       next_due_on: Date.today + 7)
   end
 
@@ -35,11 +37,8 @@ class StacksTaskTest < ActiveSupport::TestCase
   end
 
   test 'subject_display_name for Reimbursement is generic when redacted' do
-    fp = ForecastPerson.create!(forecast_id: rand(1..2_000_000_000),
-                                email: "rb@ex.co", data: {})
-    contributor = Contributor.create!(forecast_person: fp)
-    ledger = Ledger.find_or_create_for(enterprise: @enterprise, contributor: contributor)
-    reimbursement = Reimbursement.create!(ledger: ledger, description: 'Team dinner $840',
+    reimbursement = Reimbursement.create!(ledger: ledger!(email: "rb@ex.co"),
+                                          description: 'Team dinner $840',
                                           amount: 840.0, receipts: 'receipt.pdf')
     task = StacksTask.new(type: :pending_acceptance, subject: reimbursement, owners: [@admin])
     assert_equal "Reimbursement ##{reimbursement.id}", task.subject_display_name(redact_amounts: true)

--- a/test/services/mcp/admin_tasks_tool_test.rb
+++ b/test/services/mcp/admin_tasks_tool_test.rb
@@ -48,49 +48,34 @@ class Mcp::AdminTasksToolTest < ActiveSupport::TestCase
     assert_equal 1, payload['count']
   end
 
-  test 'unknown owner returns an error payload listing valid emails' do
+  test 'unknown owner returns an error payload listing current queue owners emails' do
+    # @other owns nothing — only @admin's id is in owner_ids — so the roster
+    # must include @admin and exclude @other, proving it lists current queue
+    # owners rather than some attribute-based admin roster.
+    Stacks::TaskBuilder.any_instance.stubs(:owner_ids).returns([@admin.id])
     payload = payload_for(Mcp::ListOpenAdminTasksTool.call(owner: 'nobody@nowhere.dev', server_context: {}))
     assert_includes payload['error'], "Unknown owner 'nobody@nowhere.dev'"
     assert_includes payload['error'], @admin.email
+    refute_includes payload['error'], @other.email
   end
 
-  test 'an archived admin is neither a resolvable owner nor listed in the error roster' do
-    # roles: [] — otherwise this admin would also match AdminUser.admin (the
-    # role-admin fallback covered by the test above) and resolve regardless
-    # of being archived, which isn't what this test is checking.
+  test 'any real admin email resolves, even archived (taskless admins get an empty list, not an error)' do
+    # roles: [] and ended_at in the past — neither active nor a role-admin —
+    # yet the email still resolves because resolution is now "any real
+    # AdminUser", not an attribute-based allowlist.
     archived = active_admin!(email_prefix: 'archived', roles: [], ended_at: Date.today - 30)
 
-    Stacks::TaskBuilder.any_instance.expects(:tasks_for).never
+    Stacks::TaskBuilder.any_instance.expects(:tasks_for).with(archived).returns([task_for(archived)])
     payload = payload_for(Mcp::ListOpenAdminTasksTool.call(owner: archived.email, server_context: {}))
-    assert_includes payload['error'], "Unknown owner '#{archived.email}'"
-    roster = payload['error'].sub("Unknown owner '#{archived.email}'.", '')
-    refute_includes roster, archived.email
-  end
-
-  test 'an active admin with two overlapping open full-time periods appears exactly once in the unknown-owner roster' do
-    doubly_covered = active_admin!(email_prefix: 'dbl')
-    # A second, overlapping open period for the same admin — AdminUser.active
-    # joins full_time_periods, so without .distinct this admin would surface
-    # twice in the roster.
-    FullTimePeriod.create!(admin_user: doubly_covered, started_at: Date.today - 10, ended_at: nil,
-                           contributor_type: Enum::ContributorType::FIVE_DAY,
-                           expected_utilization: 0.8)
-
-    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(owner: 'nobody@nowhere.dev', server_context: {}))
-    roster = payload['error']
-    occurrences = roster.scan(doubly_covered.email).length
-    assert_equal 1, occurrences, "expected #{doubly_covered.email} to appear exactly once in: #{roster}"
-  end
-
-  test 'a role-admin with no FullTimePeriod resolves as an owner and appears in the unknown-owner roster' do
-    role_admin = active_admin!(email_prefix: 'role', with_period: false)
-
-    Stacks::TaskBuilder.any_instance.expects(:tasks_for).with(role_admin).returns([task_for(role_admin)])
-    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(owner: role_admin.email, server_context: {}))
     assert_equal 1, payload['count']
+  end
 
-    unknown_payload = payload_for(Mcp::ListOpenAdminTasksTool.call(owner: 'nobody@nowhere.dev', server_context: {}))
-    assert_includes unknown_payload['error'], role_admin.email
+  test 'a real admin who owns no tasks resolves to an empty payload, not an error' do
+    Stacks::TaskBuilder.any_instance.expects(:tasks_for).with(@other).returns([])
+    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(owner: @other.email, server_context: {}))
+    assert_equal 0, payload['count']
+    assert_equal [], payload['tasks']
+    assert_not payload.key?('error')
   end
 
   test 'a task whose mapping raises is skipped with a warning, not fatal' do

--- a/test/services/mcp/admin_tasks_tool_test.rb
+++ b/test/services/mcp/admin_tasks_tool_test.rb
@@ -1,0 +1,65 @@
+require 'test_helper'
+
+class Mcp::AdminTasksToolTest < ActiveSupport::TestCase
+  setup do
+    @admin = AdminUser.create!(email: "at#{SecureRandom.hex(2)}@example.com",
+                               password: 'password123', password_confirmation: 'password123',
+                               roles: ['admin'])
+    @other = AdminUser.create!(email: "ot#{SecureRandom.hex(2)}@example.com",
+                               password: 'password123', password_confirmation: 'password123',
+                               roles: ['admin'])
+  end
+
+  def task_for(admin, type: :missing_skill_tree)
+    StacksTask.new(type: type, subject: admin, owners: [admin])
+  end
+
+  def payload_for(resp)
+    JSON.parse(resp.content.first[:text])
+  end
+
+  test 'returns mapped, sorted tasks with owner emails' do
+    Stacks::TaskBuilder.any_instance.stubs(:tasks).returns(
+      [task_for(@other, type: :no_full_time_periods_set), task_for(@admin)]
+    )
+    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(server_context: {}))
+    assert_equal 2, payload['count']
+    row = payload['tasks'].find { |t| t['type'] == 'missing_skill_tree' }
+    assert_equal 'Admin user needs skill tree set', row['task']
+    assert_equal 'admin_users', row['subject_class']
+    assert_equal @admin.email, row['subject']
+    assert_equal false, row['url_external']
+    assert_match %r{/admin/admin_users/#{@admin.id}}, row['url']
+    assert_equal [@admin.email], row['owners']
+    types = payload['tasks'].map { |t| t['type'] }
+    assert_equal types.sort, types, 'tasks sorted within subject_class by type'
+  end
+
+  test 'owner param filters via tasks_for with case-insensitive email' do
+    Stacks::TaskBuilder.any_instance.expects(:tasks_for).with(@admin).returns([task_for(@admin)])
+    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(owner: @admin.email.upcase, server_context: {}))
+    assert_equal 1, payload['count']
+  end
+
+  test 'unknown owner returns an error payload listing valid emails' do
+    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(owner: 'nobody@nowhere.dev', server_context: {}))
+    assert_includes payload['error'], "Unknown owner 'nobody@nowhere.dev'"
+    assert_includes payload['error'], @admin.email
+  end
+
+  test 'a task whose mapping raises is skipped with a warning, not fatal' do
+    Stacks::TaskBuilder.any_instance.stubs(:tasks).returns([task_for(@admin)])
+    StacksTask.any_instance.stubs(:subject_url).raises(RuntimeError, 'boom')
+    Rails.logger.expects(:warn).with { |msg| msg.include?('skipping task') }
+    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(server_context: {}))
+    assert_equal 0, payload['count']
+    assert_equal [], payload['tasks']
+  end
+
+  test 'empty queue returns a valid empty payload' do
+    Stacks::TaskBuilder.any_instance.stubs(:tasks).returns([])
+    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(server_context: {}))
+    assert_equal 0, payload['count']
+    assert_equal [], payload['tasks']
+  end
+end

--- a/test/services/mcp/admin_tasks_tool_test.rb
+++ b/test/services/mcp/admin_tasks_tool_test.rb
@@ -2,17 +2,21 @@ require 'test_helper'
 
 class Mcp::AdminTasksToolTest < ActiveSupport::TestCase
   setup do
-    @admin = AdminUser.create!(email: "at#{SecureRandom.hex(2)}@example.com",
-                               password: 'password123', password_confirmation: 'password123',
-                               roles: ['admin'])
-    @other = AdminUser.create!(email: "ot#{SecureRandom.hex(2)}@example.com",
-                               password: 'password123', password_confirmation: 'password123',
-                               roles: ['admin'])
-    [@admin, @other].each do |admin|
-      FullTimePeriod.create!(admin_user: admin, started_at: Date.today - 30, ended_at: nil,
-                             contributor_type: Enum::ContributorType::FIVE_DAY,
-                             expected_utilization: 0.8)
-    end
+    @admin = active_admin!(email_prefix: 'at')
+    @other = active_admin!(email_prefix: 'ot')
+  end
+
+  # Creates an AdminUser with a FullTimePeriod. Pass ended_at: a past date to
+  # simulate an archived (no-longer-active) admin.
+  def active_admin!(email_prefix:, ended_at: nil)
+    admin = AdminUser.create!(email: "#{email_prefix}#{SecureRandom.hex(2)}@example.com",
+                              password: 'password123', password_confirmation: 'password123',
+                              roles: ['admin'])
+    started_at = ended_at ? ended_at - 30 : Date.today - 30
+    FullTimePeriod.create!(admin_user: admin, started_at: started_at, ended_at: ended_at,
+                           contributor_type: Enum::ContributorType::FIVE_DAY,
+                           expected_utilization: 0.8)
+    admin
   end
 
   def task_for(admin, type: :missing_skill_tree)
@@ -64,19 +68,28 @@ class Mcp::AdminTasksToolTest < ActiveSupport::TestCase
   end
 
   test 'an archived admin is neither a resolvable owner nor listed in the error roster' do
-    archived = AdminUser.create!(email: "archived#{SecureRandom.hex(2)}@example.com",
-                                 password: 'password123', password_confirmation: 'password123',
-                                 roles: ['admin'])
-    FullTimePeriod.create!(admin_user: archived, started_at: Date.today - 60,
-                           ended_at: Date.today - 30,
-                           contributor_type: Enum::ContributorType::FIVE_DAY,
-                           expected_utilization: 0.8)
+    archived = active_admin!(email_prefix: 'archived', ended_at: Date.today - 30)
 
     Stacks::TaskBuilder.any_instance.expects(:tasks_for).never
     payload = payload_for(Mcp::ListOpenAdminTasksTool.call(owner: archived.email, server_context: {}))
     assert_includes payload['error'], "Unknown owner '#{archived.email}'"
     roster = payload['error'].sub("Unknown owner '#{archived.email}'.", '')
     refute_includes roster, archived.email
+  end
+
+  test 'an active admin with two overlapping open full-time periods appears exactly once in the unknown-owner roster' do
+    doubly_covered = active_admin!(email_prefix: 'dbl')
+    # A second, overlapping open period for the same admin — AdminUser.active
+    # joins full_time_periods, so without .distinct this admin would surface
+    # twice in the roster.
+    FullTimePeriod.create!(admin_user: doubly_covered, started_at: Date.today - 10, ended_at: nil,
+                           contributor_type: Enum::ContributorType::FIVE_DAY,
+                           expected_utilization: 0.8)
+
+    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(owner: 'nobody@nowhere.dev', server_context: {}))
+    roster = payload['error']
+    occurrences = roster.scan(doubly_covered.email).length
+    assert_equal 1, occurrences, "expected #{doubly_covered.email} to appear exactly once in: #{roster}"
   end
 
   test 'a task whose mapping raises is skipped with a warning, not fatal' do

--- a/test/services/mcp/admin_tasks_tool_test.rb
+++ b/test/services/mcp/admin_tasks_tool_test.rb
@@ -6,19 +6,6 @@ class Mcp::AdminTasksToolTest < ActiveSupport::TestCase
     @other = active_admin!(email_prefix: 'ot')
   end
 
-  # Creates an AdminUser with a FullTimePeriod. Pass ended_at: a past date to
-  # simulate an archived (no-longer-active) admin.
-  def active_admin!(email_prefix:, ended_at: nil)
-    admin = AdminUser.create!(email: "#{email_prefix}#{SecureRandom.hex(2)}@example.com",
-                              password: 'password123', password_confirmation: 'password123',
-                              roles: ['admin'])
-    started_at = ended_at ? ended_at - 30 : Date.today - 30
-    FullTimePeriod.create!(admin_user: admin, started_at: started_at, ended_at: ended_at,
-                           contributor_type: Enum::ContributorType::FIVE_DAY,
-                           expected_utilization: 0.8)
-    admin
-  end
-
   def task_for(admin, type: :missing_skill_tree)
     StacksTask.new(type: type, subject: admin, owners: [admin])
   end
@@ -68,7 +55,10 @@ class Mcp::AdminTasksToolTest < ActiveSupport::TestCase
   end
 
   test 'an archived admin is neither a resolvable owner nor listed in the error roster' do
-    archived = active_admin!(email_prefix: 'archived', ended_at: Date.today - 30)
+    # roles: [] — otherwise this admin would also match AdminUser.admin (the
+    # role-admin fallback covered by the test above) and resolve regardless
+    # of being archived, which isn't what this test is checking.
+    archived = active_admin!(email_prefix: 'archived', roles: [], ended_at: Date.today - 30)
 
     Stacks::TaskBuilder.any_instance.expects(:tasks_for).never
     payload = payload_for(Mcp::ListOpenAdminTasksTool.call(owner: archived.email, server_context: {}))
@@ -90,6 +80,17 @@ class Mcp::AdminTasksToolTest < ActiveSupport::TestCase
     roster = payload['error']
     occurrences = roster.scan(doubly_covered.email).length
     assert_equal 1, occurrences, "expected #{doubly_covered.email} to appear exactly once in: #{roster}"
+  end
+
+  test 'a role-admin with no FullTimePeriod resolves as an owner and appears in the unknown-owner roster' do
+    role_admin = active_admin!(email_prefix: 'role', with_period: false)
+
+    Stacks::TaskBuilder.any_instance.expects(:tasks_for).with(role_admin).returns([task_for(role_admin)])
+    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(owner: role_admin.email, server_context: {}))
+    assert_equal 1, payload['count']
+
+    unknown_payload = payload_for(Mcp::ListOpenAdminTasksTool.call(owner: 'nobody@nowhere.dev', server_context: {}))
+    assert_includes unknown_payload['error'], role_admin.email
   end
 
   test 'a task whose mapping raises is skipped with a warning, not fatal' do

--- a/test/services/mcp/admin_tasks_tool_test.rb
+++ b/test/services/mcp/admin_tasks_tool_test.rb
@@ -2,8 +2,8 @@ require 'test_helper'
 
 class Mcp::AdminTasksToolTest < ActiveSupport::TestCase
   setup do
-    @admin = active_admin!(email_prefix: 'at')
-    @other = active_admin!(email_prefix: 'ot')
+    @admin = build_admin!(email_prefix: 'at')
+    @other = build_admin!(email_prefix: 'ot')
   end
 
   def task_for(admin, type: :missing_skill_tree)
@@ -72,7 +72,7 @@ class Mcp::AdminTasksToolTest < ActiveSupport::TestCase
     # roles: [] and ended_at in the past — neither active nor a role-admin —
     # yet the email still resolves because resolution is now "any real
     # AdminUser", not an attribute-based allowlist.
-    archived = active_admin!(email_prefix: 'archived', roles: [], ended_at: Date.today - 30)
+    archived = build_admin!(email_prefix: 'archived', roles: [], ended_at: Date.today - 30)
 
     Stacks::TaskBuilder.any_instance.expects(:tasks_for).with(archived).returns([task_for(archived)])
     payload = payload_for(Mcp::ListOpenAdminTasksTool.call(owner: archived.email, server_context: {}))

--- a/test/services/mcp/admin_tasks_tool_test.rb
+++ b/test/services/mcp/admin_tasks_tool_test.rb
@@ -19,11 +19,13 @@ class Mcp::AdminTasksToolTest < ActiveSupport::TestCase
   end
 
   test 'returns mapped, sorted tasks with owner emails' do
+    enterprise_task = StacksTask.new(type: :needs_archiving, subject: enterprises(:sanctuary),
+                                     owners: [@admin])
     Stacks::TaskBuilder.any_instance.stubs(:tasks).returns(
-      [task_for(@other, type: :no_full_time_periods_set), task_for(@admin)]
+      [enterprise_task, task_for(@other, type: :no_full_time_periods_set), task_for(@admin)]
     )
     payload = payload_for(Mcp::ListOpenAdminTasksTool.call(server_context: {}))
-    assert_equal 2, payload['count']
+    assert_equal 3, payload['count']
     row = payload['tasks'].find { |t| t['type'] == 'missing_skill_tree' }
     assert_equal 'Admin user needs skill tree set', row['task']
     assert_equal 'admin_users', row['subject_class']
@@ -31,8 +33,17 @@ class Mcp::AdminTasksToolTest < ActiveSupport::TestCase
     assert_equal false, row['url_external']
     assert_match %r{/admin/admin_users/#{@admin.id}}, row['url']
     assert_equal [@admin.email], row['owners']
-    types = payload['tasks'].map { |t| t['type'] }
-    assert_equal types.sort, types, 'tasks sorted within subject_class by type'
+    classes = payload['tasks'].map { |t| t['subject_class'] }
+    assert_equal classes.sort, classes, 'tasks sorted by subject_class first'
+    admin_types = payload['tasks'].select { |t| t['subject_class'] == 'admin_users' }.map { |t| t['type'] }
+    assert_equal admin_types.sort, admin_types, 'tasks sorted within subject_class by type'
+  end
+
+  test 'subjects without an explicit display branch get a conservative redacted name' do
+    task = StacksTask.new(type: :needs_archiving, subject: enterprises(:sanctuary), owners: [@admin])
+    Stacks::TaskBuilder.any_instance.stubs(:tasks).returns([task])
+    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(server_context: {}))
+    assert_equal "Enterprise ##{enterprises(:sanctuary).id}", payload['tasks'].first['subject']
   end
 
   test 'owner param filters via tasks_for with case-insensitive email' do

--- a/test/services/mcp/admin_tasks_tool_test.rb
+++ b/test/services/mcp/admin_tasks_tool_test.rb
@@ -8,6 +8,11 @@ class Mcp::AdminTasksToolTest < ActiveSupport::TestCase
     @other = AdminUser.create!(email: "ot#{SecureRandom.hex(2)}@example.com",
                                password: 'password123', password_confirmation: 'password123',
                                roles: ['admin'])
+    [@admin, @other].each do |admin|
+      FullTimePeriod.create!(admin_user: admin, started_at: Date.today - 30, ended_at: nil,
+                             contributor_type: Enum::ContributorType::FIVE_DAY,
+                             expected_utilization: 0.8)
+    end
   end
 
   def task_for(admin, type: :missing_skill_tree)
@@ -56,6 +61,22 @@ class Mcp::AdminTasksToolTest < ActiveSupport::TestCase
     payload = payload_for(Mcp::ListOpenAdminTasksTool.call(owner: 'nobody@nowhere.dev', server_context: {}))
     assert_includes payload['error'], "Unknown owner 'nobody@nowhere.dev'"
     assert_includes payload['error'], @admin.email
+  end
+
+  test 'an archived admin is neither a resolvable owner nor listed in the error roster' do
+    archived = AdminUser.create!(email: "archived#{SecureRandom.hex(2)}@example.com",
+                                 password: 'password123', password_confirmation: 'password123',
+                                 roles: ['admin'])
+    FullTimePeriod.create!(admin_user: archived, started_at: Date.today - 60,
+                           ended_at: Date.today - 30,
+                           contributor_type: Enum::ContributorType::FIVE_DAY,
+                           expected_utilization: 0.8)
+
+    Stacks::TaskBuilder.any_instance.expects(:tasks_for).never
+    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(owner: archived.email, server_context: {}))
+    assert_includes payload['error'], "Unknown owner '#{archived.email}'"
+    roster = payload['error'].sub("Unknown owner '#{archived.email}'.", '')
+    refute_includes roster, archived.email
   end
 
   test 'a task whose mapping raises is skipped with a warning, not fatal' do

--- a/test/services/mcp/admin_tasks_tool_test.rb
+++ b/test/services/mcp/admin_tasks_tool_test.rb
@@ -49,14 +49,23 @@ class Mcp::AdminTasksToolTest < ActiveSupport::TestCase
   end
 
   test 'unknown owner returns an error payload listing current queue owners emails' do
-    # @other owns nothing — only @admin's id is in owner_ids — so the roster
-    # must include @admin and exclude @other, proving it lists current queue
-    # owners rather than some attribute-based admin roster.
-    Stacks::TaskBuilder.any_instance.stubs(:owner_ids).returns([@admin.id])
+    # @other owns nothing — only @admin owns a hydrated task — so the roster
+    # must include @admin and exclude @other, proving it lists exactly the
+    # owners the unfiltered call would emit (not raw cached ids, not an
+    # attribute-based admin roster).
+    Stacks::TaskBuilder.any_instance.stubs(:tasks).returns([task_for(@admin)])
     payload = payload_for(Mcp::ListOpenAdminTasksTool.call(owner: 'nobody@nowhere.dev', server_context: {}))
     assert_includes payload['error'], "Unknown owner 'nobody@nowhere.dev'"
     assert_includes payload['error'], @admin.email
     refute_includes payload['error'], @other.email
+  end
+
+  test 'unknown owner with an empty queue says so instead of dangling an empty roster' do
+    Stacks::TaskBuilder.any_instance.stubs(:tasks).returns([])
+    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(owner: 'nobody@nowhere.dev', server_context: {}))
+    assert_includes payload['error'], "Unknown owner 'nobody@nowhere.dev'"
+    assert_includes payload['error'], 'task queue is currently empty'
+    refute_includes payload['error'], 'Current task owners:'
   end
 
   test 'any real admin email resolves, even archived (taskless admins get an empty list, not an error)' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -100,7 +100,7 @@ class ActiveSupport::TestCase
   # StudioMembership wiring that make_admin_user! (below) sets up. Use this
   # when a test only cares about AdminUser.active / AdminUser.admin
   # resolution, not studio membership.
-  def active_admin!(email_prefix: 'admin', roles: ['admin'], ended_at: nil, with_period: true)
+  def build_admin!(email_prefix: 'admin', roles: ['admin'], ended_at: nil, with_period: true)
     admin = AdminUser.create!(email: "#{email_prefix}#{SecureRandom.hex(4)}@example.com",
                               password: 'password123', password_confirmation: 'password123',
                               roles: roles)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -95,6 +95,27 @@ class ActiveSupport::TestCase
     [tb, g3d]
   end
 
+  # Lightweight admin builder for tool/model tests — creates a bare AdminUser
+  # (optionally with a FullTimePeriod) without the studio/ForecastPerson/
+  # StudioMembership wiring that make_admin_user! (below) sets up. Use this
+  # when a test only cares about AdminUser.active / AdminUser.admin
+  # resolution, not studio membership.
+  def active_admin!(email_prefix: 'admin', roles: ['admin'], ended_at: nil, with_period: true)
+    admin = AdminUser.create!(email: "#{email_prefix}#{SecureRandom.hex(4)}@example.com",
+                              password: 'password123', password_confirmation: 'password123',
+                              roles: roles)
+    if with_period
+      started_at = ended_at ? ended_at - 30 : Date.today - 30
+      FullTimePeriod.create!(admin_user: admin, started_at: started_at, ended_at: ended_at,
+                             contributor_type: Enum::ContributorType::FIVE_DAY,
+                             expected_utilization: 0.8)
+    end
+    admin
+  end
+
+  # Studio-wired admin builder: creates AdminUser + ForecastPerson +
+  # FullTimePeriod + StudioMembership. Use this for tests that exercise
+  # studio membership / payroll flows, not just AdminUser resolution.
   def make_admin_user!(studio, started_at, ended_at = nil, email = "chad@thoughtbot.com")
     admin_user = AdminUser.create!({
       email: email,


### PR DESCRIPTION
## What

The next Phase 1a slice from the [Stacksbot roadmap](https://www.notion.so/garden3d/ROADMAP-md-391131fea2c7801485e0d767177e0da3): the \`Stacks::TaskBuilder\` attention queue — "the single most agent-ready dataset in the whole company" per the [MCP upgrades spec](https://www.notion.so/garden3d/SPEC-Stacks-MCP-upgrades-391131fea2c78147a3aff77c7a6a5493) — exposed as a read-only MCP tool.

- **\`list_open_admin_tasks\`** — named per Hugh's call to distinguish Stacks *system-administration* tasks (data hygiene, approvals, sync debt) from Notion's day-to-day work Tasks. Thin presenter over \`TaskBuilder#tasks\` / \`#tasks_for\`. Payload rows: \`type\`, \`task\` (humanized), \`subject_class\`, \`subject\`, \`url\` + \`url_external\`, \`owners\`; sorted by \`[subject_class, type, subject]\`.
- **Owner filter (design refined across the review loop)**: any real admin email resolves, Unicode-safe, case-insensitive — a taskless or archived admin gets an honest empty list, not an error. Only an email matching no AdminUser errors, and the suggestion roster is derived from the hydrated queue's own owners — the same set the tool emits — so suggestions are always followable (TaskBuilder routes ownership to arbitrary admins, so no attribute-based allowlist can be correct).
- **Comp boundary**: \`StacksTask#subject_display_name\` gains \`redact_amounts:\` (default \`false\` — admin dashboard byte-identical). The tool always redacts comp-adjacent figures: \`RecurringLedgerAdjustment\` drops its \`\$\` amount, \`Reimbursement\` becomes generic, unknown future subject types get a conservative \`Class #id\` fallback. **Scope note**: operational free-text (project names, lead titles, survey titles) passes through by design — that's business data the MCP layer already exposes via \`list_pipeline\`/\`get_pnl\`/the corpus.
- **Shared-layer wins**: \`SUBJECT_PRELOADS\` in TaskBuilder hydration kills a warm-cache N+1 that also slowed \`/admin/tasks\`; per-task mapping failures skip with \`Rails.logger.warn\` + \`Sentry.capture_exception\` (mirrors TaskBuilder's own discovery rescue); the two \`require_relative\`s missing from \`task_builder.rb\` added (spec §7).

## Review process

Spec-first (design + plan in \`docs/superpowers/\`), subagent-driven development in an isolated worktree with per-task reviews and a whole-branch final review, then **six rounds of high-effort multi-agent adversarial review** (4 finder angles + independent verification per finding, per round). ~21 findings fixed across 6 commits — including the owner-filter redesign (attribute allowlists → resolve-any-admin + queue-derived suggestions), roster disclosure fixes, active-admin join dedupe, and the N+1 preloads. Round 6 converged to wording/naming-only findings. Deliberate deferrals are documented in the spec and commit history (cold-cache sweep on the request path, blank-owner-means-no-filter, operational free-text passthrough, error-path hydration cost).

## Tests

Covering suites: **52 runs, 174 assertions, 0 failures**. Full suite: **573 runs, 1321 assertions, 0 failures** (19 pre-existing skips). Coverage: redaction both directions + conservative fallback, default-behavior preservation, field mapping, cross-class sort, owner resolution (case-insensitive, archived, taskless→empty-not-error), queue-derived error roster incl. empty-queue message, skip-on-raise with warn, tools/list registry, and a JSON-RPC \`tools/call\` round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)