### PR TITLE
Add list_projects_at_risk + get_studio_health MCP tools (P1a business slice)

### DIFF
--- a/app/models/studio.rb
+++ b/app/models/studio.rb
@@ -20,6 +20,11 @@ class Studio < ApplicationRecord
     collective: 3,
   }
 
+  # Canonical gradation list for Studio#snapshot — generate_snapshot! writes
+  # one array of period entries per gradation; readers (MCP get_studio_health)
+  # validate against this same list so the two can't drift.
+  SNAPSHOT_GRADATIONS = %i[year month quarter trailing_3_months trailing_4_months trailing_6_months trailing_12_months].freeze
+
   def ytd_snapshot
     (snapshot["year"].find{|p| p["label"] == "YTD"} || {})
   end
@@ -149,7 +154,7 @@ class Studio < ApplicationRecord
     g3d = preloaded_studios.find(&:is_garden3d?)
 
     snapshot =
-      [:year, :month, :quarter, :trailing_3_months, :trailing_4_months, :trailing_6_months, :trailing_12_months].reduce({
+      SNAPSHOT_GRADATIONS.reduce({
         started_at: DateTime.now.iso8601,
       }) do |acc, gradation|
         periods = Stacks::Period.for_gradation(gradation)

--- a/app/services/mcp/get_studio_health_tool.rb
+++ b/app/services/mcp/get_studio_health_tool.rb
@@ -34,12 +34,14 @@ module Mcp
       requested =
         if studio.present?
           key = studio.to_s.strip
-          # mini_name can hold a comma-separated list (see Studio's own
-          # split(",") usages), so match any element, not the whole field.
-          match = all_studios.find do |s|
-            s.name.to_s.casecmp?(key) ||
-              s.mini_name.to_s.split(',').map(&:strip).any? { |m| m.casecmp?(key) }
-          end
+          # Prefer an exact name match over a mini_name-alias match, so a real
+          # studio name can never be shadowed by another studio that happens
+          # to carry that string as one element of its comma-separated
+          # mini_name. mini_name can hold a list (see Studio's own split(",")).
+          match = all_studios.find { |s| s.name.to_s.casecmp?(key) } ||
+                  all_studios.find do |s|
+                    s.mini_name.to_s.split(',').map(&:strip).any? { |m| m.casecmp?(key) }
+                  end
           unless match
             valid = all_studios.map { |s| "#{s.name} (#{s.mini_name})" }.sort.join(', ')
             return Responses.error("Unknown studio '#{studio}'. Valid studios: #{valid}")

--- a/app/services/mcp/get_studio_health_tool.rb
+++ b/app/services/mcp/get_studio_health_tool.rb
@@ -1,0 +1,86 @@
+module Mcp
+  class GetStudioHealthTool < MCP::Tool
+    tool_name 'get_studio_health'
+    description 'Per-studio health rollups from the nightly Studio snapshot: financial datapoints ' \
+                '(income, cogs, net operating income, profit margin), utilization hours, lead counts, ' \
+                'satisfaction scores, and OKR health per period. Pure read of the persisted rollup — ' \
+                'figures always match Stacks\' own reporting. Never regenerates, never calls live APIs.'
+    input_schema(
+      properties: {
+        studio: { type: 'string', description: 'Optional studio name or mini_name (case-insensitive). Default: all studios with a snapshot.' },
+        gradation: { type: 'string', description: 'month (default), quarter, year, trailing_3_months, trailing_4_months, trailing_6_months, trailing_12_months' },
+        accounting_method: { type: 'string', description: 'cash (default) or accrual' },
+        periods: { type: 'integer', description: 'Most recent N periods (default 6, clamped 1..24)' },
+      },
+      required: []
+    )
+    annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true)
+
+    GRADATIONS = %w[month quarter year trailing_3_months trailing_4_months trailing_6_months trailing_12_months].freeze
+    ACCOUNTING_METHODS = %w[cash accrual].freeze
+
+    def self.call(studio: nil, gradation: 'month', accounting_method: 'cash', periods: 6, server_context:)
+      gradation = gradation.to_s
+      unless GRADATIONS.include?(gradation)
+        return Responses.error("Invalid gradation '#{gradation}'. Valid gradations: #{GRADATIONS.join(', ')}")
+      end
+      method = accounting_method.to_s
+      unless ACCOUNTING_METHODS.include?(method)
+        return Responses.error("Invalid accounting_method '#{method}'. Valid: #{ACCOUNTING_METHODS.join(', ')}")
+      end
+      recent = periods.to_i.clamp(1, 24)
+
+      all_studios = Studio.all.to_a
+      requested =
+        if studio.present?
+          key = studio.to_s.strip
+          match = all_studios.find { |s| s.name.casecmp?(key) || s.mini_name.to_s.casecmp?(key) }
+          unless match
+            valid = all_studios.map { |s| "#{s.name} (#{s.mini_name})" }.sort.join(', ')
+            return Responses.error("Unknown studio '#{studio}'. Valid studios: #{valid}")
+          end
+          if match.snapshot.blank? || match.snapshot[gradation].blank?
+            return Responses.error("Studio '#{match.name}' has no generated snapshot for gradation '#{gradation}' yet.")
+          end
+          [match]
+        else
+          all_studios
+        end
+
+      studios_payload = requested.filter_map do |s|
+        entries = s.snapshot.presence && s.snapshot[gradation]
+        if entries.blank?
+          Rails.logger.warn("[Mcp::GetStudioHealthTool] skipping studio '#{s.name}': no snapshot data for '#{gradation}'") if studio.blank?
+          next nil
+        end
+
+        # Pass label/dates + the chosen accounting subtree (datapoints + okrs)
+        # through VERBATIM — re-mapping invites drift from the canonical
+        # computed shape. The period-level 'utilization' key is deliberately
+        # excluded: it is a per-person email → hours map (get_capacity's
+        # future surface), not a studio rollup.
+        {
+          studio: s.name,
+          mini_name: s.mini_name,
+          gradation: gradation,
+          accounting_method: method,
+          periods: Array(entries).last(recent).map do |entry|
+            {
+              label: entry['label'],
+              period_starts_at: entry['period_starts_at'],
+              period_ends_at: entry['period_ends_at'],
+              datapoints: entry.dig(method, 'datapoints'),
+              okrs: entry.dig(method, 'okrs'),
+            }
+          end,
+        }
+      rescue StandardError => e
+        Rails.logger.warn("[Mcp::GetStudioHealthTool] skipping studio '#{s.name}': #{e.class}: #{e.message}")
+        Sentry.capture_exception(e)
+        nil
+      end
+
+      Responses.ok({ studios: studios_payload })
+    end
+  end
+end

--- a/app/services/mcp/get_studio_health_tool.rb
+++ b/app/services/mcp/get_studio_health_tool.rb
@@ -34,7 +34,7 @@ module Mcp
       requested =
         if studio.present?
           key = studio.to_s.strip
-          match = all_studios.find { |s| s.name.casecmp?(key) || s.mini_name.to_s.casecmp?(key) }
+          match = all_studios.find { |s| s.name.to_s.casecmp?(key) || s.mini_name.to_s.casecmp?(key) }
           unless match
             valid = all_studios.map { |s| "#{s.name} (#{s.mini_name})" }.sort.join(', ')
             return Responses.error("Unknown studio '#{studio}'. Valid studios: #{valid}")
@@ -76,7 +76,7 @@ module Mcp
         }
       rescue StandardError => e
         Rails.logger.warn("[Mcp::GetStudioHealthTool] skipping studio '#{s.name}': #{e.class}: #{e.message}")
-        Sentry.capture_exception(e)
+        Sentry.capture_exception(e) if defined?(Sentry)
         nil
       end
 

--- a/app/services/mcp/get_studio_health_tool.rb
+++ b/app/services/mcp/get_studio_health_tool.rb
@@ -80,6 +80,10 @@ module Mcp
         nil
       end
 
+      if studio.present? && studios_payload.empty?
+        return Responses.error("Studio '#{requested.first.name}' snapshot could not be read for gradation '#{gradation}' — it may be malformed. The failure was logged.")
+      end
+
       Responses.ok({ studios: studios_payload })
     end
   end

--- a/app/services/mcp/get_studio_health_tool.rb
+++ b/app/services/mcp/get_studio_health_tool.rb
@@ -5,19 +5,19 @@ module Mcp
                 '(income, cogs, net operating income, profit margin), utilization hours, lead counts, ' \
                 'satisfaction scores, and OKR health per period. Pure read of the persisted rollup — ' \
                 'figures always match Stacks\' own reporting. Never regenerates, never calls live APIs.'
+    GRADATIONS = Studio::SNAPSHOT_GRADATIONS.map(&:to_s).freeze
+    ACCOUNTING_METHODS = %w[cash accrual].freeze
+
     input_schema(
       properties: {
         studio: { type: 'string', description: 'Optional studio name or mini_name (case-insensitive). Default: all studios with a snapshot.' },
-        gradation: { type: 'string', description: 'month (default), quarter, year, trailing_3_months, trailing_4_months, trailing_6_months, trailing_12_months' },
+        gradation: { type: 'string', description: "#{GRADATIONS.join(', ')} (default month)" },
         accounting_method: { type: 'string', description: 'cash (default) or accrual' },
         periods: { type: 'integer', description: 'Most recent N periods (default 6, clamped 1..24)' },
       },
       required: []
     )
     annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true)
-
-    GRADATIONS = %w[month quarter year trailing_3_months trailing_4_months trailing_6_months trailing_12_months].freeze
-    ACCOUNTING_METHODS = %w[cash accrual].freeze
 
     def self.call(studio: nil, gradation: 'month', accounting_method: 'cash', periods: 6, server_context:)
       gradation = gradation.to_s
@@ -75,7 +75,7 @@ module Mcp
           end,
         }
       rescue StandardError => e
-        Rails.logger.warn("[Mcp::GetStudioHealthTool] skipping studio '#{s.name}': #{e.class}: #{e.message}")
+        Rails.logger.warn("[Mcp::GetStudioHealthTool] skipping studio id=#{s.id}: #{e.class}: #{e.message}")
         Sentry.capture_exception(e) if defined?(Sentry)
         nil
       end

--- a/app/services/mcp/get_studio_health_tool.rb
+++ b/app/services/mcp/get_studio_health_tool.rb
@@ -34,20 +34,25 @@ module Mcp
       requested =
         if studio.present?
           key = studio.to_s.strip
-          # Prefer an exact name match over a mini_name-alias match, so a real
-          # studio name can never be shadowed by another studio that happens
-          # to carry that string as one element of its comma-separated
-          # mini_name. mini_name can hold a list (see Studio's own split(",")).
-          match = all_studios.find { |s| s.name.to_s.casecmp?(key) } ||
-                  all_studios.find do |s|
-                    s.mini_name.to_s.split(',').map(&:strip).any? { |m| m.casecmp?(key) }
-                  end
-          unless match
+          # All studios the query could mean: exact name matches first (they
+          # take priority when several have data), then mini_name-alias matches
+          # (mini_name can hold a comma-separated list — see Studio's own
+          # split(",")). Dedup preserves that priority order.
+          candidates = (
+            all_studios.select { |s| s.name.to_s.casecmp?(key) } +
+            all_studios.select { |s| s.mini_name.to_s.split(',').map(&:strip).any? { |m| m.casecmp?(key) } }
+          ).uniq
+          if candidates.empty?
             valid = all_studios.map { |s| "#{s.name} (#{s.mini_name})" }.sort.join(', ')
             return Responses.error("Unknown studio '#{studio}'. Valid studios: #{valid}")
           end
-          if match.snapshot.blank? || match.snapshot[gradation].blank?
-            return Responses.error("Studio '#{match.name}' has no generated snapshot for gradation '#{gradation}' yet.")
+          # Resolve to the highest-priority candidate that actually has data for
+          # this gradation, so a data-carrying match is never shadowed by a
+          # higher-priority but not-yet-snapshotted one. Only error when NONE
+          # of the matches has a snapshot.
+          match = candidates.find { |s| s.snapshot.present? && s.snapshot[gradation].present? }
+          unless match
+            return Responses.error("Studio '#{candidates.first.name}' has no generated snapshot for gradation '#{gradation}' yet.")
           end
           [match]
         else

--- a/app/services/mcp/get_studio_health_tool.rb
+++ b/app/services/mcp/get_studio_health_tool.rb
@@ -34,7 +34,12 @@ module Mcp
       requested =
         if studio.present?
           key = studio.to_s.strip
-          match = all_studios.find { |s| s.name.to_s.casecmp?(key) || s.mini_name.to_s.casecmp?(key) }
+          # mini_name can hold a comma-separated list (see Studio's own
+          # split(",") usages), so match any element, not the whole field.
+          match = all_studios.find do |s|
+            s.name.to_s.casecmp?(key) ||
+              s.mini_name.to_s.split(',').map(&:strip).any? { |m| m.casecmp?(key) }
+          end
           unless match
             valid = all_studios.map { |s| "#{s.name} (#{s.mini_name})" }.sort.join(', ')
             return Responses.error("Unknown studio '#{studio}'. Valid studios: #{valid}")

--- a/app/services/mcp/list_projects_at_risk_tool.rb
+++ b/app/services/mcp/list_projects_at_risk_tool.rb
@@ -20,20 +20,22 @@ module Mcp
       ProjectTracker.preload_for_render(trackers)
 
       rows = trackers.filter_map do |pt|
-        status = pt.work_status
-        next nil unless include_complete || ACTIVE_STATUSES.include?(status)
         if pt.snapshot.blank?
           Rails.logger.warn("[Mcp::ListProjectsAtRiskTool] skipping '#{pt.name}' (id=#{pt.id}): no snapshot")
           next nil
         end
 
+        status = pt.work_status
+        next nil unless include_complete || ACTIVE_STATUSES.include?(status)
+
         # Risk = the tracker's own targets, via the model's own predicates
-        # (single source of truth with considered_successful?). Only the
-        # budget comparison lives here — no model predicate exists for it.
+        # (single source of truth with considered_successful?). The budget
+        # comparison reuses ProjectTracker#status (the same source the admin
+        # UI uses) rather than re-deriving it here.
         reasons = []
         reasons << 'margin_below_target' unless pt.target_profit_margin_satisfied?
         reasons << 'free_hours_above_target' unless pt.target_free_hours_ratio_satisfied?
-        reasons << 'over_budget' if pt.budget_high_end.present? && pt.spend > pt.budget_high_end.to_f
+        reasons << 'over_budget' if pt.status == :over_budget
 
         {
           name: pt.name,

--- a/app/services/mcp/list_projects_at_risk_tool.rb
+++ b/app/services/mcp/list_projects_at_risk_tool.rb
@@ -35,7 +35,13 @@ module Mcp
         reasons = []
         reasons << 'margin_below_target' unless pt.target_profit_margin_satisfied?
         reasons << 'free_hours_above_target' unless pt.target_free_hours_ratio_satisfied?
-        reasons << 'over_budget' if pt.status == :over_budget
+        # #status raises on a half-configured budget (exactly one bound set —
+        # invalid per model validation, but possible in legacy rows). Guard on
+        # both bounds so a bad budget can't mask a tracker's margin/free-hours
+        # risk by dropping the whole row through the rescue below.
+        if pt.budget_low_end.present? && pt.budget_high_end.present?
+          reasons << 'over_budget' if pt.status == :over_budget
+        end
 
         {
           name: pt.name,

--- a/app/services/mcp/list_projects_at_risk_tool.rb
+++ b/app/services/mcp/list_projects_at_risk_tool.rb
@@ -41,7 +41,7 @@ module Mcp
           spend: pt.spend.round(2),
           budget_low_end: pt.budget_low_end&.to_f,
           budget_high_end: pt.budget_high_end&.to_f,
-          profit_margin: pt.profit_margin.round(1),
+          profit_margin: pt.profit_margin.to_f.round(1),
           target_profit_margin: pt.target_profit_margin.to_f,
           free_hours_percent: (pt.free_hours_ratio * 100).round(1),
           target_free_hours_percent: pt.target_free_hours_percent.to_f,
@@ -53,7 +53,7 @@ module Mcp
         }
       rescue StandardError => e
         Rails.logger.warn("[Mcp::ListProjectsAtRiskTool] skipping tracker id=#{pt.id}: #{e.class}: #{e.message}")
-        Sentry.capture_exception(e)
+        Sentry.capture_exception(e) if defined?(Sentry)
         nil
       end
 

--- a/app/services/mcp/list_projects_at_risk_tool.rb
+++ b/app/services/mcp/list_projects_at_risk_tool.rb
@@ -47,7 +47,6 @@ module Mcp
           target_profit_margin: pt.target_profit_margin.to_f,
           free_hours_percent: (pt.free_hours_ratio * 100).round(1),
           target_free_hours_percent: pt.target_free_hours_percent.to_f,
-          likely_complete: pt.likely_complete?,
           considered_successful: pt.considered_successful?,
           at_risk: reasons.any?,
           risk_reasons: reasons,

--- a/app/services/mcp/list_projects_at_risk_tool.rb
+++ b/app/services/mcp/list_projects_at_risk_tool.rb
@@ -1,0 +1,66 @@
+module Mcp
+  class ListProjectsAtRiskTool < MCP::Tool
+    tool_name 'list_projects_at_risk'
+    description 'Projects at risk, judged against each ProjectTracker\'s own configured targets ' \
+                '(margin below target, free hours above target, spend beyond budget). Reads the ' \
+                'nightly tracker snapshots — never live data. Sorted most-at-risk first.'
+    input_schema(
+      properties: {
+        only_at_risk: { type: 'boolean', description: 'Default true. When false, returns every project in scope with metrics + targets.' },
+        include_complete: { type: 'boolean', description: 'Default false. Include completed / capsule-pending projects.' },
+      },
+      required: []
+    )
+    annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true)
+
+    ACTIVE_STATUSES = %i[in_progress likely_complete].freeze
+
+    def self.call(only_at_risk: true, include_complete: false, server_context:)
+      trackers = ProjectTracker.all.to_a
+      ProjectTracker.preload_for_render(trackers)
+
+      rows = trackers.filter_map do |pt|
+        status = pt.work_status
+        next nil unless include_complete || ACTIVE_STATUSES.include?(status)
+        if pt.snapshot.blank?
+          Rails.logger.warn("[Mcp::ListProjectsAtRiskTool] skipping '#{pt.name}' (id=#{pt.id}): no snapshot")
+          next nil
+        end
+
+        # Risk = the tracker's own targets, via the model's own predicates
+        # (single source of truth with considered_successful?). Only the
+        # budget comparison lives here — no model predicate exists for it.
+        reasons = []
+        reasons << 'margin_below_target' unless pt.target_profit_margin_satisfied?
+        reasons << 'free_hours_above_target' unless pt.target_free_hours_ratio_satisfied?
+        reasons << 'over_budget' if pt.budget_high_end.present? && pt.spend > pt.budget_high_end.to_f
+
+        {
+          name: pt.name,
+          work_status: status,
+          spend: pt.spend.round(2),
+          budget_low_end: pt.budget_low_end&.to_f,
+          budget_high_end: pt.budget_high_end&.to_f,
+          profit_margin: pt.profit_margin.round(1),
+          target_profit_margin: pt.target_profit_margin.to_f,
+          free_hours_percent: (pt.free_hours_ratio * 100).round(1),
+          target_free_hours_percent: pt.target_free_hours_percent.to_f,
+          likely_complete: pt.likely_complete?,
+          considered_successful: pt.considered_successful?,
+          at_risk: reasons.any?,
+          risk_reasons: reasons,
+          url: pt.external_link,
+        }
+      rescue StandardError => e
+        Rails.logger.warn("[Mcp::ListProjectsAtRiskTool] skipping tracker id=#{pt.id}: #{e.class}: #{e.message}")
+        Sentry.capture_exception(e)
+        nil
+      end
+
+      rows = rows.select { |r| r[:at_risk] } if only_at_risk
+      rows = rows.sort_by { |r| [-r[:risk_reasons].length, r[:name].to_s] }
+
+      Responses.ok({ count: rows.length, projects: rows })
+    end
+  end
+end

--- a/app/services/mcp/server.rb
+++ b/app/services/mcp/server.rb
@@ -19,6 +19,7 @@ module Mcp
       Mcp::GetArAgingTool,
       Mcp::ListOverdueInvoicesTool,
       Mcp::ListOpenAdminTasksTool,
+      Mcp::ListProjectsAtRiskTool,
     ].freeze
 
     def self.build

--- a/app/services/mcp/server.rb
+++ b/app/services/mcp/server.rb
@@ -20,6 +20,7 @@ module Mcp
       Mcp::ListOverdueInvoicesTool,
       Mcp::ListOpenAdminTasksTool,
       Mcp::ListProjectsAtRiskTool,
+      Mcp::GetStudioHealthTool,
     ].freeze
 
     def self.build

--- a/docs/superpowers/plans/2026-07-05-mcp-business-tools.md
+++ b/docs/superpowers/plans/2026-07-05-mcp-business-tools.md
@@ -1,0 +1,530 @@
+# list_projects_at_risk + get_studio_health Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two read-only MCP tools — `list_projects_at_risk` (ProjectTracker snapshots judged against each tracker's own targets) and `get_studio_health` (pure pass-through of the persisted `Studio#snapshot` rollup) — unblocking Stacksbot automation #2 (Business pre-read v1).
+
+**Architecture:** Two thin presenter tools following the established one-file-per-tool pattern (`Mcp::Responses` envelope, read-only annotations, skip-with-warn+Sentry doctrine). No new queries beyond batch-preloaded model reads of already-computed nightly data.
+
+**Tech Stack:** Rails, `mcp` Ruby gem, Minitest + mocha.
+
+**Spec:** `docs/superpowers/specs/2026-07-05-mcp-business-tools-design.md`
+
+## Global Constraints
+
+- `annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true)` on both tools; `Mcp::Responses.ok(payload)` / `.error(message)` envelope.
+- Risk judgments reuse the model's own predicates — `!target_profit_margin_satisfied?`, `!target_free_hours_ratio_satisfied?` — never re-derive the comparisons. Only `over_budget` (`budget_high_end` present and `spend > budget_high_end`) lives in the tool.
+- `get_studio_health` NEVER regenerates snapshots — pure read of the persisted jsonb. It must NOT include the period-level `utilization` key (a per-person email → hours map; that's `get_capacity`'s future surface). Pass through only `label`, `period_starts_at`, `period_ends_at`, and the chosen accounting method's `datapoints` + `okrs`, verbatim.
+- Per-row mapping failures: skip + `Rails.logger.warn` + `Sentry.capture_exception(e)`, never fail the report. Unknown/invalid params → error payloads listing valid values.
+- No schema changes, no new gems, no cache changes, no live external API calls.
+- Tests: `bin/rails test <path>`; mocha available; `build_admin!` helper exists in test_helper (not needed here); worktree already has `config/master.key`. Do not modify initializers/credentials/unrelated code.
+- Known pre-existing failure to ignore: `AdminUserTest` salary-window date flake (environment-date-sensitive).
+
+---
+
+### Task 1: `list_projects_at_risk` tool
+
+**Files:**
+- Create: `app/services/mcp/list_projects_at_risk_tool.rb`
+- Create: `test/services/mcp/projects_at_risk_tool_test.rb`
+- Modify: `app/services/mcp/server.rb` (TOOLS array, currently 7 entries)
+- Modify: `test/integration/mcp_endpoint_test.rb` (tool-name array) — done in Task 2 alongside its own entry? NO — each task keeps the suite green independently: update the array here to include `list_projects_at_risk` (7→8 names happens across the two tasks; after this task the sorted array is `%w[get_ar_aging get_document list_documents list_open_admin_tasks list_overdue_invoices list_projects_at_risk list_sources search]`).
+
+**Interfaces:**
+- Consumes: `ProjectTracker` — `.preload_for_render(trackers)` (class method taking an array), `#work_status` (`:in_progress`/`:likely_complete`/`:complete`/`:capsule_pending`), `#snapshot` (jsonb hash), `#spend`, `#profit_margin`, `#free_hours_ratio`, `#target_profit_margin`, `#target_free_hours_percent`, `#target_profit_margin_satisfied?`, `#target_free_hours_ratio_satisfied?`, `#likely_complete?`, `#considered_successful?`, `#budget_low_end`/`#budget_high_end` (nullable numeric columns), `#external_link` (absolute admin URL). `Mcp::Responses.ok/.error`.
+- Produces: the `list_projects_at_risk` MCP tool. Payload: `{ count:, projects: [{ name, work_status, spend, budget_low_end, budget_high_end, profit_margin, target_profit_margin, free_hours_percent, target_free_hours_percent, likely_complete, considered_successful, at_risk, risk_reasons, url }] }` sorted most-at-risk first (`[-risk_reasons.length, name]`).
+
+- [ ] **Step 1: Discover the free-hours snapshot key**
+
+Run: `grep -n "def total_free_hours" -A 3 app/models/project_tracker.rb`
+Note the exact snapshot key it reads (e.g. `"free_hours_total"`) — use that key in the test helper below wherever `FREE_HOURS_KEY` appears. Also run `grep -n "def estimated_cost" -A 3 app/models/project_tracker.rb` to confirm the cost key (expected `"cost_total"`).
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `test/services/mcp/projects_at_risk_tool_test.rb` (replace `FREE_HOURS_KEY` per Step 1):
+
+```ruby
+require 'test_helper'
+
+class Mcp::ProjectsAtRiskToolTest < ActiveSupport::TestCase
+  # Snapshot-backed tracker factory. Defaults produce a HEALTHY project:
+  # margin 50% (>= target 30), free hours 0% (<= target 10), no budget.
+  def tracker!(name:, spend: 1000.0, cost: 500.0, hours: 100.0, free_hours: 0.0,
+               budget_high: nil, budget_low: nil, margin_target: 30, free_target: 10)
+    ProjectTracker.create!(
+      name: name,
+      budget_low_end: budget_low,
+      budget_high_end: budget_high,
+      target_profit_margin: margin_target,
+      target_free_hours_percent: free_target,
+      snapshot: {
+        'invoiced_with_running_spend_total' => spend,
+        'cost_total' => cost,
+        'hours_total' => hours,
+        'FREE_HOURS_KEY' => free_hours,
+      }
+    )
+  end
+
+  def payload_for(resp)
+    JSON.parse(resp.content.first[:text])
+  end
+
+  test 'flags margin below the tracker target with a named reason' do
+    tracker!(name: 'Thin Margin', spend: 1000.0, cost: 900.0) # margin 10% < target 30
+    payload = payload_for(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
+    row = payload['projects'].find { |p| p['name'] == 'Thin Margin' }
+    assert row['at_risk']
+    assert_includes row['risk_reasons'], 'margin_below_target'
+    assert_equal 10.0, row['profit_margin']
+    assert_equal 30.0, row['target_profit_margin']
+  end
+
+  test 'flags free hours above the tracker target' do
+    tracker!(name: 'Free Heavy', hours: 100.0, free_hours: 20.0, free_target: 10)
+    payload = payload_for(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
+    row = payload['projects'].find { |p| p['name'] == 'Free Heavy' }
+    assert_includes row['risk_reasons'], 'free_hours_above_target'
+    assert_equal 20.0, row['free_hours_percent']
+  end
+
+  test 'flags spend beyond budget_high_end only when a budget is set' do
+    tracker!(name: 'Over Budget', spend: 5000.0, cost: 1000.0, budget_low: 1000.0, budget_high: 4000.0)
+    tracker!(name: 'No Budget', spend: 5000.0, cost: 1000.0)
+    payload = payload_for(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
+    over = payload['projects'].find { |p| p['name'] == 'Over Budget' }
+    assert_includes over['risk_reasons'], 'over_budget'
+    assert_nil payload['projects'].find { |p| p['name'] == 'No Budget' }, 'healthy-but-unbudgeted project must not be flagged'
+  end
+
+  test 'only_at_risk: false returns healthy projects too, sorted most-at-risk first' do
+    tracker!(name: 'Healthy One')
+    tracker!(name: 'Doubly Risky', spend: 5000.0, cost: 4800.0, budget_high: 4000.0, budget_low: 1000.0)
+    payload = payload_for(Mcp::ListProjectsAtRiskTool.call(only_at_risk: false, server_context: {}))
+    names = payload['projects'].map { |p| p['name'] }
+    assert_includes names, 'Healthy One'
+    assert_equal 'Doubly Risky', names.first, 'most tripped criteria sorts first'
+    healthy = payload['projects'].find { |p| p['name'] == 'Healthy One' }
+    assert_equal false, healthy['at_risk']
+    assert_equal [], healthy['risk_reasons']
+  end
+
+  test 'completed trackers are excluded by default and included with include_complete' do
+    done = tracker!(name: 'Done Project', spend: 1000.0, cost: 900.0)
+    done.update!(work_completed_at: Time.current)
+    payload = payload_for(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
+    assert_nil payload['projects'].find { |p| p['name'] == 'Done Project' }
+    payload = payload_for(Mcp::ListProjectsAtRiskTool.call(include_complete: true, server_context: {}))
+    assert payload['projects'].find { |p| p['name'] == 'Done Project' }
+  end
+
+  test 'trackers with a blank snapshot are skipped with a warning, never raise' do
+    ProjectTracker.create!(name: 'Unsnapshotted', target_profit_margin: 30, target_free_hours_percent: 10)
+    tracker!(name: 'Thin Margin', spend: 1000.0, cost: 900.0)
+    Rails.logger.expects(:warn).with { |msg| msg.include?('Unsnapshotted') }.at_least_once
+    payload = payload_for(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
+    assert_nil payload['projects'].find { |p| p['name'] == 'Unsnapshotted' }
+    assert_equal 1, payload['count']
+  end
+
+  test 'empty result is a valid payload' do
+    payload = payload_for(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
+    assert_equal 0, payload['count']
+    assert_equal [], payload['projects']
+  end
+end
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `bin/rails test test/services/mcp/projects_at_risk_tool_test.rb`
+Expected: FAIL — `NameError: uninitialized constant Mcp::ListProjectsAtRiskTool`. (If `ProjectTracker.create!` itself fails a validation in the factory, add the minimal missing attribute and note it — do not change the model.)
+
+- [ ] **Step 4: Implement the tool**
+
+Create `app/services/mcp/list_projects_at_risk_tool.rb`:
+
+```ruby
+module Mcp
+  class ListProjectsAtRiskTool < MCP::Tool
+    tool_name 'list_projects_at_risk'
+    description 'Projects at risk, judged against each ProjectTracker\'s own configured targets ' \
+                '(margin below target, free hours above target, spend beyond budget). Reads the ' \
+                'nightly tracker snapshots — never live data. Sorted most-at-risk first.'
+    input_schema(
+      properties: {
+        only_at_risk: { type: 'boolean', description: 'Default true. When false, returns every project in scope with metrics + targets.' },
+        include_complete: { type: 'boolean', description: 'Default false. Include completed / capsule-pending projects.' },
+      },
+      required: []
+    )
+    annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true)
+
+    ACTIVE_STATUSES = %i[in_progress likely_complete].freeze
+
+    def self.call(only_at_risk: true, include_complete: false, server_context:)
+      trackers = ProjectTracker.all.to_a
+      ProjectTracker.preload_for_render(trackers)
+
+      rows = trackers.filter_map do |pt|
+        status = pt.work_status
+        next nil unless include_complete || ACTIVE_STATUSES.include?(status)
+        if pt.snapshot.blank?
+          Rails.logger.warn("[Mcp::ListProjectsAtRiskTool] skipping '#{pt.name}' (id=#{pt.id}): no snapshot")
+          next nil
+        end
+
+        # Risk = the tracker's own targets, via the model's own predicates
+        # (single source of truth with considered_successful?). Only the
+        # budget comparison lives here — no model predicate exists for it.
+        reasons = []
+        reasons << 'margin_below_target' unless pt.target_profit_margin_satisfied?
+        reasons << 'free_hours_above_target' unless pt.target_free_hours_ratio_satisfied?
+        reasons << 'over_budget' if pt.budget_high_end.present? && pt.spend > pt.budget_high_end.to_f
+
+        {
+          name: pt.name,
+          work_status: status,
+          spend: pt.spend.round(2),
+          budget_low_end: pt.budget_low_end&.to_f,
+          budget_high_end: pt.budget_high_end&.to_f,
+          profit_margin: pt.profit_margin.round(1),
+          target_profit_margin: pt.target_profit_margin.to_f,
+          free_hours_percent: (pt.free_hours_ratio * 100).round(1),
+          target_free_hours_percent: pt.target_free_hours_percent.to_f,
+          likely_complete: pt.likely_complete?,
+          considered_successful: pt.considered_successful?,
+          at_risk: reasons.any?,
+          risk_reasons: reasons,
+          url: pt.external_link,
+        }
+      rescue StandardError => e
+        Rails.logger.warn("[Mcp::ListProjectsAtRiskTool] skipping tracker id=#{pt.id}: #{e.class}: #{e.message}")
+        Sentry.capture_exception(e)
+        nil
+      end
+
+      rows = rows.select { |r| r[:at_risk] } if only_at_risk
+      rows = rows.sort_by { |r| [-r[:risk_reasons].length, r[:name].to_s] }
+
+      Responses.ok({ count: rows.length, projects: rows })
+    end
+  end
+end
+```
+
+Append `Mcp::ListProjectsAtRiskTool,` to `TOOLS` in `app/services/mcp/server.rb`.
+
+- [ ] **Step 5: Run unit tests to verify they pass**
+
+Run: `bin/rails test test/services/mcp/projects_at_risk_tool_test.rb`
+Expected: PASS (7 tests).
+
+- [ ] **Step 6: Update the integration tool-name array**
+
+In `test/integration/mcp_endpoint_test.rb`, the sorted array assertion becomes:
+
+```ruby
+    assert_equal %w[get_ar_aging get_document list_documents list_open_admin_tasks list_overdue_invoices list_projects_at_risk list_sources search], tool_names.sort,
+      "Expected all registered tools, got: #{tool_names.inspect}"
+```
+
+Add a round-trip test (mirror the existing `list_open_admin_tasks` round-trip in the same file for envelope/headers):
+
+```ruby
+  test "tools/call round-trip for list_projects_at_risk returns a valid payload" do
+    post "/api/mcp",
+      headers: api_key_headers,
+      params: {
+        jsonrpc: "2.0", id: 11, method: "tools/call",
+        params: { name: "list_projects_at_risk", arguments: {} },
+      }.to_json
+    assert_response :success
+    text = JSON.parse(response.body).dig("result", "content", 0, "text")
+    payload = JSON.parse(text)
+    assert payload.key?("count")
+    assert payload.key?("projects")
+  end
+```
+
+Run: `bin/rails test test/integration/mcp_endpoint_test.rb`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/services/mcp/list_projects_at_risk_tool.rb app/services/mcp/server.rb \
+        test/services/mcp/projects_at_risk_tool_test.rb test/integration/mcp_endpoint_test.rb
+git commit -m "Add list_projects_at_risk MCP tool (tracker-target risk judgments)"
+```
+
+---
+
+### Task 2: `get_studio_health` tool
+
+**Files:**
+- Create: `app/services/mcp/get_studio_health_tool.rb`
+- Create: `test/services/mcp/studio_health_tool_test.rb`
+- Modify: `app/services/mcp/server.rb` (TOOLS array, 8 entries after Task 1)
+- Modify: `test/integration/mcp_endpoint_test.rb` (array gains `get_studio_health`; sorted: `%w[get_ar_aging get_document get_studio_health list_documents list_open_admin_tasks list_overdue_invoices list_projects_at_risk list_sources search]`) + one round-trip test.
+
+**Interfaces:**
+- Consumes: `Studio` — `#name`, `#mini_name`, `#snapshot` (jsonb: gradation string keys → array of period entries, each `{ 'label', 'period_starts_at', 'period_ends_at', 'cash' => { 'datapoints', 'okrs' }, 'accrual' => {...}, 'utilization' => <per-person map — MUST NOT be emitted> }`; also top-level `started_at`/`finished_at` strings — ignore). `Mcp::Responses.ok/.error`.
+- Produces: the `get_studio_health` MCP tool. Payload: `{ studios: [{ studio, mini_name, gradation, accounting_method, periods: [{ label, period_starts_at, period_ends_at, datapoints, okrs }] }] }` — `datapoints`/`okrs` passed through verbatim.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/services/mcp/studio_health_tool_test.rb`:
+
+```ruby
+require 'test_helper'
+
+class Mcp::StudioHealthToolTest < ActiveSupport::TestCase
+  def period_entry(label, income:, okr_health: 'healthy')
+    {
+      'label' => label,
+      'period_starts_at' => '01/01/2026',
+      'period_ends_at' => '01/31/2026',
+      'cash' => {
+        'datapoints' => { 'income' => { 'value' => income, 'unit' => 'usd' },
+                          'lead_count' => { 'value' => 3, 'unit' => 'count' } },
+        'okrs' => { 'Profit Margin' => { 'health' => okr_health, 'target' => 30 } },
+      },
+      'accrual' => {
+        'datapoints' => { 'income' => { 'value' => income + 1, 'unit' => 'usd' } },
+        'okrs' => {},
+      },
+      'utilization' => { 'someone@sanctuary.computer' => { 'billable' => 120 } },
+    }
+  end
+
+  def studio!(name:, mini_name:, periods: 2)
+    Studio.create!(
+      name: name, mini_name: mini_name,
+      snapshot: { 'month' => (1..periods).map { |i| period_entry("2026-%02d" % i, income: i * 1000) } }
+    )
+  end
+
+  def payload_for(resp)
+    JSON.parse(resp.content.first[:text])
+  end
+
+  test 'passes the chosen accounting subtree through verbatim, excluding per-person utilization' do
+    studio!(name: 'Sanctuary Test', mini_name: 'sanc')
+    payload = payload_for(Mcp::GetStudioHealthTool.call(studio: 'sanc', server_context: {}))
+    s = payload['studios'].first
+    assert_equal 'Sanctuary Test', s['studio']
+    assert_equal 'month', s['gradation']
+    assert_equal 'cash', s['accounting_method']
+    period = s['periods'].last
+    assert_equal({ 'value' => 2000, 'unit' => 'usd' }, period['datapoints']['income'])
+    assert_equal 'healthy', period['okrs']['Profit Margin']['health']
+    assert_nil period['utilization'], 'per-person utilization must never be emitted'
+    refute s['periods'].first.key?('utilization')
+  end
+
+  test 'accrual accounting_method selects the accrual subtree' do
+    studio!(name: 'Accrual Studio', mini_name: 'accr')
+    payload = payload_for(Mcp::GetStudioHealthTool.call(studio: 'accr', accounting_method: 'accrual', server_context: {}))
+    assert_equal 2001, payload['studios'].first['periods'].last['datapoints']['income']['value']
+  end
+
+  test 'periods param takes the most recent N' do
+    studio!(name: 'Many Periods', mini_name: 'many', periods: 10)
+    payload = payload_for(Mcp::GetStudioHealthTool.call(studio: 'many', periods: 3, server_context: {}))
+    labels = payload['studios'].first['periods'].map { |p| p['label'] }
+    assert_equal %w[2026-08 2026-09 2026-10], labels
+  end
+
+  test 'unknown studio errors listing valid studios; invalid gradation and accounting_method error' do
+    studio!(name: 'Only Studio', mini_name: 'only')
+    err = payload_for(Mcp::GetStudioHealthTool.call(studio: 'nope', server_context: {}))
+    assert_includes err['error'], "Unknown studio 'nope'"
+    assert_includes err['error'], 'Only Studio'
+    err = payload_for(Mcp::GetStudioHealthTool.call(gradation: 'weekly', server_context: {}))
+    assert_includes err['error'], "Invalid gradation 'weekly'"
+    err = payload_for(Mcp::GetStudioHealthTool.call(accounting_method: 'both', server_context: {}))
+    assert_includes err['error'], "Invalid accounting_method 'both'"
+  end
+
+  test 'listing all skips snapshotless studios with a warning; explicit request errors' do
+    studio!(name: 'Has Snapshot', mini_name: 'has')
+    Studio.create!(name: 'No Snapshot', mini_name: 'none')
+    Rails.logger.expects(:warn).with { |msg| msg.include?('No Snapshot') }.at_least_once
+    payload = payload_for(Mcp::GetStudioHealthTool.call(server_context: {}))
+    assert_equal ['Has Snapshot'], payload['studios'].map { |s| s['studio'] }
+    err = payload_for(Mcp::GetStudioHealthTool.call(studio: 'none', server_context: {}))
+    assert_includes err['error'], 'no generated snapshot'
+  end
+end
+```
+
+NOTE: if `Studio.create!` requires more attributes (check validations/DB constraints if it fails), add the minimal ones — do not change the model. If existing Studio fixtures/records exist in the test DB, scope assertions by the created names (they already are).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bin/rails test test/services/mcp/studio_health_tool_test.rb`
+Expected: FAIL — `NameError: uninitialized constant Mcp::GetStudioHealthTool`.
+
+- [ ] **Step 3: Implement the tool**
+
+Create `app/services/mcp/get_studio_health_tool.rb`:
+
+```ruby
+module Mcp
+  class GetStudioHealthTool < MCP::Tool
+    tool_name 'get_studio_health'
+    description 'Per-studio health rollups from the nightly Studio snapshot: financial datapoints ' \
+                '(income, cogs, net operating income, profit margin), utilization hours, lead counts, ' \
+                'satisfaction scores, and OKR health per period. Pure read of the persisted rollup — ' \
+                'figures always match Stacks\' own reporting. Never regenerates, never calls live APIs.'
+    input_schema(
+      properties: {
+        studio: { type: 'string', description: 'Optional studio name or mini_name (case-insensitive). Default: all studios with a snapshot.' },
+        gradation: { type: 'string', description: 'month (default), quarter, year, trailing_3_months, trailing_4_months, trailing_6_months, trailing_12_months' },
+        accounting_method: { type: 'string', description: 'cash (default) or accrual' },
+        periods: { type: 'integer', description: 'Most recent N periods (default 6, clamped 1..24)' },
+      },
+      required: []
+    )
+    annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true)
+
+    GRADATIONS = %w[month quarter year trailing_3_months trailing_4_months trailing_6_months trailing_12_months].freeze
+    ACCOUNTING_METHODS = %w[cash accrual].freeze
+
+    def self.call(studio: nil, gradation: 'month', accounting_method: 'cash', periods: 6, server_context:)
+      gradation = gradation.to_s
+      unless GRADATIONS.include?(gradation)
+        return Responses.error("Invalid gradation '#{gradation}'. Valid gradations: #{GRADATIONS.join(', ')}")
+      end
+      method = accounting_method.to_s
+      unless ACCOUNTING_METHODS.include?(method)
+        return Responses.error("Invalid accounting_method '#{method}'. Valid: #{ACCOUNTING_METHODS.join(', ')}")
+      end
+      recent = periods.to_i.clamp(1, 24)
+
+      all_studios = Studio.all.to_a
+      requested =
+        if studio.present?
+          key = studio.to_s.strip
+          match = all_studios.find { |s| s.name.casecmp?(key) || s.mini_name.to_s.casecmp?(key) }
+          unless match
+            valid = all_studios.map { |s| "#{s.name} (#{s.mini_name})" }.sort.join(', ')
+            return Responses.error("Unknown studio '#{studio}'. Valid studios: #{valid}")
+          end
+          if match.snapshot.blank? || match.snapshot[gradation].blank?
+            return Responses.error("Studio '#{match.name}' has no generated snapshot for gradation '#{gradation}' yet.")
+          end
+          [match]
+        else
+          all_studios
+        end
+
+      studios_payload = requested.filter_map do |s|
+        entries = s.snapshot.presence && s.snapshot[gradation]
+        if entries.blank?
+          Rails.logger.warn("[Mcp::GetStudioHealthTool] skipping studio '#{s.name}': no snapshot data for '#{gradation}'") if studio.blank?
+          next nil
+        end
+
+        # Pass label/dates + the chosen accounting subtree (datapoints + okrs)
+        # through VERBATIM — re-mapping invites drift from the canonical
+        # computed shape. The period-level 'utilization' key is deliberately
+        # excluded: it is a per-person email → hours map (get_capacity's
+        # future surface), not a studio rollup.
+        {
+          studio: s.name,
+          mini_name: s.mini_name,
+          gradation: gradation,
+          accounting_method: method,
+          periods: Array(entries).last(recent).map do |entry|
+            {
+              label: entry['label'],
+              period_starts_at: entry['period_starts_at'],
+              period_ends_at: entry['period_ends_at'],
+              datapoints: entry.dig(method, 'datapoints'),
+              okrs: entry.dig(method, 'okrs'),
+            }
+          end,
+        }
+      rescue StandardError => e
+        Rails.logger.warn("[Mcp::GetStudioHealthTool] skipping studio '#{s.name}': #{e.class}: #{e.message}")
+        Sentry.capture_exception(e)
+        nil
+      end
+
+      Responses.ok({ studios: studios_payload })
+    end
+  end
+end
+```
+
+Append `Mcp::GetStudioHealthTool,` to `TOOLS` in `app/services/mcp/server.rb`.
+
+- [ ] **Step 4: Run unit tests to verify they pass**
+
+Run: `bin/rails test test/services/mcp/studio_health_tool_test.rb`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Update the integration tool-name array + round-trip**
+
+Sorted array becomes:
+
+```ruby
+    assert_equal %w[get_ar_aging get_document get_studio_health list_documents list_open_admin_tasks list_overdue_invoices list_projects_at_risk list_sources search], tool_names.sort,
+      "Expected all registered tools, got: #{tool_names.inspect}"
+```
+
+Round-trip test (empty test DB has no studios — a valid empty payload):
+
+```ruby
+  test "tools/call round-trip for get_studio_health returns a valid payload" do
+    post "/api/mcp",
+      headers: api_key_headers,
+      params: {
+        jsonrpc: "2.0", id: 12, method: "tools/call",
+        params: { name: "get_studio_health", arguments: { gradation: "month" } },
+      }.to_json
+    assert_response :success
+    text = JSON.parse(response.body).dig("result", "content", 0, "text")
+    payload = JSON.parse(text)
+    assert payload.key?("studios")
+  end
+```
+
+Run: `bin/rails test test/services/mcp/studio_health_tool_test.rb test/integration/mcp_endpoint_test.rb`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/mcp/get_studio_health_tool.rb app/services/mcp/server.rb \
+        test/services/mcp/studio_health_tool_test.rb test/integration/mcp_endpoint_test.rb
+git commit -m "Add get_studio_health MCP tool (verbatim snapshot rollup pass-through)"
+```
+
+---
+
+### Task 3: Full-suite verification
+
+**Files:** none new — fix only branch-caused fallout.
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–2.
+- Produces: a green suite (modulo the known pre-existing `AdminUserTest` date flake — classify, don't fix).
+
+- [ ] **Step 1: Run the MCP suites**
+
+Run: `bin/rails test test/services/mcp test/integration/mcp_endpoint_test.rb`
+Expected: PASS.
+
+- [ ] **Step 2: Run the full suite**
+
+Run: `bin/rails test`
+Expected: no new failures relative to `main`.
+
+- [ ] **Step 3: Commit (only if fixes were needed)**
+
+```bash
+git add -A && git commit -m "Fix test fallout from business-tools MCP slice"
+```

--- a/docs/superpowers/specs/2026-07-05-mcp-business-tools-design.md
+++ b/docs/superpowers/specs/2026-07-05-mcp-business-tools-design.md
@@ -51,8 +51,10 @@ pipeline/OKR aggregates from Stacks, and lead rows from Notion.
   work stays out of the pre-read by default.
 - **Row fields:** `name`, `work_status`, `spend`, `budget_low_end`, `budget_high_end`,
   `profit_margin` (rounded 1dp), `target_profit_margin`, `free_hours_percent` (ratio × 100,
-  rounded 1dp), `target_free_hours_percent`, `likely_complete`, `considered_successful`,
+  rounded 1dp), `target_free_hours_percent`, `considered_successful`,
   `at_risk`, `risk_reasons`, `url` (`#external_link` — absolute Stacks admin URL).
+  (`likely_complete` was dropped in review round 2: redundant with work_status for active rows,
+  contradictory for completed ones — work_status carries the same signal coherently.)
 - **Batch loading:** `ProjectTracker.preload_for_render(scope)` before mapping; rows sorted
   most-at-risk first (by number of tripped criteria, then name) so the pre-read reads top-down.
 - **Snapshot dependence:** metrics come from the nightly snapshot jsonb. Trackers with an

--- a/docs/superpowers/specs/2026-07-05-mcp-business-tools-design.md
+++ b/docs/superpowers/specs/2026-07-05-mcp-business-tools-design.md
@@ -41,6 +41,9 @@ established pattern (finance pair → admin tasks → business pair).
     predicate — this one comparison lives in the tool)
   Each row carries `at_risk: true/false` and `risk_reasons: [...]` naming the tripped criteria.
   Alternatives Hugh can pick: fixed global thresholds as params, or no server-side judgment.
+- **Base scope:** all `ProjectTracker`s whose `work_status` is `:in_progress` or
+  `:likely_complete`; `include_complete: true` widens to every tracker. Historical completed
+  work stays out of the pre-read by default.
 - **Row fields:** `name`, `work_status`, `spend`, `budget_low_end`, `budget_high_end`,
   `profit_margin` (rounded 1dp), `target_profit_margin`, `free_hours_percent` (ratio × 100,
   rounded 1dp), `target_free_hours_percent`, `likely_complete`, `considered_successful`,
@@ -60,12 +63,20 @@ established pattern (finance pair → admin tasks → business pair).
   - `studio` (optional string; matched against Studio name or mini_name, case-insensitive,
     Ruby-side like the enterprise/owner resolvers; unknown → error listing valid studios).
 - **Reads:** `Stacks::Notion::Lead.all` once (the synced Notion mirror — never live Notion),
-  partitioned per studio via each lead's `#studios`; period logic via
-  `Studio#leads_recieved_in_period` / `#sent_proposals_settled_in_period` semantics (received /
-  settled date within period).
+  partitioned per studio. **N+1 hazard:** `Lead#studios` calls `Studio.all_studios` internally
+  per lead — the tool must hoist: load studios once and resolve each lead's studio names
+  against that in-memory list (extend `Lead#studios` with an optional preloaded-studios
+  argument, mirroring the existing `account_lead_admin_users_cache` pattern in that class,
+  rather than re-implementing the matching in the tool). Period semantics follow
+  `Studio#leads_recieved_in_period` / `#sent_proposals_settled_in_period` (received / settled
+  date within period).
+- **Params (additional):** `aging_min_days` (optional integer, default 30, clamped ≥ 1).
 - **Payload:** per studio: `leads_received` (count + rows), `proposals_settled` (count + rows),
-  `won` (count), plus a cross-period `aging_unsettled` list (leads received before the period
-  that remain unsettled — the "aging Leads" half of the pre-read), sorted oldest first.
+  `won` (count of leads with `won_at` within the period), plus `aging_unsettled` — unsettled
+  leads (`settled_at` absent) with `age_days >= aging_min_days`, **excluding leads whose
+  `reactivate_at` is in the future** (deliberately parked, not aging — the roadmap treats
+  Reactivate Date as scheduled re-engagement), sorted oldest first. Independent of the period
+  params: aging is a now-state, not a period bucket.
 - **Lead row fields:** `title` (Notion page title), `studios`, `received_at`, `age_days`,
   `proposal_sent_at`, `settled_at`, `won_at`, `reactivate_at`, `account_leads` (emails),
   `notion_url`. Lead titles/emails are operational business data — in-bounds per the

--- a/docs/superpowers/specs/2026-07-05-mcp-business-tools-design.md
+++ b/docs/superpowers/specs/2026-07-05-mcp-business-tools-design.md
@@ -42,8 +42,9 @@ pipeline/OKR aggregates from Stacks, and lead rows from Notion.
   never re-derive the comparisons in the tool:
   - `margin_below_target`: `!target_profit_margin_satisfied?`
   - `free_hours_above_target`: `!target_free_hours_ratio_satisfied?`
-  - `over_budget`: `budget_high_end` present and `spend > budget_high_end` (no existing
-    predicate — this one comparison lives in the tool)
+  - `over_budget`: `ProjectTracker#status == :over_budget` (review round 1 found the model
+    predicate the earlier draft claimed didn't exist — the admin UI's budget pill uses it,
+    so the tool now shares it)
   Each row carries `at_risk: true/false` and `risk_reasons: [...]` naming the tripped criteria.
   Alternatives Hugh can pick: fixed global thresholds as params, or no server-side judgment.
 - **Base scope:** all `ProjectTracker`s whose `work_status` is `:in_progress` or

--- a/docs/superpowers/specs/2026-07-05-mcp-business-tools-design.md
+++ b/docs/superpowers/specs/2026-07-05-mcp-business-tools-design.md
@@ -56,8 +56,9 @@ pipeline/OKR aggregates from Stacks, and lead rows from Notion.
 - **Batch loading:** `ProjectTracker.preload_for_render(scope)` before mapping; rows sorted
   most-at-risk first (by number of tripped criteria, then name) so the pre-read reads top-down.
 - **Snapshot dependence:** metrics come from the nightly snapshot jsonb. Trackers with an
-  empty/missing snapshot are skipped with a logged warning (same never-raise doctrine as the
-  prior tools; a Rails.logger.warn + Sentry, matching the admin-tasks skip path).
+  empty/missing snapshot are skipped with a logged warning only (a routine state — new
+  trackers before their first nightly run — not an alert). Mapping *raises* get
+  warn + Sentry, matching the admin-tasks skip path.
 
 ## Tool 2: `get_studio_health`
 

--- a/docs/superpowers/specs/2026-07-05-mcp-business-tools-design.md
+++ b/docs/superpowers/specs/2026-07-05-mcp-business-tools-design.md
@@ -1,0 +1,101 @@
+# Design: MCP tools — `list_pipeline` + `list_projects_at_risk`
+
+**Date:** 2026-07-05
+**Source:** [Stacksbot ROADMAP](https://www.notion.so/garden3d/ROADMAP-md-391131fea2c7801485e0d767177e0da3) Phase 1a + [SPEC — Stacks MCP upgrades](https://www.notion.so/garden3d/SPEC-Stacks-MCP-upgrades-391131fea2c78147a3aff77c7a6a5493)
+**Status:** Draft — awaiting Hugh's review. One decision defaulted while he was away, flagged ⚖️ below.
+
+## Why this slice
+
+The roadmap's ranked delivery order puts **Business pre-read v1 (automation #2)** next, and it
+depends on exactly these two P1a tools: new/aging Leads (`list_pipeline`) + at-risk projects
+(`list_projects_at_risk`). Both read data Stacks already computes — ProjectTracker nightly
+snapshots and the Notion Leads mirror — no schema changes, no new syncs. Third slice in the
+established pattern (finance pair → admin tasks → business pair).
+
+## Approaches considered
+
+1. **Two thin presenter tools over existing model methods (chosen).** Mirrors the finance/admin
+   slices: one file per tool, `Mcp::Responses` envelope, read-only annotations, params with
+   sane defaults. `list_projects_at_risk` uses `ProjectTracker.preload_for_render` for batch
+   loading; `list_pipeline` uses `Stacks::Notion::Lead.all` + `Studio` period helpers.
+2. **One combined `get_business_preread` tool.** Couples two different consumers (pipeline
+   review vs delivery oversight) and diverges from the spec's named tool contract. Rejected.
+3. **Server-side pre-read composition (render the whole meeting doc).** That's the Stacksbot
+   job's concern, not Stacks'. Rejected.
+
+## Tool 1: `list_projects_at_risk`
+
+- **File:** `app/services/mcp/list_projects_at_risk_tool.rb`
+- **Params:**
+  - `only_at_risk` (optional boolean, default `true`) — when `false`, returns every non-complete
+    project with its metrics + targets so the agent can judge for itself.
+  - `include_complete` (optional boolean, default `false`) — include projects whose
+    `work_status` is complete/capsule-pending.
+- ⚖️ **Risk semantics (defaulted — Hugh to confirm).** At risk = any of, judged against **the
+  tracker's own configured targets** (no invented policy — this is what `considered_successful?`
+  already means in Stacks). Single source of truth: reuse the model's existing predicates,
+  never re-derive the comparisons in the tool:
+  - `margin_below_target`: `!target_profit_margin_satisfied?`
+  - `free_hours_above_target`: `!target_free_hours_ratio_satisfied?`
+  - `over_budget`: `budget_high_end` present and `spend > budget_high_end` (no existing
+    predicate — this one comparison lives in the tool)
+  Each row carries `at_risk: true/false` and `risk_reasons: [...]` naming the tripped criteria.
+  Alternatives Hugh can pick: fixed global thresholds as params, or no server-side judgment.
+- **Row fields:** `name`, `work_status`, `spend`, `budget_low_end`, `budget_high_end`,
+  `profit_margin` (rounded 1dp), `target_profit_margin`, `free_hours_percent` (ratio × 100,
+  rounded 1dp), `target_free_hours_percent`, `likely_complete`, `considered_successful`,
+  `at_risk`, `risk_reasons`, `url` (`#external_link` — absolute Stacks admin URL).
+- **Batch loading:** `ProjectTracker.preload_for_render(scope)` before mapping; rows sorted
+  most-at-risk first (by number of tripped criteria, then name) so the pre-read reads top-down.
+- **Snapshot dependence:** metrics come from the nightly snapshot jsonb. Trackers with an
+  empty/missing snapshot are skipped with a logged warning (same never-raise doctrine as the
+  prior tools; a Rails.logger.warn + Sentry, matching the admin-tasks skip path).
+
+## Tool 2: `list_pipeline`
+
+- **File:** `app/services/mcp/list_pipeline_tool.rb`
+- **Params:**
+  - `period_start` / `period_end` (optional ISO dates; default: trailing 30 days ending today).
+    Invalid dates → error payload naming the expected format.
+  - `studio` (optional string; matched against Studio name or mini_name, case-insensitive,
+    Ruby-side like the enterprise/owner resolvers; unknown → error listing valid studios).
+- **Reads:** `Stacks::Notion::Lead.all` once (the synced Notion mirror — never live Notion),
+  partitioned per studio via each lead's `#studios`; period logic via
+  `Studio#leads_recieved_in_period` / `#sent_proposals_settled_in_period` semantics (received /
+  settled date within period).
+- **Payload:** per studio: `leads_received` (count + rows), `proposals_settled` (count + rows),
+  `won` (count), plus a cross-period `aging_unsettled` list (leads received before the period
+  that remain unsettled — the "aging Leads" half of the pre-read), sorted oldest first.
+- **Lead row fields:** `title` (Notion page title), `studios`, `received_at`, `age_days`,
+  `proposal_sent_at`, `settled_at`, `won_at`, `reactivate_at`, `account_leads` (emails),
+  `notion_url`. Lead titles/emails are operational business data — in-bounds per the
+  established comp-boundary scope (same rationale as the admin-tasks slice).
+- **Leads with malformed/missing dates:** skipped from period buckets they can't be evaluated
+  for, never raise; a lead with no `received_at` appears only in a `undated` count so the
+  data-hygiene signal isn't silently lost.
+
+## Shared conventions (as the prior two slices)
+
+`Mcp::Responses.ok/.error`; `annotations(read_only_hint: true, destructive_hint: false,
+idempotent_hint: true)`; registered in `Mcp::Server::TOOLS` (8 tools after this); integration
+test tool-name array updated; a `tools/call` round-trip per tool; never a live external API
+call (snapshots + synced NotionPage rows only).
+
+## Error handling
+
+Unknown `studio` → error listing valid studios. Invalid `period_start`/`period_end` → error
+naming expected ISO format. Per-row mapping failures → skip + warn + Sentry, never fail the
+report. Empty results → valid empty payloads with zero counts.
+
+## Testing
+
+Unit tests per tool (fixtures/created records for trackers with snapshot jsonb covering:
+at-risk on each criterion separately, not-at-risk, no-budget trackers, missing snapshot skip;
+leads via NotionPage rows covering: received-in-period, settled-in-period, won, aging
+unsettled, undated, studio partitioning, period-param validation). Integration: registry
+array + one round-trip per tool. Full suite green.
+
+## Out of scope
+
+The Business pre-read automation itself (Stacksbot config), `get_studio_health`,
+`get_capacity`, `get_pnl`, privacy hardening G1–G4, any write path.

--- a/docs/superpowers/specs/2026-07-05-mcp-business-tools-design.md
+++ b/docs/superpowers/specs/2026-07-05-mcp-business-tools-design.md
@@ -1,23 +1,28 @@
-# Design: MCP tools — `list_pipeline` + `list_projects_at_risk`
+# Design: MCP tools — `list_projects_at_risk` + `get_studio_health`
 
 **Date:** 2026-07-05
 **Source:** [Stacksbot ROADMAP](https://www.notion.so/garden3d/ROADMAP-md-391131fea2c7801485e0d767177e0da3) Phase 1a + [SPEC — Stacks MCP upgrades](https://www.notion.so/garden3d/SPEC-Stacks-MCP-upgrades-391131fea2c78147a3aff77c7a6a5493)
-**Status:** Draft — awaiting Hugh's review. One decision defaulted while he was away, flagged ⚖️ below.
+**Status:** Approved direction (Hugh, 2026-07-05): `list_pipeline` dropped in favor of Notion MCP for lead rows; OKR/win-rate rollups via `get_studio_health` blessed. Remaining defaulted decision flagged ⚖️ below (risk semantics).
 
 ## Why this slice
 
-The roadmap's ranked delivery order puts **Business pre-read v1 (automation #2)** next, and it
-depends on exactly these two P1a tools: new/aging Leads (`list_pipeline`) + at-risk projects
-(`list_projects_at_risk`). Both read data Stacks already computes — ProjectTracker nightly
-snapshots and the Notion Leads mirror — no schema changes, no new syncs. Third slice in the
-established pattern (finance pair → admin tasks → business pair).
+The roadmap's ranked delivery order puts **Business pre-read v1 (automation #2)** next. Its
+named dependencies were `list_pipeline` + `list_projects_at_risk` — but **`list_pipeline` is
+dropped by decision (Hugh, 2026-07-05)**: lead rows live canonically in the Notion Leads DB,
+which Stacksbot reads directly via the Notion MCP (fresher than the Stacks mirror, with all
+properties; 🎯 Leads becomes its own Datazone Sources row). Duplicating those rows on Stacks
+MCP would create two sources for one dataset. What Stacks uniquely owns is the *rollup* —
+`Studio#snapshot`'s per-period lead counts, win rates, financials, utilization, and OKR
+health — which is `get_studio_health` (also P1a). This slice therefore ships
+`list_projects_at_risk` + `get_studio_health`: the pre-read gets at-risk projects and
+pipeline/OKR aggregates from Stacks, and lead rows from Notion.
 
 ## Approaches considered
 
 1. **Two thin presenter tools over existing model methods (chosen).** Mirrors the finance/admin
    slices: one file per tool, `Mcp::Responses` envelope, read-only annotations, params with
    sane defaults. `list_projects_at_risk` uses `ProjectTracker.preload_for_render` for batch
-   loading; `list_pipeline` uses `Stacks::Notion::Lead.all` + `Studio` period helpers.
+   loading; `get_studio_health` is a pure read of the persisted `Studio#snapshot` rollup.
 2. **One combined `get_business_preread` tool.** Couples two different consumers (pipeline
    review vs delivery oversight) and diverges from the spec's named tool contract. Rejected.
 3. **Server-side pre-read composition (render the whole meeting doc).** That's the Stacksbot
@@ -54,59 +59,61 @@ established pattern (finance pair → admin tasks → business pair).
   empty/missing snapshot are skipped with a logged warning (same never-raise doctrine as the
   prior tools; a Rails.logger.warn + Sentry, matching the admin-tasks skip path).
 
-## Tool 2: `list_pipeline`
+## Tool 2: `get_studio_health`
 
-- **File:** `app/services/mcp/list_pipeline_tool.rb`
+- **File:** `app/services/mcp/get_studio_health_tool.rb`
 - **Params:**
-  - `period_start` / `period_end` (optional ISO dates; default: trailing 30 days ending today).
-    Invalid dates → error payload naming the expected format.
   - `studio` (optional string; matched against Studio name or mini_name, case-insensitive,
-    Ruby-side like the enterprise/owner resolvers; unknown → error listing valid studios).
-- **Reads:** `Stacks::Notion::Lead.all` once (the synced Notion mirror — never live Notion),
-  partitioned per studio. **N+1 hazard:** `Lead#studios` calls `Studio.all_studios` internally
-  per lead — the tool must hoist: load studios once and resolve each lead's studio names
-  against that in-memory list (extend `Lead#studios` with an optional preloaded-studios
-  argument, mirroring the existing `account_lead_admin_users_cache` pattern in that class,
-  rather than re-implementing the matching in the tool). Period semantics follow
-  `Studio#leads_recieved_in_period` / `#sent_proposals_settled_in_period` (received / settled
-  date within period).
-- **Params (additional):** `aging_min_days` (optional integer, default 30, clamped ≥ 1).
-- **Payload:** per studio: `leads_received` (count + rows), `proposals_settled` (count + rows),
-  `won` (count of leads with `won_at` within the period), plus `aging_unsettled` — unsettled
-  leads (`settled_at` absent) with `age_days >= aging_min_days`, **excluding leads whose
-  `reactivate_at` is in the future** (deliberately parked, not aging — the roadmap treats
-  Reactivate Date as scheduled re-engagement), sorted oldest first. Independent of the period
-  params: aging is a now-state, not a period bucket.
-- **Lead row fields:** `title` (Notion page title), `studios`, `received_at`, `age_days`,
-  `proposal_sent_at`, `settled_at`, `won_at`, `reactivate_at`, `account_leads` (emails),
-  `notion_url`. Lead titles/emails are operational business data — in-bounds per the
-  established comp-boundary scope (same rationale as the admin-tasks slice).
-- **Leads with malformed/missing dates:** skipped from period buckets they can't be evaluated
-  for, never raise; a lead with no `received_at` appears only in a `undated` count so the
-  data-hygiene signal isn't silently lost.
+    Ruby-side like the enterprise/owner resolvers; unknown → error listing valid studios;
+    default: all studios with a snapshot).
+  - `gradation` (optional enum: `month` / `quarter` / `year` / `trailing_3_months` /
+    `trailing_4_months` / `trailing_6_months` / `trailing_12_months`; default `month`;
+    invalid → error listing valid gradations).
+  - `accounting_method` (optional: `cash` | `accrual`, default `cash`; invalid → error).
+  - `periods` (optional integer, default 6, clamped 1..24) — most recent N periods, bounding
+    payload size.
+- **Reads:** `Studio#snapshot` jsonb (built nightly by `Studio#generate_snapshot!`) — the tool
+  NEVER regenerates; it is a pure read of the persisted rollup, so figures always match what
+  Stacks reports elsewhere. Structure per period: the chosen accounting method's subtree
+  (`datapoints` — income, cogs, expenses, net operating income, profit margin, utilization
+  hours (sellable/billable/free), lead_count, satisfaction scores, etc. — plus `okrs` with
+  targets/actuals/health). **Pass the subtree through verbatim** (period label/dates +
+  `datapoints` + `okrs`): re-mapping invites drift from the canonical computed shape; the
+  `periods` clamp keeps payloads bounded.
+- **Pipeline aggregates + OKR/win-rate surface** (per Hugh: "cool to surface OKR/win rate
+  stuff") come through these snapshot datapoints/okrs — this is the blessed replacement for
+  the dropped `list_pipeline` rollups.
+- **Studios with a blank/missing snapshot:** skipped with a logged warning when listing all;
+  an explicitly requested studio with no snapshot → error saying the snapshot hasn't been
+  generated yet.
 
 ## Shared conventions (as the prior two slices)
 
 `Mcp::Responses.ok/.error`; `annotations(read_only_hint: true, destructive_hint: false,
 idempotent_hint: true)`; registered in `Mcp::Server::TOOLS` (8 tools after this); integration
 test tool-name array updated; a `tools/call` round-trip per tool; never a live external API
-call (snapshots + synced NotionPage rows only).
+call (persisted tracker + studio snapshots only).
 
 ## Error handling
 
-Unknown `studio` → error listing valid studios. Invalid `period_start`/`period_end` → error
-naming expected ISO format. Per-row mapping failures → skip + warn + Sentry, never fail the
-report. Empty results → valid empty payloads with zero counts.
+Unknown `studio` → error listing valid studios. Invalid `gradation` / `accounting_method` →
+error listing valid values; `periods` clamped, never errors. Per-row mapping failures →
+skip + warn + Sentry, never fail the report. Empty results → valid empty payloads with zero
+counts.
 
 ## Testing
 
-Unit tests per tool (fixtures/created records for trackers with snapshot jsonb covering:
-at-risk on each criterion separately, not-at-risk, no-budget trackers, missing snapshot skip;
-leads via NotionPage rows covering: received-in-period, settled-in-period, won, aging
-unsettled, undated, studio partitioning, period-param validation). Integration: registry
-array + one round-trip per tool. Full suite green.
+Unit tests per tool. Trackers: created records with snapshot jsonb covering at-risk on each
+criterion separately, not-at-risk, no-budget trackers, missing-snapshot skip, only_at_risk
+and include_complete params. Studio health: created Studio records with a representative
+snapshot jsonb covering gradation/accounting_method/periods params, param validation errors,
+all-studios vs single-studio, blank-snapshot skip vs explicit-request error, and verbatim
+subtree pass-through. Integration: registry array + one round-trip per tool. Full suite
+green.
 
 ## Out of scope
 
-The Business pre-read automation itself (Stacksbot config), `get_studio_health`,
-`get_capacity`, `get_pnl`, privacy hardening G1–G4, any write path.
+The Business pre-read automation itself (Stacksbot config), the 🎯 Leads Notion Sources row
+(follows with automation #2 wiring), `get_capacity`, `get_pnl`, privacy hardening G1–G4, any
+write path. `list_pipeline` is not deferred — it is dropped (decision above); the roadmap's
+P1a tool list should be amended accordingly.

--- a/test/integration/mcp_endpoint_test.rb
+++ b/test/integration/mcp_endpoint_test.rb
@@ -17,6 +17,16 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
     MCP_HEADERS.merge("X-Api-Key" => Stacks::Utils.config[:stacks][:private_api_key])
   end
 
+  # POSTs a JSON-RPC tools/call and returns the parsed tool payload.
+  def call_tool(name, arguments = {})
+    post "/api/mcp",
+      headers: api_key_headers,
+      params: { jsonrpc: "2.0", id: 99, method: "tools/call",
+                params: { name: name, arguments: arguments } }.to_json
+    assert_response :success
+    JSON.parse(JSON.parse(response.body).dig("result", "content", 0, "text"))
+  end
+
   # ----- auth -----
 
   test "POST without X-Api-Key returns 403 forbidden" do
@@ -50,20 +60,7 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
   end
 
   test "POST tools/call for get_ar_aging returns a parseable report" do
-    post "/api/mcp",
-      headers: api_key_headers,
-      params: {
-        jsonrpc: "2.0",
-        id: 1,
-        method: "tools/call",
-        params: { name: "get_ar_aging", arguments: {} }
-      }.to_json
-
-    assert_response :success
-    body = JSON.parse(response.body)
-    assert body.key?("result"), "Expected JSON-RPC result key, got: #{body.inspect}"
-    text = body["result"]["content"][0]["text"]
-    payload = JSON.parse(text)
+    payload = call_tool("get_ar_aging")
     assert payload.key?("total_ar"), "Expected 'total_ar' key in payload, got: #{payload.inspect}"
     assert payload.key?("enterprises"), "Expected 'enterprises' key in payload, got: #{payload.inspect}"
     assert_match(/\A\d{4}-\d{2}-\d{2}\z/, payload["as_of"])
@@ -71,43 +68,19 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
 
   test "tools/call round-trip for list_open_admin_tasks returns a valid payload" do
     Stacks::TaskBuilder.any_instance.stubs(:tasks).returns([])
-    post "/api/mcp",
-      headers: api_key_headers,
-      params: {
-        jsonrpc: "2.0", id: 9, method: "tools/call",
-        params: { name: "list_open_admin_tasks", arguments: {} },
-      }.to_json
-    assert_response :success
-    text = JSON.parse(response.body).dig("result", "content", 0, "text")
-    payload = JSON.parse(text)
+    payload = call_tool("list_open_admin_tasks")
     assert_equal 0, payload["count"]
     assert_equal [], payload["tasks"]
   end
 
   test "tools/call round-trip for list_projects_at_risk returns a valid payload" do
-    post "/api/mcp",
-      headers: api_key_headers,
-      params: {
-        jsonrpc: "2.0", id: 11, method: "tools/call",
-        params: { name: "list_projects_at_risk", arguments: {} },
-      }.to_json
-    assert_response :success
-    text = JSON.parse(response.body).dig("result", "content", 0, "text")
-    payload = JSON.parse(text)
+    payload = call_tool("list_projects_at_risk")
     assert payload.key?("count")
     assert payload.key?("projects")
   end
 
   test "tools/call round-trip for get_studio_health returns a valid payload" do
-    post "/api/mcp",
-      headers: api_key_headers,
-      params: {
-        jsonrpc: "2.0", id: 12, method: "tools/call",
-        params: { name: "get_studio_health", arguments: { gradation: "month" } },
-      }.to_json
-    assert_response :success
-    text = JSON.parse(response.body).dig("result", "content", 0, "text")
-    payload = JSON.parse(text)
+    payload = call_tool("get_studio_health", { gradation: "month" })
     assert payload.key?("studios")
   end
 

--- a/test/integration/mcp_endpoint_test.rb
+++ b/test/integration/mcp_endpoint_test.rb
@@ -45,7 +45,7 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
     assert body.key?("result"), "Expected JSON-RPC result key, got: #{body.inspect}"
     tool_names = body["result"]["tools"].map { |t| t["name"] }
     assert_includes tool_names, "search", "Expected 'search' tool in: #{tool_names.inspect}"
-    assert_equal %w[get_ar_aging get_document list_documents list_open_admin_tasks list_overdue_invoices list_sources search], tool_names.sort,
+    assert_equal %w[get_ar_aging get_document list_documents list_open_admin_tasks list_overdue_invoices list_projects_at_risk list_sources search], tool_names.sort,
       "Expected all registered tools, got: #{tool_names.inspect}"
   end
 
@@ -82,6 +82,20 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
     payload = JSON.parse(text)
     assert_equal 0, payload["count"]
     assert_equal [], payload["tasks"]
+  end
+
+  test "tools/call round-trip for list_projects_at_risk returns a valid payload" do
+    post "/api/mcp",
+      headers: api_key_headers,
+      params: {
+        jsonrpc: "2.0", id: 11, method: "tools/call",
+        params: { name: "list_projects_at_risk", arguments: {} },
+      }.to_json
+    assert_response :success
+    text = JSON.parse(response.body).dig("result", "content", 0, "text")
+    payload = JSON.parse(text)
+    assert payload.key?("count")
+    assert payload.key?("projects")
   end
 
   test "POST returns 403 when MCP API key is not configured" do

--- a/test/integration/mcp_endpoint_test.rb
+++ b/test/integration/mcp_endpoint_test.rb
@@ -45,7 +45,7 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
     assert body.key?("result"), "Expected JSON-RPC result key, got: #{body.inspect}"
     tool_names = body["result"]["tools"].map { |t| t["name"] }
     assert_includes tool_names, "search", "Expected 'search' tool in: #{tool_names.inspect}"
-    assert_equal %w[get_ar_aging get_document list_documents list_open_admin_tasks list_overdue_invoices list_projects_at_risk list_sources search], tool_names.sort,
+    assert_equal %w[get_ar_aging get_document get_studio_health list_documents list_open_admin_tasks list_overdue_invoices list_projects_at_risk list_sources search], tool_names.sort,
       "Expected all registered tools, got: #{tool_names.inspect}"
   end
 
@@ -96,6 +96,19 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
     payload = JSON.parse(text)
     assert payload.key?("count")
     assert payload.key?("projects")
+  end
+
+  test "tools/call round-trip for get_studio_health returns a valid payload" do
+    post "/api/mcp",
+      headers: api_key_headers,
+      params: {
+        jsonrpc: "2.0", id: 12, method: "tools/call",
+        params: { name: "get_studio_health", arguments: { gradation: "month" } },
+      }.to_json
+    assert_response :success
+    text = JSON.parse(response.body).dig("result", "content", 0, "text")
+    payload = JSON.parse(text)
+    assert payload.key?("studios")
   end
 
   test "POST returns 403 when MCP API key is not configured" do

--- a/test/services/mcp/admin_tasks_tool_test.rb
+++ b/test/services/mcp/admin_tasks_tool_test.rb
@@ -10,17 +10,13 @@ class Mcp::AdminTasksToolTest < ActiveSupport::TestCase
     StacksTask.new(type: type, subject: admin, owners: [admin])
   end
 
-  def payload_for(resp)
-    JSON.parse(resp.content.first[:text])
-  end
-
   test 'returns mapped, sorted tasks with owner emails' do
     enterprise_task = StacksTask.new(type: :needs_archiving, subject: enterprises(:sanctuary),
                                      owners: [@admin])
     Stacks::TaskBuilder.any_instance.stubs(:tasks).returns(
       [enterprise_task, task_for(@other, type: :no_full_time_periods_set), task_for(@admin)]
     )
-    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::ListOpenAdminTasksTool.call(server_context: {}))
     assert_equal 3, payload['count']
     row = payload['tasks'].find { |t| t['type'] == 'missing_skill_tree' }
     assert_equal 'Admin user needs skill tree set', row['task']
@@ -38,13 +34,13 @@ class Mcp::AdminTasksToolTest < ActiveSupport::TestCase
   test 'subjects without an explicit display branch get a conservative redacted name' do
     task = StacksTask.new(type: :needs_archiving, subject: enterprises(:sanctuary), owners: [@admin])
     Stacks::TaskBuilder.any_instance.stubs(:tasks).returns([task])
-    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::ListOpenAdminTasksTool.call(server_context: {}))
     assert_equal "Enterprise ##{enterprises(:sanctuary).id}", payload['tasks'].first['subject']
   end
 
   test 'owner param filters via tasks_for with case-insensitive email' do
     Stacks::TaskBuilder.any_instance.expects(:tasks_for).with(@admin).returns([task_for(@admin)])
-    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(owner: @admin.email.upcase, server_context: {}))
+    payload = mcp_payload(Mcp::ListOpenAdminTasksTool.call(owner: @admin.email.upcase, server_context: {}))
     assert_equal 1, payload['count']
   end
 
@@ -54,7 +50,7 @@ class Mcp::AdminTasksToolTest < ActiveSupport::TestCase
     # owners the unfiltered call would emit (not raw cached ids, not an
     # attribute-based admin roster).
     Stacks::TaskBuilder.any_instance.stubs(:tasks).returns([task_for(@admin)])
-    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(owner: 'nobody@nowhere.dev', server_context: {}))
+    payload = mcp_payload(Mcp::ListOpenAdminTasksTool.call(owner: 'nobody@nowhere.dev', server_context: {}))
     assert_includes payload['error'], "Unknown owner 'nobody@nowhere.dev'"
     assert_includes payload['error'], @admin.email
     refute_includes payload['error'], @other.email
@@ -62,7 +58,7 @@ class Mcp::AdminTasksToolTest < ActiveSupport::TestCase
 
   test 'unknown owner with an empty queue says so instead of dangling an empty roster' do
     Stacks::TaskBuilder.any_instance.stubs(:tasks).returns([])
-    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(owner: 'nobody@nowhere.dev', server_context: {}))
+    payload = mcp_payload(Mcp::ListOpenAdminTasksTool.call(owner: 'nobody@nowhere.dev', server_context: {}))
     assert_includes payload['error'], "Unknown owner 'nobody@nowhere.dev'"
     assert_includes payload['error'], 'task queue is currently empty'
     refute_includes payload['error'], 'Current task owners:'
@@ -75,13 +71,13 @@ class Mcp::AdminTasksToolTest < ActiveSupport::TestCase
     archived = build_admin!(email_prefix: 'archived', roles: [], ended_at: Date.today - 30)
 
     Stacks::TaskBuilder.any_instance.expects(:tasks_for).with(archived).returns([task_for(archived)])
-    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(owner: archived.email, server_context: {}))
+    payload = mcp_payload(Mcp::ListOpenAdminTasksTool.call(owner: archived.email, server_context: {}))
     assert_equal 1, payload['count']
   end
 
   test 'a real admin who owns no tasks resolves to an empty payload, not an error' do
     Stacks::TaskBuilder.any_instance.expects(:tasks_for).with(@other).returns([])
-    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(owner: @other.email, server_context: {}))
+    payload = mcp_payload(Mcp::ListOpenAdminTasksTool.call(owner: @other.email, server_context: {}))
     assert_equal 0, payload['count']
     assert_equal [], payload['tasks']
     assert_not payload.key?('error')
@@ -91,14 +87,14 @@ class Mcp::AdminTasksToolTest < ActiveSupport::TestCase
     Stacks::TaskBuilder.any_instance.stubs(:tasks).returns([task_for(@admin)])
     StacksTask.any_instance.stubs(:subject_url).raises(RuntimeError, 'boom')
     Rails.logger.expects(:warn).with { |msg| msg.include?('skipping task') }
-    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::ListOpenAdminTasksTool.call(server_context: {}))
     assert_equal 0, payload['count']
     assert_equal [], payload['tasks']
   end
 
   test 'empty queue returns a valid empty payload' do
     Stacks::TaskBuilder.any_instance.stubs(:tasks).returns([])
-    payload = payload_for(Mcp::ListOpenAdminTasksTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::ListOpenAdminTasksTool.call(server_context: {}))
     assert_equal 0, payload['count']
     assert_equal [], payload['tasks']
   end

--- a/test/services/mcp/finance_tools_test.rb
+++ b/test/services/mcp/finance_tools_test.rb
@@ -27,10 +27,6 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     QboInvoice.create!(qbo_account: account, qbo_id: "inv-#{doc}", data: data)
   end
 
-  def payload_for(resp)
-    JSON.parse(resp.content.first[:text])
-  end
-
   # --- get_ar_aging ---
 
   test 'get_ar_aging buckets balances by days overdue with correct boundaries' do
@@ -40,7 +36,7 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     invoice!(doc: 'd', due: @today - 90, balance: 80.0)      # 90 days -> days_61_90
     invoice!(doc: 'e', due: @today - 91, balance: 160.0)     # 91 days -> days_over_90
 
-    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::GetArAgingTool.call(server_context: {}))
     ent = payload['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
     acme = ent['customers'].find { |c| c['customer'] == 'Acme Co' }
 
@@ -60,7 +56,7 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     invoice!(doc: 'cf2', due: @today - 30, balance: 20.02, customer: 'Cent Co', customer_id: 'cc')
     invoice!(doc: 'cf3', due: @today - 31, balance: 0.99, customer: 'Cent Co', customer_id: 'cc')
 
-    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::GetArAgingTool.call(server_context: {}))
     ent = payload['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
     row = ent['customers'].find { |c| c['customer'] == 'Cent Co' }
 
@@ -72,7 +68,7 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
 
   test 'get_ar_aging sums outstanding balance, not invoice total' do
     invoice!(doc: 'p', due: @today - 10, balance: 500.0, total: 1000.0)
-    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::GetArAgingTool.call(server_context: {}))
     acme = payload['enterprises'].first['customers'].first
     assert_equal 500.0, acme['days_1_30']
     assert_equal 500.0, acme['total']
@@ -85,7 +81,7 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     QboInvoice.create!(qbo_account: @account, qbo_id: 'inv-unsynced', data: nil)
 
     QboInvoice.any_instance.expects(:sync!).never
-    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::GetArAgingTool.call(server_context: {}))
     assert_equal 100.0, payload['total_ar']
   end
 
@@ -96,11 +92,11 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     invoice!(doc: 'o1', due: @today - 5, balance: 999.0, account: other,
              customer: 'Other Client')
 
-    all = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    all = mcp_payload(Mcp::GetArAgingTool.call(server_context: {}))
     assert_equal 1099.0, all['total_ar']
     assert_equal 2, all['enterprises'].length
 
-    scoped = payload_for(Mcp::GetArAgingTool.call(
+    scoped = mcp_payload(Mcp::GetArAgingTool.call(
       enterprise: 'sanctuary computer inc', server_context: {}))
     assert_equal 100.0, scoped['total_ar']
     assert_equal [@sanctuary.name], scoped['enterprises'].map { |e| e['enterprise'] }
@@ -109,7 +105,7 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
   test 'get_ar_aging resolves an enterprise name padded with whitespace' do
     invoice!(doc: 's2', due: @today - 5, balance: 100.0)
 
-    scoped = payload_for(Mcp::GetArAgingTool.call(
+    scoped = mcp_payload(Mcp::GetArAgingTool.call(
       enterprise: '  sanctuary computer inc  ', server_context: {}))
     assert_equal 100.0, scoped['total_ar']
     assert_equal [@sanctuary.name], scoped['enterprises'].map { |e| e['enterprise'] }
@@ -119,7 +115,7 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     invoice!(doc: 'dup1', due: @today - 5, balance: 100.0, customer: 'Studio LLC', customer_id: 'c1')
     invoice!(doc: 'dup2', due: @today - 10, balance: 200.0, customer: 'Studio LLC', customer_id: 'c2')
 
-    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::GetArAgingTool.call(server_context: {}))
     ent = payload['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
     studios = ent['customers'].select { |c| c['customer'] == 'Studio LLC' }
 
@@ -133,7 +129,7 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     invoice!(doc: 'rn1', due: @today - 20, balance: 100.0, customer: 'Acme', customer_id: 'c1')
     invoice!(doc: 'rn2', due: @today - 5, balance: 200.0, customer: 'Acme Co', customer_id: 'c1')
 
-    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::GetArAgingTool.call(server_context: {}))
     ent = payload['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
     rows = ent['customers'].select { |c| c['customer_id'] == 'c1' }
 
@@ -143,7 +139,7 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
   end
 
   test 'get_ar_aging returns an error payload for an unknown enterprise' do
-    payload = payload_for(Mcp::GetArAgingTool.call(enterprise: 'Nope Inc', server_context: {}))
+    payload = mcp_payload(Mcp::GetArAgingTool.call(enterprise: 'Nope Inc', server_context: {}))
     assert_includes payload['error'], "Unknown enterprise 'Nope Inc'"
     assert_includes payload['error'], @sanctuary.name
   end
@@ -158,7 +154,7 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
       'doc_number' => 'bad1',
     })
 
-    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::GetArAgingTool.call(server_context: {}))
     assert_equal 100.0, payload['total_ar']
     ent = payload['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
     assert_equal ['Acme Co'], ent['customers'].map { |c| c['customer'] }
@@ -185,13 +181,13 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     # A missing/unparseable total is display-only — the row still owes its
     # balance, so it must not be dropped from AR: both the missing-total and
     # comma-total balances still show up in the aging buckets/total.
-    aging = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    aging = mcp_payload(Mcp::GetArAgingTool.call(server_context: {}))
     assert_equal 200.0, aging['total_ar']
     ent = aging['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
     assert_equal ['Acme Co', 'Comma Total Inc', 'Missing Total Inc'].sort,
                  ent['customers'].map { |c| c['customer'] }.sort
 
-    overdue = payload_for(Mcp::ListOverdueInvoicesTool.call(server_context: {}))
+    overdue = mcp_payload(Mcp::ListOverdueInvoicesTool.call(server_context: {}))
     assert_equal %w[comma-total good no-total].sort, overdue['invoices'].map { |i| i['doc_number'] }.sort
     no_total_row = overdue['invoices'].find { |i| i['doc_number'] == 'no-total' }
     comma_total_row = overdue['invoices'].find { |i| i['doc_number'] == 'comma-total' }
@@ -213,7 +209,7 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
 
     Rails.logger.expects(:warn).with { |msg| msg.include?('excluded as malformed') }
 
-    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::GetArAgingTool.call(server_context: {}))
     assert_equal 100.0, payload['total_ar']
     ent = payload['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
     assert_equal ['Acme Co'], ent['customers'].map { |c| c['customer'] }
@@ -225,7 +221,7 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
 
     Rails.logger.expects(:warn).with { |msg| msg.include?('no synced data and are excluded') }
 
-    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::GetArAgingTool.call(server_context: {}))
     assert_equal 100.0, payload['total_ar']
     ent = payload['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
     assert_equal ['Acme Co'], ent['customers'].map { |c| c['customer'] }
@@ -235,7 +231,7 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     invoice!(doc: 'anon1', due: @today - 5, balance: 100.0, omit_customer_ref: true)
     invoice!(doc: 'anon2', due: @today - 10, balance: 200.0, omit_customer_ref: true)
 
-    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::GetArAgingTool.call(server_context: {}))
     ent = payload['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
     unknown_rows = ent['customers'].select { |c| c['customer'] == 'Unknown' }
 
@@ -262,7 +258,7 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
       'total' => 200.0,
     })
 
-    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::GetArAgingTool.call(server_context: {}))
     ent = payload['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
     unknown_rows = ent['customers'].select { |c| c['customer'] == 'Unknown' }
 
@@ -275,7 +271,7 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     invoice!(doc: 'lit1', due: @today - 5, balance: 100.0, customer: 'Unknown')
     invoice!(doc: 'lit2', due: @today - 10, balance: 200.0, customer: 'Unknown')
 
-    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::GetArAgingTool.call(server_context: {}))
     ent = payload['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
     rows = ent['customers'].select { |c| c['customer'] == 'Unknown' }
 
@@ -284,20 +280,20 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
   end
 
   test 'get_ar_aging returns an empty report when there are no receivables' do
-    payload = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::GetArAgingTool.call(server_context: {}))
     assert_equal 0, payload['total_ar']
   end
 
   test 'an empty-string customer name falls back to Unknown in both tools' do
     invoice!(doc: 'nc1', due: @today - 5, balance: 100.0, customer: '')
 
-    aging = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    aging = mcp_payload(Mcp::GetArAgingTool.call(server_context: {}))
     ent = aging['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
     unknown = ent['customers'].find { |c| c['customer'] == 'Unknown' }
     assert unknown, "Expected an 'Unknown' customer row, got: #{ent['customers'].inspect}"
     assert_equal 100.0, unknown['total']
 
-    overdue = payload_for(Mcp::ListOverdueInvoicesTool.call(server_context: {}))
+    overdue = mcp_payload(Mcp::ListOverdueInvoicesTool.call(server_context: {}))
     assert_equal ['Unknown'], overdue['invoices'].map { |i| i['customer'] }
   end
 
@@ -317,11 +313,11 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     Rails.logger.stubs(:warn)
     Rails.logger.expects(:warn).with { |msg| msg.include?('malformed customer_ref') }.at_least_once
 
-    aging = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    aging = mcp_payload(Mcp::GetArAgingTool.call(server_context: {}))
     ent = aging['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
     assert_equal ['Unknown'], ent['customers'].map { |c| c['customer'] }
 
-    overdue = payload_for(Mcp::ListOverdueInvoicesTool.call(server_context: {}))
+    overdue = mcp_payload(Mcp::ListOverdueInvoicesTool.call(server_context: {}))
     assert_equal ['Unknown'], overdue['invoices'].map { |i| i['customer'] }
   end
 
@@ -336,12 +332,12 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
       'customer_ref' => { 'name' => 'Broken Dates Inc' },
     })
 
-    aging = payload_for(Mcp::GetArAgingTool.call(server_context: {}))
+    aging = mcp_payload(Mcp::GetArAgingTool.call(server_context: {}))
     assert_equal 100.0, aging['total_ar']
     ent = aging['enterprises'].find { |e| e['enterprise'] == @sanctuary.name }
     assert_equal ['Acme Co'], ent['customers'].map { |c| c['customer'] }
 
-    overdue = payload_for(Mcp::ListOverdueInvoicesTool.call(server_context: {}))
+    overdue = mcp_payload(Mcp::ListOverdueInvoicesTool.call(server_context: {}))
     assert_equal %w[ok], overdue['invoices'].map { |i| i['doc_number'] }
   end
 
@@ -353,7 +349,7 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     invoice!(doc: '12', due: @today + 5, balance: 300.0)   # not overdue
     invoice!(doc: '13', due: @today - 20, balance: 150.0, total: 400.0) # partially paid overdue
 
-    payload = payload_for(Mcp::ListOverdueInvoicesTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::ListOverdueInvoicesTool.call(server_context: {}))
     assert_equal 3, payload['count']
     assert_equal %w[11 13 10], payload['invoices'].map { |i| i['doc_number'] }
 
@@ -376,7 +372,7 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     invoice!(doc: '20', due: @today - 5, balance: 100.0)
     invoice!(doc: '21', due: @today - 40, balance: 200.0)
 
-    payload = payload_for(Mcp::ListOverdueInvoicesTool.call(min_days_overdue: 30, server_context: {}))
+    payload = mcp_payload(Mcp::ListOverdueInvoicesTool.call(min_days_overdue: 30, server_context: {}))
     assert_equal %w[21], payload['invoices'].map { |i| i['doc_number'] }
   end
 
@@ -384,7 +380,7 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     invoice!(doc: '25', due: @today, balance: 100.0)      # due today, 0 days overdue
     invoice!(doc: '26', due: @today - 3, balance: 200.0)  # 3 days overdue
 
-    payload = payload_for(Mcp::ListOverdueInvoicesTool.call(min_days_overdue: 0, server_context: {}))
+    payload = mcp_payload(Mcp::ListOverdueInvoicesTool.call(min_days_overdue: 0, server_context: {}))
     assert_equal %w[26], payload['invoices'].map { |i| i['doc_number'] }
   end
 
@@ -394,18 +390,18 @@ class Mcp::FinanceToolsTest < ActiveSupport::TestCase
     invoice!(doc: '30', due: @today - 5, balance: 100.0)
     invoice!(doc: '31', due: @today - 5, balance: 200.0, account: other)
 
-    scoped = payload_for(Mcp::ListOverdueInvoicesTool.call(
+    scoped = mcp_payload(Mcp::ListOverdueInvoicesTool.call(
       enterprise: @sanctuary.name, server_context: {}))
     assert_equal %w[30], scoped['invoices'].map { |i| i['doc_number'] }
 
-    err = payload_for(Mcp::ListOverdueInvoicesTool.call(enterprise: 'Nope Inc', server_context: {}))
+    err = mcp_payload(Mcp::ListOverdueInvoicesTool.call(enterprise: 'Nope Inc', server_context: {}))
     assert_includes err['error'], "Unknown enterprise 'Nope Inc'"
   end
 
   test 'list_overdue_invoices skips unsynced rows without syncing' do
     QboInvoice.create!(qbo_account: @account, qbo_id: 'inv-unsynced-2', data: nil)
     QboInvoice.any_instance.expects(:sync!).never
-    payload = payload_for(Mcp::ListOverdueInvoicesTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::ListOverdueInvoicesTool.call(server_context: {}))
     assert_equal 0, payload['count']
     assert_equal [], payload['invoices']
   end

--- a/test/services/mcp/projects_at_risk_tool_test.rb
+++ b/test/services/mcp/projects_at_risk_tool_test.rb
@@ -26,13 +26,9 @@ class Mcp::ProjectsAtRiskToolTest < ActiveSupport::TestCase
     )
   end
 
-  def payload_for(resp)
-    JSON.parse(resp.content.first[:text])
-  end
-
   test 'flags margin below the tracker target with a named reason' do
     tracker!(name: 'Thin Margin', spend: 1000.0, cost: 900.0) # margin 10% < target 30
-    payload = payload_for(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
     row = payload['projects'].find { |p| p['name'] == 'Thin Margin' }
     assert row['at_risk']
     assert_includes row['risk_reasons'], 'margin_below_target'
@@ -42,7 +38,7 @@ class Mcp::ProjectsAtRiskToolTest < ActiveSupport::TestCase
 
   test 'flags free hours above the tracker target' do
     tracker!(name: 'Free Heavy', hours: 100.0, free_hours: 20.0, free_target: 10)
-    payload = payload_for(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
     row = payload['projects'].find { |p| p['name'] == 'Free Heavy' }
     assert_includes row['risk_reasons'], 'free_hours_above_target'
     assert_equal 20.0, row['free_hours_percent']
@@ -51,7 +47,7 @@ class Mcp::ProjectsAtRiskToolTest < ActiveSupport::TestCase
   test 'flags spend beyond budget_high_end only when a budget is set' do
     tracker!(name: 'Over Budget', spend: 5000.0, cost: 1000.0, budget_low: 1000.0, budget_high: 4000.0)
     tracker!(name: 'No Budget', spend: 5000.0, cost: 1000.0)
-    payload = payload_for(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
     over = payload['projects'].find { |p| p['name'] == 'Over Budget' }
     assert_includes over['risk_reasons'], 'over_budget'
     assert_nil payload['projects'].find { |p| p['name'] == 'No Budget' }, 'healthy-but-unbudgeted project must not be flagged'
@@ -60,7 +56,7 @@ class Mcp::ProjectsAtRiskToolTest < ActiveSupport::TestCase
   test 'only_at_risk: false returns healthy projects too, sorted most-at-risk first' do
     tracker!(name: 'Healthy One')
     tracker!(name: 'Doubly Risky', spend: 5000.0, cost: 4800.0, budget_high: 4000.0, budget_low: 1000.0)
-    payload = payload_for(Mcp::ListProjectsAtRiskTool.call(only_at_risk: false, server_context: {}))
+    payload = mcp_payload(Mcp::ListProjectsAtRiskTool.call(only_at_risk: false, server_context: {}))
     names = payload['projects'].map { |p| p['name'] }
     assert_includes names, 'Healthy One'
     assert_equal 'Doubly Risky', names.first, 'most tripped criteria sorts first'
@@ -72,9 +68,9 @@ class Mcp::ProjectsAtRiskToolTest < ActiveSupport::TestCase
   test 'completed trackers are excluded by default and included with include_complete' do
     done = tracker!(name: 'Done Project', spend: 1000.0, cost: 900.0)
     done.update!(work_completed_at: Time.current)
-    payload = payload_for(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
     assert_nil payload['projects'].find { |p| p['name'] == 'Done Project' }
-    payload = payload_for(Mcp::ListProjectsAtRiskTool.call(include_complete: true, server_context: {}))
+    payload = mcp_payload(Mcp::ListProjectsAtRiskTool.call(include_complete: true, server_context: {}))
     assert payload['projects'].find { |p| p['name'] == 'Done Project' }
   end
 
@@ -83,13 +79,13 @@ class Mcp::ProjectsAtRiskToolTest < ActiveSupport::TestCase
     tracker!(name: 'Thin Margin', spend: 1000.0, cost: 900.0)
     Rails.logger.expects(:warn).with { |msg| msg.include?('Unsnapshotted') }.at_least_once
     Sentry.expects(:capture_exception).never
-    payload = payload_for(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
     assert_nil payload['projects'].find { |p| p['name'] == 'Unsnapshotted' }
     assert_equal 1, payload['count']
   end
 
   test 'empty result is a valid payload' do
-    payload = payload_for(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
     assert_equal 0, payload['count']
     assert_equal [], payload['projects']
   end
@@ -99,7 +95,7 @@ class Mcp::ProjectsAtRiskToolTest < ActiveSupport::TestCase
     ProjectTracker.any_instance.stubs(:external_link).raises(RuntimeError, 'boom')
     Rails.logger.expects(:warn).with { |msg| msg.include?('skipping tracker') }.at_least_once
     Sentry.expects(:capture_exception).at_least_once
-    payload = payload_for(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
     assert_equal 0, payload['count']
     assert_equal [], payload['projects']
   end

--- a/test/services/mcp/projects_at_risk_tool_test.rb
+++ b/test/services/mcp/projects_at_risk_tool_test.rb
@@ -84,6 +84,20 @@ class Mcp::ProjectsAtRiskToolTest < ActiveSupport::TestCase
     assert_equal 1, payload['count']
   end
 
+  test 'a half-configured budget does not crash or drop the tracker; other criteria still judged' do
+    # Only budget_high_end set — invalid per validation but possible in legacy
+    # rows; ProjectTracker#status raises on this. The tool must still evaluate
+    # margin (thin here) and not drop the row via the rescue.
+    t = tracker!(name: 'Half Budget', spend: 1000.0, cost: 900.0)
+    t.update_column(:budget_high_end, 4000) # bypasses the both-or-neither validation
+    Sentry.expects(:capture_exception).never
+    payload = mcp_payload(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
+    row = payload['projects'].find { |p| p['name'] == 'Half Budget' }
+    refute_nil row, 'half-budget tracker must not be silently dropped'
+    assert_includes row['risk_reasons'], 'margin_below_target'
+    refute_includes row['risk_reasons'], 'over_budget'
+  end
+
   test 'empty result is a valid payload' do
     payload = mcp_payload(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
     assert_equal 0, payload['count']

--- a/test/services/mcp/projects_at_risk_tool_test.rb
+++ b/test/services/mcp/projects_at_risk_tool_test.rb
@@ -1,0 +1,97 @@
+require 'test_helper'
+
+class Mcp::ProjectsAtRiskToolTest < ActiveSupport::TestCase
+  # Snapshot-backed tracker factory. Defaults produce a HEALTHY project:
+  # margin 50% (>= target 30), free hours 0% (<= target 10), no budget.
+  def tracker!(name:, spend: 1000.0, cost: 500.0, hours: 100.0, free_hours: 0.0,
+               budget_high: nil, budget_low: nil, margin_target: 30, free_target: 10)
+    ProjectTracker.create!(
+      name: name,
+      budget_low_end: budget_low,
+      budget_high_end: budget_high,
+      target_profit_margin: margin_target,
+      target_free_hours_percent: free_target,
+      project_tracker_links: [
+        ProjectTrackerLink.new(name: 'SOW', url: 'https://example.com/sow', link_type: 'sow'),
+        ProjectTrackerLink.new(name: 'MSA', url: 'https://example.com/msa', link_type: 'msa'),
+      ],
+      snapshot: {
+        'invoiced_with_running_spend_total' => spend,
+        'cost_total' => cost,
+        'hours_total' => hours,
+        'hours_free' => free_hours,
+      }
+    )
+  end
+
+  def payload_for(resp)
+    JSON.parse(resp.content.first[:text])
+  end
+
+  test 'flags margin below the tracker target with a named reason' do
+    tracker!(name: 'Thin Margin', spend: 1000.0, cost: 900.0) # margin 10% < target 30
+    payload = payload_for(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
+    row = payload['projects'].find { |p| p['name'] == 'Thin Margin' }
+    assert row['at_risk']
+    assert_includes row['risk_reasons'], 'margin_below_target'
+    assert_equal 10.0, row['profit_margin']
+    assert_equal 30.0, row['target_profit_margin']
+  end
+
+  test 'flags free hours above the tracker target' do
+    tracker!(name: 'Free Heavy', hours: 100.0, free_hours: 20.0, free_target: 10)
+    payload = payload_for(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
+    row = payload['projects'].find { |p| p['name'] == 'Free Heavy' }
+    assert_includes row['risk_reasons'], 'free_hours_above_target'
+    assert_equal 20.0, row['free_hours_percent']
+  end
+
+  test 'flags spend beyond budget_high_end only when a budget is set' do
+    tracker!(name: 'Over Budget', spend: 5000.0, cost: 1000.0, budget_low: 1000.0, budget_high: 4000.0)
+    tracker!(name: 'No Budget', spend: 5000.0, cost: 1000.0)
+    payload = payload_for(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
+    over = payload['projects'].find { |p| p['name'] == 'Over Budget' }
+    assert_includes over['risk_reasons'], 'over_budget'
+    assert_nil payload['projects'].find { |p| p['name'] == 'No Budget' }, 'healthy-but-unbudgeted project must not be flagged'
+  end
+
+  test 'only_at_risk: false returns healthy projects too, sorted most-at-risk first' do
+    tracker!(name: 'Healthy One')
+    tracker!(name: 'Doubly Risky', spend: 5000.0, cost: 4800.0, budget_high: 4000.0, budget_low: 1000.0)
+    payload = payload_for(Mcp::ListProjectsAtRiskTool.call(only_at_risk: false, server_context: {}))
+    names = payload['projects'].map { |p| p['name'] }
+    assert_includes names, 'Healthy One'
+    assert_equal 'Doubly Risky', names.first, 'most tripped criteria sorts first'
+    healthy = payload['projects'].find { |p| p['name'] == 'Healthy One' }
+    assert_equal false, healthy['at_risk']
+    assert_equal [], healthy['risk_reasons']
+  end
+
+  test 'completed trackers are excluded by default and included with include_complete' do
+    done = tracker!(name: 'Done Project', spend: 1000.0, cost: 900.0)
+    done.update!(work_completed_at: Time.current)
+    payload = payload_for(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
+    assert_nil payload['projects'].find { |p| p['name'] == 'Done Project' }
+    payload = payload_for(Mcp::ListProjectsAtRiskTool.call(include_complete: true, server_context: {}))
+    assert payload['projects'].find { |p| p['name'] == 'Done Project' }
+  end
+
+  test 'trackers with a blank snapshot are skipped with a warning, never raise' do
+    ProjectTracker.create!(name: 'Unsnapshotted', target_profit_margin: 30, target_free_hours_percent: 10,
+                           project_tracker_links: [
+                             ProjectTrackerLink.new(name: 'SOW', url: 'https://example.com/sow', link_type: 'sow'),
+                             ProjectTrackerLink.new(name: 'MSA', url: 'https://example.com/msa', link_type: 'msa'),
+                           ])
+    tracker!(name: 'Thin Margin', spend: 1000.0, cost: 900.0)
+    Rails.logger.expects(:warn).with { |msg| msg.include?('Unsnapshotted') }.at_least_once
+    payload = payload_for(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
+    assert_nil payload['projects'].find { |p| p['name'] == 'Unsnapshotted' }
+    assert_equal 1, payload['count']
+  end
+
+  test 'empty result is a valid payload' do
+    payload = payload_for(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
+    assert_equal 0, payload['count']
+    assert_equal [], payload['projects']
+  end
+end

--- a/test/services/mcp/projects_at_risk_tool_test.rb
+++ b/test/services/mcp/projects_at_risk_tool_test.rb
@@ -4,7 +4,14 @@ class Mcp::ProjectsAtRiskToolTest < ActiveSupport::TestCase
   # Snapshot-backed tracker factory. Defaults produce a HEALTHY project:
   # margin 50% (>= target 30), free hours 0% (<= target 10), no budget.
   def tracker!(name:, spend: 1000.0, cost: 500.0, hours: 100.0, free_hours: 0.0,
-               budget_high: nil, budget_low: nil, margin_target: 30, free_target: 10)
+               budget_high: nil, budget_low: nil, margin_target: 30, free_target: 10, snapshot: :default)
+    snapshot = {
+      'invoiced_with_running_spend_total' => spend,
+      'cost_total' => cost,
+      'hours_total' => hours,
+      'hours_free' => free_hours,
+    } if snapshot == :default
+
     ProjectTracker.create!(
       name: name,
       budget_low_end: budget_low,
@@ -15,12 +22,7 @@ class Mcp::ProjectsAtRiskToolTest < ActiveSupport::TestCase
         ProjectTrackerLink.new(name: 'SOW', url: 'https://example.com/sow', link_type: 'sow'),
         ProjectTrackerLink.new(name: 'MSA', url: 'https://example.com/msa', link_type: 'msa'),
       ],
-      snapshot: {
-        'invoiced_with_running_spend_total' => spend,
-        'cost_total' => cost,
-        'hours_total' => hours,
-        'hours_free' => free_hours,
-      }
+      snapshot: snapshot
     )
   end
 
@@ -77,13 +79,10 @@ class Mcp::ProjectsAtRiskToolTest < ActiveSupport::TestCase
   end
 
   test 'trackers with a blank snapshot are skipped with a warning, never raise' do
-    ProjectTracker.create!(name: 'Unsnapshotted', target_profit_margin: 30, target_free_hours_percent: 10,
-                           project_tracker_links: [
-                             ProjectTrackerLink.new(name: 'SOW', url: 'https://example.com/sow', link_type: 'sow'),
-                             ProjectTrackerLink.new(name: 'MSA', url: 'https://example.com/msa', link_type: 'msa'),
-                           ])
+    tracker!(name: 'Unsnapshotted', snapshot: nil)
     tracker!(name: 'Thin Margin', spend: 1000.0, cost: 900.0)
     Rails.logger.expects(:warn).with { |msg| msg.include?('Unsnapshotted') }.at_least_once
+    Sentry.expects(:capture_exception).never
     payload = payload_for(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
     assert_nil payload['projects'].find { |p| p['name'] == 'Unsnapshotted' }
     assert_equal 1, payload['count']

--- a/test/services/mcp/projects_at_risk_tool_test.rb
+++ b/test/services/mcp/projects_at_risk_tool_test.rb
@@ -94,4 +94,14 @@ class Mcp::ProjectsAtRiskToolTest < ActiveSupport::TestCase
     assert_equal 0, payload['count']
     assert_equal [], payload['projects']
   end
+
+  test 'a tracker whose mapping raises is skipped with warn + Sentry, not fatal' do
+    tracker!(name: 'Raises Mid-Map', spend: 1000.0, cost: 900.0)
+    ProjectTracker.any_instance.stubs(:external_link).raises(RuntimeError, 'boom')
+    Rails.logger.expects(:warn).with { |msg| msg.include?('skipping tracker') }.at_least_once
+    Sentry.expects(:capture_exception).at_least_once
+    payload = payload_for(Mcp::ListProjectsAtRiskTool.call(server_context: {}))
+    assert_equal 0, payload['count']
+    assert_equal [], payload['projects']
+  end
 end

--- a/test/services/mcp/studio_health_tool_test.rb
+++ b/test/services/mcp/studio_health_tool_test.rb
@@ -40,6 +40,12 @@ class Mcp::StudioHealthToolTest < ActiveSupport::TestCase
     refute s['periods'].first.key?('utilization')
   end
 
+  test 'resolves a studio by one element of a comma-separated mini_name' do
+    studio!(name: 'Comma Studio', mini_name: 'cs, sanctu')
+    payload = mcp_payload(Mcp::GetStudioHealthTool.call(studio: 'sanctu', server_context: {}))
+    assert_equal 'Comma Studio', payload['studios'].first['studio']
+  end
+
   test 'accrual accounting_method selects the accrual subtree' do
     studio!(name: 'Accrual Studio', mini_name: 'accr')
     payload = mcp_payload(Mcp::GetStudioHealthTool.call(studio: 'accr', accounting_method: 'accrual', server_context: {}))

--- a/test/services/mcp/studio_health_tool_test.rb
+++ b/test/services/mcp/studio_health_tool_test.rb
@@ -81,7 +81,7 @@ class Mcp::StudioHealthToolTest < ActiveSupport::TestCase
   test 'a studio whose mapping raises is skipped with warn + Sentry, not fatal' do
     studio!(name: 'Raises Mid-Map', mini_name: 'boom')
     Studio.any_instance.stubs(:mini_name).raises(RuntimeError, 'boom')
-    Rails.logger.expects(:warn).with { |msg| msg.include?('Raises Mid-Map') }.at_least_once
+    Rails.logger.expects(:warn).with { |msg| msg.include?('skipping studio') }.at_least_once
     Sentry.expects(:capture_exception).at_least_once
     payload = payload_for(Mcp::GetStudioHealthTool.call(server_context: {}))
     assert_equal [], payload['studios']

--- a/test/services/mcp/studio_health_tool_test.rb
+++ b/test/services/mcp/studio_health_tool_test.rb
@@ -53,6 +53,15 @@ class Mcp::StudioHealthToolTest < ActiveSupport::TestCase
     assert_equal 'Orbit', payload['studios'].first['studio'], 'real name must not be shadowed by an alias'
   end
 
+  test 'falls back to an alias match with data when the exact-name studio has no snapshot' do
+    # 'Orbit' matches by name but has no snapshot; 'Northstar' carries 'orbit'
+    # as an alias and does have data — the reachable data must win over erroring.
+    Studio.create!(name: 'Orbit', mini_name: 'orb') # no snapshot
+    studio!(name: 'Northstar', mini_name: 'ns, orbit')
+    payload = mcp_payload(Mcp::GetStudioHealthTool.call(studio: 'orbit', server_context: {}))
+    assert_equal 'Northstar', payload['studios'].first['studio']
+  end
+
   test 'accrual accounting_method selects the accrual subtree' do
     studio!(name: 'Accrual Studio', mini_name: 'accr')
     payload = mcp_payload(Mcp::GetStudioHealthTool.call(studio: 'accr', accounting_method: 'accrual', server_context: {}))

--- a/test/services/mcp/studio_health_tool_test.rb
+++ b/test/services/mcp/studio_health_tool_test.rb
@@ -77,4 +77,13 @@ class Mcp::StudioHealthToolTest < ActiveSupport::TestCase
     err = payload_for(Mcp::GetStudioHealthTool.call(studio: 'none', server_context: {}))
     assert_includes err['error'], 'no generated snapshot'
   end
+
+  test 'a studio whose mapping raises is skipped with warn + Sentry, not fatal' do
+    studio!(name: 'Raises Mid-Map', mini_name: 'boom')
+    Studio.any_instance.stubs(:mini_name).raises(RuntimeError, 'boom')
+    Rails.logger.expects(:warn).with { |msg| msg.include?('Raises Mid-Map') }.at_least_once
+    Sentry.expects(:capture_exception).at_least_once
+    payload = payload_for(Mcp::GetStudioHealthTool.call(server_context: {}))
+    assert_equal [], payload['studios']
+  end
 end

--- a/test/services/mcp/studio_health_tool_test.rb
+++ b/test/services/mcp/studio_health_tool_test.rb
@@ -1,0 +1,80 @@
+require 'test_helper'
+
+class Mcp::StudioHealthToolTest < ActiveSupport::TestCase
+  def period_entry(label, income:, okr_health: 'healthy')
+    {
+      'label' => label,
+      'period_starts_at' => '01/01/2026',
+      'period_ends_at' => '01/31/2026',
+      'cash' => {
+        'datapoints' => { 'income' => { 'value' => income, 'unit' => 'usd' },
+                          'lead_count' => { 'value' => 3, 'unit' => 'count' } },
+        'okrs' => { 'Profit Margin' => { 'health' => okr_health, 'target' => 30 } },
+      },
+      'accrual' => {
+        'datapoints' => { 'income' => { 'value' => income + 1, 'unit' => 'usd' } },
+        'okrs' => {},
+      },
+      'utilization' => { 'someone@sanctuary.computer' => { 'billable' => 120 } },
+    }
+  end
+
+  def studio!(name:, mini_name:, periods: 2)
+    Studio.create!(
+      name: name, mini_name: mini_name,
+      snapshot: { 'month' => (1..periods).map { |i| period_entry("2026-%02d" % i, income: i * 1000) } }
+    )
+  end
+
+  def payload_for(resp)
+    JSON.parse(resp.content.first[:text])
+  end
+
+  test 'passes the chosen accounting subtree through verbatim, excluding per-person utilization' do
+    studio!(name: 'Sanctuary Test', mini_name: 'sanc')
+    payload = payload_for(Mcp::GetStudioHealthTool.call(studio: 'sanc', server_context: {}))
+    s = payload['studios'].first
+    assert_equal 'Sanctuary Test', s['studio']
+    assert_equal 'month', s['gradation']
+    assert_equal 'cash', s['accounting_method']
+    period = s['periods'].last
+    assert_equal({ 'value' => 2000, 'unit' => 'usd' }, period['datapoints']['income'])
+    assert_equal 'healthy', period['okrs']['Profit Margin']['health']
+    assert_nil period['utilization'], 'per-person utilization must never be emitted'
+    refute s['periods'].first.key?('utilization')
+  end
+
+  test 'accrual accounting_method selects the accrual subtree' do
+    studio!(name: 'Accrual Studio', mini_name: 'accr')
+    payload = payload_for(Mcp::GetStudioHealthTool.call(studio: 'accr', accounting_method: 'accrual', server_context: {}))
+    assert_equal 2001, payload['studios'].first['periods'].last['datapoints']['income']['value']
+  end
+
+  test 'periods param takes the most recent N' do
+    studio!(name: 'Many Periods', mini_name: 'many', periods: 10)
+    payload = payload_for(Mcp::GetStudioHealthTool.call(studio: 'many', periods: 3, server_context: {}))
+    labels = payload['studios'].first['periods'].map { |p| p['label'] }
+    assert_equal %w[2026-08 2026-09 2026-10], labels
+  end
+
+  test 'unknown studio errors listing valid studios; invalid gradation and accounting_method error' do
+    studio!(name: 'Only Studio', mini_name: 'only')
+    err = payload_for(Mcp::GetStudioHealthTool.call(studio: 'nope', server_context: {}))
+    assert_includes err['error'], "Unknown studio 'nope'"
+    assert_includes err['error'], 'Only Studio'
+    err = payload_for(Mcp::GetStudioHealthTool.call(gradation: 'weekly', server_context: {}))
+    assert_includes err['error'], "Invalid gradation 'weekly'"
+    err = payload_for(Mcp::GetStudioHealthTool.call(accounting_method: 'both', server_context: {}))
+    assert_includes err['error'], "Invalid accounting_method 'both'"
+  end
+
+  test 'listing all skips snapshotless studios with a warning; explicit request errors' do
+    studio!(name: 'Has Snapshot', mini_name: 'has')
+    Studio.create!(name: 'No Snapshot', mini_name: 'none')
+    Rails.logger.expects(:warn).with { |msg| msg.include?('No Snapshot') }.at_least_once
+    payload = payload_for(Mcp::GetStudioHealthTool.call(server_context: {}))
+    assert_equal ['Has Snapshot'], payload['studios'].map { |s| s['studio'] }
+    err = payload_for(Mcp::GetStudioHealthTool.call(studio: 'none', server_context: {}))
+    assert_includes err['error'], 'no generated snapshot'
+  end
+end

--- a/test/services/mcp/studio_health_tool_test.rb
+++ b/test/services/mcp/studio_health_tool_test.rb
@@ -46,6 +46,13 @@ class Mcp::StudioHealthToolTest < ActiveSupport::TestCase
     assert_equal 'Comma Studio', payload['studios'].first['studio']
   end
 
+  test 'an exact name match wins over another studio carrying that string as a mini_name alias' do
+    studio!(name: 'Alias Holder', mini_name: 'ah, orbit')
+    studio!(name: 'Orbit', mini_name: 'orb')
+    payload = mcp_payload(Mcp::GetStudioHealthTool.call(studio: 'Orbit', server_context: {}))
+    assert_equal 'Orbit', payload['studios'].first['studio'], 'real name must not be shadowed by an alias'
+  end
+
   test 'accrual accounting_method selects the accrual subtree' do
     studio!(name: 'Accrual Studio', mini_name: 'accr')
     payload = mcp_payload(Mcp::GetStudioHealthTool.call(studio: 'accr', accounting_method: 'accrual', server_context: {}))

--- a/test/services/mcp/studio_health_tool_test.rb
+++ b/test/services/mcp/studio_health_tool_test.rb
@@ -26,13 +26,9 @@ class Mcp::StudioHealthToolTest < ActiveSupport::TestCase
     )
   end
 
-  def payload_for(resp)
-    JSON.parse(resp.content.first[:text])
-  end
-
   test 'passes the chosen accounting subtree through verbatim, excluding per-person utilization' do
     studio!(name: 'Sanctuary Test', mini_name: 'sanc')
-    payload = payload_for(Mcp::GetStudioHealthTool.call(studio: 'sanc', server_context: {}))
+    payload = mcp_payload(Mcp::GetStudioHealthTool.call(studio: 'sanc', server_context: {}))
     s = payload['studios'].first
     assert_equal 'Sanctuary Test', s['studio']
     assert_equal 'month', s['gradation']
@@ -46,25 +42,25 @@ class Mcp::StudioHealthToolTest < ActiveSupport::TestCase
 
   test 'accrual accounting_method selects the accrual subtree' do
     studio!(name: 'Accrual Studio', mini_name: 'accr')
-    payload = payload_for(Mcp::GetStudioHealthTool.call(studio: 'accr', accounting_method: 'accrual', server_context: {}))
+    payload = mcp_payload(Mcp::GetStudioHealthTool.call(studio: 'accr', accounting_method: 'accrual', server_context: {}))
     assert_equal 2001, payload['studios'].first['periods'].last['datapoints']['income']['value']
   end
 
   test 'periods param takes the most recent N' do
     studio!(name: 'Many Periods', mini_name: 'many', periods: 10)
-    payload = payload_for(Mcp::GetStudioHealthTool.call(studio: 'many', periods: 3, server_context: {}))
+    payload = mcp_payload(Mcp::GetStudioHealthTool.call(studio: 'many', periods: 3, server_context: {}))
     labels = payload['studios'].first['periods'].map { |p| p['label'] }
     assert_equal %w[2026-08 2026-09 2026-10], labels
   end
 
   test 'unknown studio errors listing valid studios; invalid gradation and accounting_method error' do
     studio!(name: 'Only Studio', mini_name: 'only')
-    err = payload_for(Mcp::GetStudioHealthTool.call(studio: 'nope', server_context: {}))
+    err = mcp_payload(Mcp::GetStudioHealthTool.call(studio: 'nope', server_context: {}))
     assert_includes err['error'], "Unknown studio 'nope'"
     assert_includes err['error'], 'Only Studio'
-    err = payload_for(Mcp::GetStudioHealthTool.call(gradation: 'weekly', server_context: {}))
+    err = mcp_payload(Mcp::GetStudioHealthTool.call(gradation: 'weekly', server_context: {}))
     assert_includes err['error'], "Invalid gradation 'weekly'"
-    err = payload_for(Mcp::GetStudioHealthTool.call(accounting_method: 'both', server_context: {}))
+    err = mcp_payload(Mcp::GetStudioHealthTool.call(accounting_method: 'both', server_context: {}))
     assert_includes err['error'], "Invalid accounting_method 'both'"
   end
 
@@ -72,9 +68,9 @@ class Mcp::StudioHealthToolTest < ActiveSupport::TestCase
     studio!(name: 'Has Snapshot', mini_name: 'has')
     Studio.create!(name: 'No Snapshot', mini_name: 'none')
     Rails.logger.expects(:warn).with { |msg| msg.include?('No Snapshot') }.at_least_once
-    payload = payload_for(Mcp::GetStudioHealthTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::GetStudioHealthTool.call(server_context: {}))
     assert_equal ['Has Snapshot'], payload['studios'].map { |s| s['studio'] }
-    err = payload_for(Mcp::GetStudioHealthTool.call(studio: 'none', server_context: {}))
+    err = mcp_payload(Mcp::GetStudioHealthTool.call(studio: 'none', server_context: {}))
     assert_includes err['error'], 'no generated snapshot'
   end
 
@@ -83,7 +79,20 @@ class Mcp::StudioHealthToolTest < ActiveSupport::TestCase
     Studio.any_instance.stubs(:mini_name).raises(RuntimeError, 'boom')
     Rails.logger.expects(:warn).with { |msg| msg.include?('skipping studio') }.at_least_once
     Sentry.expects(:capture_exception).at_least_once
-    payload = payload_for(Mcp::GetStudioHealthTool.call(server_context: {}))
+    payload = mcp_payload(Mcp::GetStudioHealthTool.call(server_context: {}))
     assert_equal [], payload['studios']
+  end
+
+  test 'an explicitly requested studio whose snapshot entry is malformed errors instead of returning empty success' do
+    s = studio!(name: 'Malformed Studio', mini_name: 'mal')
+    # A String entry (instead of a Hash) has no #dig, so `entry.dig(method, ...)` raises
+    # NoMethodError while mapping this studio's periods.
+    s.update!(snapshot: { 'month' => ['not-a-hash'] })
+    Rails.logger.expects(:warn).with { |msg| msg.include?('skipping studio') }.at_least_once
+    Sentry.expects(:capture_exception).at_least_once
+    err = mcp_payload(Mcp::GetStudioHealthTool.call(studio: 'mal', server_context: {}))
+    assert_includes err['error'], "Studio 'Malformed Studio'"
+    assert_includes err['error'], "gradation 'month'"
+    assert_includes err['error'], 'malformed'
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -95,6 +95,11 @@ class ActiveSupport::TestCase
     [tb, g3d]
   end
 
+  # Parses an MCP tool Response (Mcp::Responses envelope) into the payload hash.
+  def mcp_payload(resp)
+    JSON.parse(resp.content.first[:text])
+  end
+
   # Lightweight admin builder for tool/model tests — creates a bare AdminUser
   # (optionally with a FullTimePeriod) without the studio/ForecastPerson/
   # StudioMembership wiring that make_admin_user! (below) sets up. Use this


### PR DESCRIPTION
## What

The third P1a slice from the [Stacksbot roadmap](https://www.notion.so/garden3d/ROADMAP-md-391131fea2c7801485e0d767177e0da3), unblocking automation #2 (**Business pre-read v1**).

- **\`list_projects_at_risk\`** — ProjectTracker snapshot metrics judged against **each tracker's own configured targets**, reusing the model's existing predicates (\`target_profit_margin_satisfied?\`, \`target_free_hours_ratio_satisfied?\`) so the tool can never drift from what \`considered_successful?\` means; only the \`over_budget\` comparison lives in the tool. Rows carry \`at_risk\` + named \`risk_reasons\`, sorted most-at-risk first. Params: \`only_at_risk\` (default true), \`include_complete\` (default false).
- **\`get_studio_health\`** — verbatim pass-through of the persisted nightly \`Studio#snapshot\` rollup (financial datapoints, utilization hours, lead counts, satisfaction, **OKR health**) per gradation/accounting-method/period-count. Allowlist emission: the period-level per-person \`utilization\` map can never leak (that's \`get_capacity\`'s future surface). Figures always match Stacks' own reporting because nothing is recomputed.

## Scope decision (Hugh, 2026-07-05)

\`list_pipeline\` was **dropped from the P1a tool list**: lead rows live canonically in the Notion Leads DB, which Stacksbot reads directly via the Notion MCP — duplicating them here would create two sources for one dataset. Stacks keeps the *rollups* (lead counts, win rates, OKR health) via \`get_studio_health\`. Decision recorded as a comment on the Notion SPEC page.

## ⚖️ For Hugh's review: risk-semantics confirmation

The spec's defaulted decision (tracker's own targets) has one **known blind spot the final reviewer surfaced**: a project with a snapshot but zero invoiced spend reads margin 100% (model semantics: \`profit_margin\` short-circuits when \`spend == 0\`), and zero recorded hours reads 0% free hours — so a zero-activity in-progress project trips no criterion and is invisible under the default \`only_at_risk: true\`. Workaround today: \`only_at_risk: false\` returns every in-scope project with raw metrics. If pre-invoicing projects should be flagged, that's a follow-up criterion (e.g. \`no_spend_recorded\`) — say the word.

## Tests

Covering suites: **22 runs, 73 assertions, 0 failures**. Full suite: **589 runs, 1377 assertions, 0 branch-caused failures** (1 pre-existing \`AdminUserTest\` date flake, re-verified failing identically on clean \`main\` today). Coverage: each risk criterion independently, no-budget non-flagging, both params, sort order, blank-snapshot warn-only skip, raise→warn+Sentry paths (both tools), verbatim subtree pass-through, per-person utilization exclusion, gradation/accounting/periods param validation, unknown-studio errors, registry + \`tools/call\` round-trips.

## Process

Spec-first with a mid-brainstorm re-scope (Hugh's Notion-duplication catch), subagent-driven development in an isolated worktree, per-task reviews (both first-pass clean), whole-branch final review (verdict: ready; its recommended hardening — nil-safe studio matching, float margin consistency, guarded Sentry style, raise-path tests — applied pre-PR). A multi-round adversarial review loop follows; findings land as additional commits.

## ⚖️ Second model-semantics item for review (round 4)

Related to the risk-semantics confirmation above: the model's `target_free_hours_ratio_satisfied?` has no `<= 0` escape, while its margin sibling `target_profit_margin_satisfied?` treats a 0 target as "unset, don't judge." So a tracker with `target_free_hours_percent == 0` and any recorded free hours reads as at-risk on the free-hours axis. The tool faithfully reuses the model predicate (single-source-of-truth — patching it in the tool would make it disagree with `considered_successful?` and the admin UI), and `set_targets` defaults a 0 away on create, so this only bites legacy rows. If the two target predicates should be symmetric, that's a one-line model change (add the same `<= 0` guard) with an admin-UI blast radius — say the word and I'll do it as a separate model PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)