### PR TITLE
MCP get_document: return body + meeting_key (unblocks observations backfill)

### DIFF
--- a/app/services/mcp/get_document_tool.rb
+++ b/app/services/mcp/get_document_tool.rb
@@ -1,7 +1,7 @@
 module Mcp
   class GetDocumentTool < MCP::Tool
     tool_name 'get_document'
-    description 'Fetch one corpus-eligible document with its transcript segments.'
+    description 'Fetch one corpus-eligible document with its transcript segments, full text, and meeting key.'
     input_schema(properties: { id: { type: 'integer' } }, required: ['id'])
     annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true)
 
@@ -10,8 +10,15 @@ module Mcp
       return Responses.error('Document not found') unless doc
 
       meeting = doc.source_record
-      segments = meeting.is_a?(Meeting) ? meeting.segments.order(:position).map { |s| { speaker: s.speaker_name, text: s.text } } : []
-      Responses.ok({ id: doc.id, title: doc.title, url: doc.url, occurred_at: doc.occurred_at, segments: segments })
+      is_meeting = meeting.is_a?(Meeting)
+      segments = is_meeting ? meeting.segments.order(:position).map { |s| { speaker: s.speaker_name, text: s.text } } : []
+      # `body` is the document's own text (its chunks). For a transcript doc this is
+      # redundant with `segments`; it is intentional so a Gemini note (which has no
+      # segments) is still readable. Callers prefer `segments` for transcripts, `body` for notes.
+      body = doc.chunks.order(:position).pluck(:content).join("\n")
+      meeting_key = is_meeting ? meeting.id : nil
+      Responses.ok({ id: doc.id, title: doc.title, url: doc.url, occurred_at: doc.occurred_at,
+                     meeting_key: meeting_key, segments: segments, body: body })
     end
   end
 end

--- a/docs/superpowers/plans/2026-07-07-observations-backfill-meet-gemini.md
+++ b/docs/superpowers/plans/2026-07-07-observations-backfill-meet-gemini.md
@@ -1,0 +1,191 @@
+# Observations Backfill — Meet/Gemini — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Comprehensively backfill the Stacksbot Observations DB with per-meeting observations over the full year of the Meet/Gemini corpus, by simulating the `observe` skill against the live stacks MCP — after a small `get_document` enhancement and making Gemini notes an observed source.
+
+**Architecture:** One small repo code change (Task 1: `get_document` returns the document's `body` + `meeting_key`), then an **operational runbook** (Part B) the controller executes: author the Notion durable changes (notes → observed + dedup), connect this session to the live stacks MCP, enumerate meetings oldest→youngest, and run a multi-agent Workflow that applies the observe rubric per meeting and writes `New` rows. Only Task 1 is subagent-driven TDD code; Part B is controller-run and gated on Task 1 being merged + deployed.
+
+**Tech Stack:** Rails 6.1 / Ruby 3.1, Minitest + mocha, PostgreSQL + pgvector, the `mcp` gem (`MCP::Tool`), the read-only stacks MCP (`https://stacks.garden3d.net/api/mcp`), the Notion MCP, and the `Workflow` tool.
+
+## Global Constraints
+
+- **Only Task 1 is repo code (TDD).** Part B (Notion authoring + the backfill run) is operational — verification is tool-based (fetch-back / live MCP calls), not unit tests. Do not invent unit tests for Notion/Workflow steps.
+- **Privacy wall is absolute:** the backfill only ever reaches `corpus_eligible` documents; excluded (1:1/HR/perf/comp) docs 404 from `get_document` and never appear. Never widen that scope.
+- **No secrets ever printed or written** to a file, log, or Notion row — including the MCP `X-Api-Key` and any Twist token.
+- **No raw PII in an `Observation`** — the Observations DB and digest are team-visible. Summarize; reference, do not paste.
+- **`Status` is always `New`.** Never write `Triaged`/`Acted`/`Dismissed`.
+- **Canonical Notion select values only:** `Source ∈ {Google Meet, Gemini Notes}`, `Salience ∈ {High, Medium, Low}`, `Type ∈ {Lead, Risk, Decision, Question, FYI}`. Never create new select options.
+- **Dedup unit is the meeting** (`meeting_key`). New keys: `stacks:meeting:<meeting_key>:<n>`. Legacy 122 keys `stacks:meet:<doc_id>` are honored by resolving `doc_id → meeting_key` into the skip-set (keep them; do not delete or migrate).
+- **The agent never flips a Notion trust boundary** (`Enabled`, Job activation). All Notion changes are drafts / inert body edits; a human enables.
+- **Exact ids:** Observations DB `390131fea2c7808bb216c38b46c3ba55` (DS `390131fe-a2c7-80bf-b9a2-000b91fc630a`) · Sources DS `576eb9a8-8a01-4d1e-a00f-8efd361143b8` (rows: `gemini-notes` `https://app.notion.com/390131fea2c78168b3eaf1dc0bdaf85b`, `google-meet` `https://app.notion.com/390131fea2c7814890bbfea77b36ebec`) · Skills DS `38e131fe-a2c7-806b-8a4a-000b79b5b49c` (`Slug: observe`, `Slug: recall`). MCP endpoint `https://stacks.garden3d.net/api/mcp`; key at `Rails.application.credentials[:"localhost:3000"][:stacks][:private_api_key]`.
+
+---
+
+## File / artifact map
+
+| Artifact | Where | Responsibility |
+|---|---|---|
+| `get_document` `body` + `meeting_key` | `app/services/mcp/get_document_tool.rb` | Make a note readable and pair transcript↔note (Task 1) |
+| Tool tests | `test/services/mcp/tools_test.rb` | Prove body join + meeting_key (Task 1) |
+| `gemini-notes` / `google-meet` Sources rows | Notion DS `576eb9a8-…` | Durable: notes become observed + meeting dedup (Part B1) |
+| `observe` / `recall` skills | Notion Skills DS `38e131fe-…b49c` | Durable: cross-artifact dedup instruction (Part B1) |
+| Backfill Workflow | `Workflow` tool (this session) | The comprehensive per-meeting run (Part B2–B5) |
+
+---
+
+## Task 1: `get_document` returns the document `body` and `meeting_key`
+
+**Files:**
+- Modify: `app/services/mcp/get_document_tool.rb`
+- Test: `test/services/mcp/tools_test.rb`
+
+**Interfaces:**
+- Consumes: `Document.corpus_eligible`, `Document#chunks` (has `content`, `position`), `Document#source_record` (a `Meeting` or nil), `Mcp::Responses.ok/.error`.
+- Produces: `get_document` response gains two keys — `body` (String: the doc's own `chunks` ordered by `position`, joined with `"\n"`; `""` when the doc has no chunks) and `meeting_key` (Integer meeting id when `source_record` is a `Meeting`, else `null`). Existing keys (`id`, `title`, `url`, `occurred_at`, `segments`) are unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `test/services/mcp/tools_test.rb` (inside `Mcp::ToolsTest`, before the `ids_for` helper). The `setup` block already creates `@doc` (a `:meet` doc) with one chunk at position 0: `'we decided to ship the gateway'`.
+
+```ruby
+  test 'get_document returns body joined from the doc chunks in position order' do
+    # @doc already has a position-0 chunk from setup; add a later one out of insertion order.
+    Chunk.create!(document: @doc, position: 2, content: 'and we set the launch date', source: :meet)
+    Chunk.create!(document: @doc, position: 1, content: 'then we picked the rollout plan', source: :meet)
+
+    payload = JSON.parse(Mcp::GetDocumentTool.call(id: @doc.id, server_context: {}).content.first[:text])
+    assert_equal(
+      "we decided to ship the gateway\nthen we picked the rollout plan\nand we set the launch date",
+      payload['body']
+    )
+  end
+
+  test 'get_document returns meeting_key for a meeting-backed doc and nil for a standalone doc' do
+    m = Meeting.create!(meet_source: :meet_api, meet_conference_record_id: 'cr/gd-1')
+    note = Document.create!(source: :gemini_notes, external_id: 'gd-note', title: 'Roadmap notes',
+                            excluded: :not_excluded, source_record: m)
+    Chunk.create!(document: note, position: 0, content: 'summary: shipped the gateway', source: :meet)
+
+    linked = JSON.parse(Mcp::GetDocumentTool.call(id: note.id, server_context: {}).content.first[:text])
+    assert_equal m.id, linked['meeting_key']
+    assert_equal 'summary: shipped the gateway', linked['body']
+
+    standalone = JSON.parse(Mcp::GetDocumentTool.call(id: @doc.id, server_context: {}).content.first[:text])
+    assert_nil standalone['meeting_key']
+  end
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bin/rails test test/services/mcp/tools_test.rb -n '/get_document returns/'`
+Expected: 2 failures — `payload['body']` is `nil` (key absent) and `linked['meeting_key']` is `nil` for the note (key absent), so the `assert_equal` lines fail.
+
+- [ ] **Step 3: Implement the enhancement**
+
+Replace the body of `self.call` in `app/services/mcp/get_document_tool.rb` so it also computes `body` and `meeting_key`, and update the class `description`:
+
+```ruby
+module Mcp
+  class GetDocumentTool < MCP::Tool
+    tool_name 'get_document'
+    description 'Fetch one corpus-eligible document with its transcript segments, full text, and meeting key.'
+    input_schema(properties: { id: { type: 'integer' } }, required: ['id'])
+    annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true)
+
+    def self.call(id:, server_context:)
+      doc = Document.corpus_eligible.find_by(id: id)
+      return Responses.error('Document not found') unless doc
+
+      meeting = doc.source_record
+      segments = meeting.is_a?(Meeting) ? meeting.segments.order(:position).map { |s| { speaker: s.speaker_name, text: s.text } } : []
+      body = doc.chunks.order(:position).pluck(:content).join("\n")
+      meeting_key = meeting.is_a?(Meeting) ? meeting.id : nil
+      Responses.ok({ id: doc.id, title: doc.title, url: doc.url, occurred_at: doc.occurred_at,
+                     meeting_key: meeting_key, segments: segments, body: body })
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bin/rails test test/services/mcp/tools_test.rb`
+Expected: all tests pass (the two new ones plus the four pre-existing tool tests), 0 failures. (These tests don't touch embeddings, so no `skip_without_pgvector`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/mcp/get_document_tool.rb test/services/mcp/tools_test.rb
+git commit -m "MCP get_document: return document body and meeting_key"
+```
+
+---
+
+## Part B — Backfill runbook (controller-executed; **gated on Task 1 merged + deployed**)
+
+These are **not** subagent TDD tasks. The controller runs them after a human merges Task 1's PR and it deploys to `stacks.garden3d.net`. Each has a concrete verification.
+
+### B0. Deploy gate
+
+- Task 1 ships as a PR (see finishing-a-development-branch). **A human merges + deploys** (the agent cannot). Confirm live before continuing:
+  - `KEY=$(bin/rails runner 'print Rails.application.credentials[:"localhost:3000"][:stacks][:private_api_key]')` (never echo `$KEY`).
+  - `curl -s -X POST https://stacks.garden3d.net/api/mcp -H "X-Api-Key: $KEY" -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_document","arguments":{"id":<a known gemini_notes doc id>}}}'`
+  - Expected: a 200 whose result JSON contains non-empty `body` and a numeric `meeting_key`. A 401 means the `localhost:3000` key is not the prod key → fetch the prod key from Heroku config / stacksbot secrets before proceeding. If `body` is absent, the deploy has not rolled out yet — wait and retry.
+
+### B1. Durable Notion changes (notes → observed + dedup) — drafts
+
+Author via the Notion MCP. No `Enabled` flips.
+
+- **`gemini-notes` Sources row** (`390131fea2c78168b3eaf1dc0bdaf85b`): replace the "Not observed" body with an observed contract:
+  - `## Fetch`: via the stacks MCP, `list_documents(source: "gemini_notes", occurred_after/before)`; for each, `get_document(id)` and read `body` (the note prose). Normalize `{id, timestamp: occurred_at, author: participants, text: body, url}`. Source Key `stacks:meeting:<meeting_key>:<n>`. **Dedup:** a note sharing a `meeting_key` with a transcript is the *same meeting* — observe once. Source label `Gemini Notes`.
+  - Keep the existing `## Search` / `## Cite` sections.
+- **`google-meet` Sources row** (`390131fea2c7814890bbfea77b36ebec`): change its Source Key to `stacks:meeting:<meeting_key>:<n>` and add the same cross-artifact dedup note (transcript preferred when present).
+- **`observe` skill** (`Slug: observe`): add to the source-agnostic Steps: "When a source exposes one underlying meeting through more than one artifact (e.g. a transcript and a Gemini note), treat them as one meeting — observe it once, key on the meeting, and do not emit a second observation set for the other artifact."
+- **`recall` skill** (`Slug: recall`): make the same dedup language consistent so Recall does not double-report a meeting.
+- **Verify:** `notion-fetch` each edited row/skill; confirm the new `## Fetch`/dedup text is present and no `Enabled`/Status was flipped (Sources rows stay `Active`, skills stay as they were).
+
+### B2. Connect the live MCP + build the enumeration
+
+- **Connect this session** to `https://stacks.garden3d.net/api/mcp` (streamable-HTTP, header `X-Api-Key: $KEY`) via `claude mcp add` (or session MCP config). Verify with a `list_sources` call returning 200.
+- **Skip-set (dedup vs the 122):** query the Observations DB (`390131fe-…630a`) for every `Source Key`. For legacy `stacks:meet:<doc_id>` keys, `get_document(<doc_id>)` → collect `meeting_key`. For `stacks:meeting:<key>:*` keys, take `<key>` directly. Result: a set `OBSERVED_MEETING_KEYS`.
+- **Enumerate meetings oldest→youngest:** page `list_documents(source:"meet")` and `list_documents(source:"gemini_notes")` across the year (newest-first + `offset`; reverse client-side). `get_document` each to read its `meeting_key`; group docs by `meeting_key` (a `null` meeting_key → its own meeting keyed on `doc_id`) into work-items `{meeting_key, occurred_at, transcript_doc?, note_doc?}`, sorted ascending by `occurred_at`, minus `OBSERVED_MEETING_KEYS`.
+- **Verify:** print the count of work-items and the oldest/newest `occurred_at`; sanity-check against the corpus (~730 meetings minus the ~122 already observed).
+
+### B3. First-batch quality gate
+
+- Run the Workflow (B4 shape) on **only the first ~10 work-items**. Present the produced observations (Name / Observation / Salience / Type / Source Key) to the user for a rubric-quality read. Adjust the rubric prompt if needed, then proceed. Do not write the remaining meetings until the sample is reviewed.
+
+### B4. The comprehensive Workflow run
+
+- `Workflow` script: `pipeline()` over the work-items (oldest→youngest), one subagent per meeting (batch only tiny ones). Each subagent:
+  1. Reads its meeting via the live MCP — `get_document` for the transcript (prefer `segments`) and/or the note (`body`).
+  2. Applies the observe **salience rubric comprehensively** — every lead/risk/decision/question/durable-fact that clears the bar, incl. `Low`, no per-meeting cap.
+  3. Dedups within the meeting (transcript+note → one set).
+  4. Emits schema-validated observations: `Name`, `Observation` (PII-summarized), `Source` (`Google Meet` if transcript-backed else `Gemini Notes`), `Source Ref` (doc `url`), `Source Key` `stacks:meeting:<meeting_key>:<n>`, `Observed At` (meeting `occurred_at`), `Salience`, `Type`, `Status:New`; leaves `Related Observations`/`Domain`/`Functions` empty.
+  5. Writes rows via the Notion MCP `notion-create-pages` with a **concurrency cap + 429 backoff** (Notion rate-limits hard).
+- **Resumable/idempotent:** rebuild `OBSERVED_MEETING_KEYS` at start so a re-run/resume skips written meetings; the Workflow's `resumeFromRunId` is the secondary resume path.
+
+### B5. Post-run verification
+
+- Query the Observations DB grouped by `Source`, `Salience`, `Type`; confirm coverage across `High/Medium/Low` and both `Google Meet` + `Gemini Notes`.
+- Confirm **no meeting double-counted**: no `meeting_key` carries both a `Google Meet` and a `Gemini Notes` observation set.
+- Confirm the **122 legacy meetings were not re-observed** (their `meeting_key`s absent from the new writes).
+- Spot-check ~5 rows: `Source Ref` backlink resolves, `Observed At` equals the meeting time (not run time), `Status = New`.
+- Re-run once → **zero** new rows (idempotency).
+
+---
+
+## Part C — Phase 3: Twist (future, separate spec)
+
+Out of scope here. Twist creds live in this repo (`credentials[:"localhost:3000"][:twist]`), so it is unblocked. A later spec/plan exports a year of Twist threads/messages via REST v3, runs the same Workflow shape, and dedups `twist:msg:<id>` against the existing 60 rows.
+
+---
+
+## Self-Review
+
+**Spec coverage:** Phase 0 `get_document` body + meeting_key → Task 1 ✓ · notes-become-observed + cross-artifact dedup (durable) → B1 ✓ · live-MCP access (not a dump) → B0/B2 ✓ · skip-set dedup vs the 122 → B2 ✓ · oldest→youngest per-meeting enumeration → B2 ✓ · comprehensive rubric, no cap → B4 ✓ · meeting-scoped Source Keys → B4 + Global Constraints ✓ · first-batch gate → B3 ✓ · post-run + idempotency verification → B5 ✓ · Twist deferred → Part C ✓ · privacy/PII/secrets/Status/canonical-options guardrails → Global Constraints ✓.
+
+**Placeholder scan:** Task 1 carries complete test + implementation code and exact commands. Part B is intentionally operational (no unit tests, per the first Global Constraint) with concrete verifications; the one `<a known gemini_notes doc id>` / `<doc_id>` placeholders are runtime ids resolved from the live corpus at execution, not authoring gaps.
+
+**Type/name consistency:** `body` (String) and `meeting_key` (Integer|nil) names identical across Task 1's Interfaces, tests, implementation, and B0/B2. Source Key format `stacks:meeting:<meeting_key>:<n>` identical in Global Constraints, B1, B2, B4. Source labels `Google Meet` / `Gemini Notes` match the DB select options and are used consistently. Notion ids match the spec's Global Constraints.

--- a/docs/superpowers/specs/2026-07-07-observations-backfill-meet-gemini-design.md
+++ b/docs/superpowers/specs/2026-07-07-observations-backfill-meet-gemini-design.md
@@ -1,0 +1,280 @@
+# Observations Backfill — Meet/Gemini (Phase 1 source) — Design Spec
+
+- **Date:** 2026-07-07
+- **Status:** Approved (design); implementation via writing-plans → subagent-driven development
+- **Owner:** Hugh / Sanctuary Computer
+- **Worktree / branch:** `mcp-agent-features` / `worktree-mcp-agent-features`
+- **Related:** Stacksbot observation layer (`../stacksbot/docs/superpowers/specs/2026-06-30-stacksbot-observation-layer-design.md`), sense-making Recall (`../stacksbot/docs/superpowers/specs/2026-06-30-sense-making-recall-design.md`), the Stacks Meet/Gemini corpus + read-only MCP (this repo).
+
+## Background
+
+Stacksbot has a source-agnostic **Observation layer** (`sense → triage → act`, sense only so
+far). An `observe` skill reads a source's `## Fetch` contract from an always-loaded `sources`
+skill (materialized from a Notion **Sources** DB), applies a salience rubric, dedups by a stable
+`Source Key`, and writes `Status: New` rows to a team-visible Notion **Observations** DB. A
+daily digest reports new rows to Twist.
+
+Separately, this repo (`stacks`) now hosts a durable org-wide corpus: a full year of Google Meet
+transcripts + Gemini "Notes by Gemini", embedded in pgvector, exposed by a read-only **stacks
+MCP** server (`search`, `list_documents`, `get_document`, `list_sources`). As of the 365-day
+backfill: **315 transcripts, 675 notes, ~730 meetings**.
+
+The observe layer has already partially run against these sources, producing (in the Observations
+DB today):
+
+- **Google Meet: 122** observations, all `Status: New` — from an earlier, sparser partial pass
+  that predates the full corpus.
+- **Twist: 60** (56 `New`, 4 `Acted`).
+- **Notion: 2** (`New`).
+- **14 rows with no `Source`** — junk/test leftovers.
+- **Gemini notes: 0** — notes were deliberately *not observed* (see below).
+
+We want to run a **comprehensive, per-meeting historical backfill** over the full year of the
+corpus — faithfully **simulating what Stacksbot's `observe` skill would do**, but executed from
+this Claude Code session so the one-time load does not tie up the live Stacksbot agent. We also
+make **Gemini notes a first-class observed source** going forward. Twist gets the same treatment
+in a later phase.
+
+## Goals
+
+1. **Backfill meeting observations comprehensively.** For every corpus-eligible meeting in the
+   past year (oldest → youngest), record all salient observations that clear the rubric
+   (including `Low`, no per-meeting cap) into the Observations DB, deduplicated against what is
+   already there.
+2. **Make Gemini notes an observed source.** Flip the `gemini-notes` Sources row from
+   *"Not observed"* to observed, and teach `observe` to treat a meeting's transcript and note as
+   **one meeting** (dedup across artifacts), so the ~360 meetings that have a note but no
+   transcript are covered without double-counting the ~315 that have both.
+3. **Do it through the live stacks MCP**, exactly as Stacksbot reaches it — not a database dump —
+   so the run is a faithful simulation of the agent's own behavior.
+4. **Leave a durable improvement behind.** The MCP change and the Notion authoring make ongoing
+   Observe/Recall better, not just this one run.
+
+## Non-goals (YAGNI)
+
+- **Twist backfill** — deferred to Phase 3 (own spec/plan); creds are available in this repo's
+  credentials, so it is unblocked but out of scope here.
+- **Triage / act / digest tuning** — we only write `New` rows; humans triage from the DB.
+- **Enabling anything in Notion** — all authored Notion changes are drafts / inert body edits;
+  a human flips the trust boundary. This run does not enable an "Observe: Gemini notes" Job.
+- **Re-embedding or changing the corpus/ETL** — read-only against the existing corpus.
+- **Deleting the existing 122 Meet rows** — decision was to keep and dedup against them.
+
+## Decisions locked in brainstorming
+
+| # | Decision | Choice |
+|---|---|---|
+| 1 | Meeting model | Notes become a **separate observed source**; process **per-meeting, oldest→youngest**; `observe`/`recall` get **dedup instructions** so a meeting's transcript + note collapse to one observation. |
+| 2 | Selectivity | **Comprehensive** — all salience incl. `Low`, no per-meeting cap. |
+| 3 | Execution | **Multi-agent Workflow**, run in this session. |
+| 4 | Twist | **Meet/Gemini now; Twist fast-follow** (own spec). |
+| 5 | Existing 122 Meet rows | **Keep, dedup against them** (skip already-observed meetings). |
+| 6 | Data access | **Live stacks MCP** (`https://stacks.garden3d.net/api/mcp`), like Stacksbot — not a dump. |
+| 7 | Note reading | **Small MCP enhancement first** — `get_document` returns the doc's own text + a meeting group key. |
+
+## Architecture
+
+Four phases. Phase 0 is code + a deploy; Phase 1 is Notion authoring (can run in parallel with 0);
+Phase 2 is the run and depends on both; Phase 3 is a later spec.
+
+### Phase 0 — MCP enhancement (code in `stacks`, requires deploy)
+
+`get_document` (`app/services/mcp/get_document_tool.rb`) today returns
+`{id, title, url, occurred_at, segments}`, where `segments` is the **transcript** (from
+`meeting.segments`). A `Document` has **no body column** — a Gemini note's prose lives only in its
+`chunks` (`chunks.content`, ordered by `position`). So a note is currently **unreadable** through
+the MCP except as `search` snippets, and the tools expose no `meeting_id` to pair a transcript
+with its note.
+
+Change `get_document` to additionally return:
+
+- **`body`** — the document's own text: its `chunks` ordered by `position`, joined. This is the
+  note's prose for a `gemini_notes` doc (and, for a transcript doc, the chunked transcript text —
+  harmless/redundant next to `segments`).
+- **`meeting_key`** — a stable per-meeting grouping id, `source_record_id` (the `Meeting` id) when
+  `source_record` is a `Meeting`, else `null`. Lets a caller group a transcript and its note into
+  one meeting without heuristics.
+
+Constraints:
+- Stays within the existing `corpus_eligible` scope (privacy wall holds — excluded docs still 404).
+- Additive only; existing fields unchanged. TDD, mirrors the existing tool tests
+  (`test/.../mcp/` + `skip_without_pgvector` guards where embeddings are touched).
+- Ship as a normal PR. **A human merges + deploys** (I cannot); Phase 2 waits until it is live on
+  `stacks.garden3d.net` (verified by a live `get_document` call returning `body`).
+
+Optional (only if grouping proves expensive): add `meeting_key` to `list_documents` rows too. Not
+required — Phase 2 fetches every doc anyway and can group on the `get_document` result.
+
+### Phase 1 — Gemini notes become an observed source (Notion, drafted)
+
+Authoring only; no repo code. Uses the Notion MCP. Follows the repo's trust-boundary rule: the
+agent never enables; a human does.
+
+1. **`gemini-notes` Sources row** (`https://app.notion.com/390131fea2c78168b3eaf1dc0bdaf85b`):
+   replace the *"Not observed"* framing with an observed `## Fetch` contract:
+   - Fetch: via the stacks MCP, `list_documents(source: "gemini_notes", occurred_after/before)`
+     over the window; for each, `get_document(id)` and read `body` (the note prose). Normalize to
+     `{id, timestamp: occurred_at, author: participants, text: body, url}`.
+   - Source Key: **meeting-scoped** — `stacks:meeting:<meeting_key>:<n>` (see "Source Key & dedup").
+   - Dedup: a note and a transcript that share a `meeting_key` are the **same meeting** — observe
+     the meeting once. If the meeting already has observations (any artifact), skip.
+   - Source label (the `Source` select value): **`Gemini Notes`** (exact existing option name).
+2. **`google-meet` Sources row** (`https://app.notion.com/390131fea2c7814890bbfea77b36ebec`):
+   update its Source Key to the meeting-scoped scheme and add the same cross-artifact dedup note
+   (transcript preferred when present). Source label stays **`Google Meet`**.
+3. **`observe` skill** (Skills DB `38e131fe-a2c7-806b-8a4a-000b79b5b49c`, `Slug: observe`): add a
+   cross-artifact **dedup instruction** to the source-agnostic Steps — "when a source exposes the
+   same underlying meeting through more than one artifact (e.g. a transcript and a Gemini note),
+   treat them as one meeting: observe it once, key on the meeting, and do not emit a second
+   observation set for the other artifact."
+4. **`recall` skill / `gemini-notes` Search contract**: already Search-enabled; make the dedup
+   language consistent (a note and transcript of one meeting are one meeting) so Recall does not
+   double-report. Minor edit.
+
+All four are drafts / inert body edits. Editing an `Active` Sources row's body goes live on the
+next reconcile but stays **inert** until an "Observe: Gemini notes" Job is enabled — which this
+project does **not** do.
+
+### Phase 2 — The backfill Workflow (run here, simulating Stacksbot)
+
+Executed via the `Workflow` tool in this session. Depends on Phase 0 being live.
+
+**Setup (in the session, before the Workflow):**
+
+1. **Connect the live stacks MCP** to this session:
+   `https://stacks.garden3d.net/api/mcp`, transport streamable-HTTP, header `X-Api-Key: <key>`.
+   The key is read from this repo — `Rails.application.credentials[:"localhost:3000"][:stacks]
+   [:private_api_key]` (prod reads the same `localhost:3000` credentials block; verified by one
+   authenticated `list_sources` call returning 200, not 401). **Never printed.**
+2. **Build the "already-observed" set:** query the Observations DB (Notion MCP) for all existing
+   `Source Key`s. For each legacy Meet key `stacks:meet:<doc_id>`, resolve `doc_id → meeting_key`
+   via `get_document` so the 122 map onto meetings. The result is a set of `meeting_key`s to skip.
+3. **Enumerate meetings oldest→youngest:** page `list_documents(source: "meet")` and
+   `list_documents(source: "gemini_notes")` across the full year (newest-first + `offset`; reverse
+   client-side). Group docs into meetings by `meeting_key` (via `get_document`), producing one
+   work-item per meeting `{meeting_key, occurred_at, transcript_doc?, note_doc?}`, sorted ascending
+   by `occurred_at`. Drop meetings already in the skip set.
+
+**The Workflow:**
+
+- `pipeline()` over meeting work-items, one subagent per meeting (the orchestrator may batch only
+  very small meetings). Each subagent:
+  1. Reads its meeting via the live MCP — `get_document` for the transcript (prefer `segments`)
+     and/or the note (`body`).
+  2. Applies the real observe **salience rubric comprehensively** — every lead / risk / decision /
+     question / durable fact that clears the bar, incl. `Low`, no cap.
+  3. **Dedups within the meeting** (transcript + note → one observation set).
+  4. Emits structured observations (schema-validated) with fields:
+     `Name` (≤~10 words), `Observation` (self-contained, PII-summarized), `Source`
+     (`Google Meet` if a transcript backed it, else `Gemini Notes`), `Source Ref` (the doc `url`),
+     `Source Key` (`stacks:meeting:<meeting_key>:<n>`), `Observed At` (the meeting's `occurred_at`,
+     not run time), `Salience` (`High`/`Medium`/`Low`), `Type`
+     (`Lead`/`Risk`/`Decision`/`Question`/`FYI`), `Status` = `New`. Leave `Related Observations`,
+     `Domain`, `Functions` empty (triage's job).
+  5. **Writes** the rows to the Observations DB via the Notion MCP, with a **concurrency cap +
+     429 backoff** (Notion rate-limits aggressively — observed during design).
+- **Resumable / idempotent:** re-reading the existing `Source Key`s at the start and skipping
+  already-observed meetings means an interrupted run simply continues; a re-run writes nothing new.
+  The Workflow's own `resumeFromRunId` gives an additional resume path.
+
+**First-batch quality gate:** run the first ~10 meetings, present the produced observations to the
+user for a quality read on the rubric, then proceed to the full fan-out. (Even under
+"comprehensive," this confirms the rubric behaves before writing hundreds of rows.)
+
+### Phase 3 — Twist (later, own spec)
+
+Sketch only. Twist creds are in this repo (`credentials[:"localhost:3000"][:twist]` — token /
+workspace id / bot user id), so it is unblocked. Export a year of threads/messages via Twist REST
+v3 (`threads/get` per channel over 365d with `newer_than_ts`/`older_than_ts`, `comments/get` per
+thread — broader than the current client's unread-only reads), normalize per the Twist `## Fetch`
+contract, run the same Workflow shape, dedup `twist:msg:<id>` / `twist:thread:<id>:<state>` against
+the existing 60. Twist over a year is chattier than meetings; its own spec will set Twist-specific
+selectivity.
+
+## Source Key & dedup
+
+- **Dedup unit = the meeting** (`meeting_key = get_document.meeting_key = Meeting id`). A meeting is
+  observed at most once across its transcript and note(s).
+- **New observation keys:** `stacks:meeting:<meeting_key>:<n>`, where `<n>` is a stable index/slug
+  within the meeting (a meeting can yield several observations under "comprehensive").
+- **Legacy keys:** the existing 122 use `stacks:meet:<doc_id>`. They are honored by resolving
+  `doc_id → meeting_key` and adding that meeting to the skip set (Decision #5: keep + dedup, do not
+  delete or migrate them).
+- **Cross-source:** notes and transcripts of one meeting share `meeting_key`, so a note never
+  double-counts a transcript-observed meeting. Distinct meetings stay distinct.
+
+## Data / control flow
+
+```
+Phase 0 (deployed):  get_document → { …, body, meeting_key }
+                                   │
+Setup:  credentials[:"localhost:3000"][:stacks][:private_api_key]
+            └─ connect session → https://stacks.garden3d.net/api/mcp (X-Api-Key)
+        Notion: existing Source Keys ──resolve──▶ skip-set (meeting_keys, incl. the 122)
+        MCP: list_documents(meet) + list_documents(gemini_notes) ──group by meeting_key──▶
+             meetings sorted oldest→youngest, minus skip-set
+                                   │
+Phase 2 Workflow (pipeline, 1 subagent / meeting):
+        get_document(transcript?/note?) → rubric (comprehensive) → dedup-in-meeting →
+        observations{…, Source Key = stacks:meeting:<key>:<n>, Status:New} →
+        Notion create (throttled, 429 backoff)
+                                   │
+        First-batch gate (~10) ──▶ full fan-out ──▶ post-run verification
+```
+
+## Guardrails
+
+- **Read-only** on the corpus and (Phase 3) Twist. The only writes are Observations rows.
+- **Privacy wall holds:** only `corpus_eligible` docs are reachable (1:1 / HR / perf / comp meetings
+  are already excluded from the corpus and 404 from `get_document`). The backfill never sees them.
+- **No secrets / raw PII** in an `Observation` — the DB and digest are team-visible. Summarize;
+  reference, do not paste. (Mirrors the observe skill + apollo skill PII guardrails.)
+- **The API key is never printed** or written to any file, log, or Notion row.
+- **`Status` is always `New`** — no triage transitions.
+- **Canonical option values only** on write: `Source ∈ {Google Meet, Gemini Notes}`,
+  `Salience ∈ {High, Medium, Low}`, `Type ∈ {Lead, Risk, Decision, Question, FYI}`. Do not create
+  new select options. (The DB currently has option-bleed — `Salience` carries stray
+  `Decision`/`Lead`, `Type` carries stray `High`/`Medium`, `Source` has both `Meet` and
+  `Google Meet` — see Follow-ups; the backfill must not add to it.)
+
+## Verification / success criteria
+
+- **Phase 0:** a live `get_document` on a `gemini_notes` doc against `stacks.garden3d.net` returns a
+  non-empty `body` and a `meeting_key`; a transcript doc returns both `segments` and `body`; an
+  excluded doc still 404s. Existing tool tests stay green.
+- **Auth:** an authenticated `list_sources` against the live endpoint returns 200 with the
+  repo-sourced key (proves prod accepts the `localhost:3000` key).
+- **Dedup:** none of the existing 122 meetings are re-observed; no meeting appears with both a
+  `Google Meet` and a `Gemini Notes` observation set for the same `meeting_key`.
+- **Coverage:** meetings that have only a note (no transcript) receive observations (proves the
+  Phase 0 `body` path works end-to-end).
+- **Comprehensiveness:** observations exist across `High`/`Medium`/`Low`; no per-meeting cap applied.
+- **Provenance:** every row has a working `Source Ref` backlink, an `Observed At` equal to the
+  meeting time (not run time), `Status = New`, and a `stacks:meeting:…` key.
+- **Idempotency:** a second run (or a resume) writes zero new rows.
+- **Silence:** no Twist/Slack/email is sent; the run only writes Observations rows.
+
+## Risks & mitigations
+
+- **Volume (comprehensive, team-visible):** accepted by decision; humans triage from the DB with
+  filters. The first-batch gate calibrates rubric behavior before the full write.
+- **Notion rate limits (429s seen in design):** concurrency cap + exponential backoff on writes;
+  resumable so a throttle stall is not fatal.
+- **Prod key mismatch:** if the `localhost:3000` key is *not* the prod key, the first `list_sources`
+  call 401s — then fetch the prod key from Heroku config / stacksbot secrets before proceeding.
+- **Meeting grouping gaps:** `meeting_key` is exact (the `Meeting` id) for docs whose
+  `source_record` is a `Meeting`; any doc with a `null` meeting_key is treated as its own meeting
+  (keyed on its `doc_id`) — no silent merge.
+- **Token cost / long run:** hundreds of subagent runs. Mitigated by resumability, the batch gate,
+  and running as a single background Workflow.
+- **Double-count from the durable Phase 1 change:** the cross-artifact dedup instruction + the
+  meeting-scoped key are the mitigation; the verification explicitly checks for it.
+
+## Follow-ups (out of scope, noted)
+
+- **Observations schema hygiene:** `Salience`/`Type` option-bleed and the duplicate
+  `Meet`/`Google Meet` Source options predate this work. Optional one-time cleanup via
+  `notion-update-data-source`; not required for the backfill (which writes canonical values only).
+- **14 null-`Source` junk rows:** harmless; leave (Decision #5 kept scope to the 122). Optional
+  delete later.
+- **`list_documents` meeting_key:** add only if grouping cost becomes a problem.

--- a/test/services/mcp/tools_test.rb
+++ b/test/services/mcp/tools_test.rb
@@ -48,6 +48,32 @@ class Mcp::ToolsTest < ActiveSupport::TestCase
     assert_equal [note.id], ids
   end
 
+  test 'get_document returns body joined from the doc chunks in position order' do
+    # @doc already has a position-0 chunk from setup; add a later one out of insertion order.
+    Chunk.create!(document: @doc, position: 2, content: 'and we set the launch date', source: :meet)
+    Chunk.create!(document: @doc, position: 1, content: 'then we picked the rollout plan', source: :meet)
+
+    payload = JSON.parse(Mcp::GetDocumentTool.call(id: @doc.id, server_context: {}).content.first[:text])
+    assert_equal(
+      "we decided to ship the gateway\nthen we picked the rollout plan\nand we set the launch date",
+      payload['body']
+    )
+  end
+
+  test 'get_document returns meeting_key for a meeting-backed doc and nil for a standalone doc' do
+    m = Meeting.create!(meet_source: :meet_api, meet_conference_record_id: 'cr/gd-1')
+    note = Document.create!(source: :gemini_notes, external_id: 'gd-note', title: 'Roadmap notes',
+                            excluded: :not_excluded, source_record: m)
+    Chunk.create!(document: note, position: 0, content: 'summary: shipped the gateway', source: :meet)
+
+    linked = JSON.parse(Mcp::GetDocumentTool.call(id: note.id, server_context: {}).content.first[:text])
+    assert_equal m.id, linked['meeting_key']
+    assert_equal 'summary: shipped the gateway', linked['body']
+
+    standalone = JSON.parse(Mcp::GetDocumentTool.call(id: @doc.id, server_context: {}).content.first[:text])
+    assert_nil standalone['meeting_key']
+  end
+
   def ids_for(resp)
     JSON.parse(resp.content.first[:text]).map { |d| d['id'] }
   end


### PR DESCRIPTION
## What

Extends the read-only stacks MCP `get_document` tool to additionally return:

- **`body`** — the document's own text: its `chunks` joined in `position` order (`""` when it has none).
- **`meeting_key`** — the `Meeting` id when the doc's `source_record` is a `Meeting`, else `null`.

Existing fields (`id`, `title`, `url`, `occurred_at`, `segments`) are unchanged — the change is purely additive and backward-compatible.

## Why

This unblocks the **comprehensive Meet/Gemini observations backfill** (design + plan included in this branch as docs). Today `get_document` returns only transcript `segments`, so a **Gemini note is unreadable** through the MCP (its prose lives only in embedded `chunks`), and there is no `meeting_key` to pair a transcript with its note. `body` makes notes readable; `meeting_key` lets the backfill dedup a meeting's transcript + note into one observation.

## Scope

- Code: `app/services/mcp/get_document_tool.rb` (+ tests). The privacy wall is untouched — the tool still gates on `Document.corpus_eligible`, so excluded (1:1/HR) docs still 404.
- Docs: `docs/superpowers/specs/2026-07-07-observations-backfill-meet-gemini-design.md` and `docs/superpowers/plans/2026-07-07-observations-backfill-meet-gemini.md` — the design for the downstream backfill (a controller-run Workflow that simulates Stacksbot's `observe` skill against the live MCP). That run is **not** part of this PR; it happens after this merges and deploys.

## Tests

New tests in `test/services/mcp/tools_test.rb` prove `body` respects `position` order (chunks inserted out of order) and `meeting_key` covers both the Meeting-backed and standalone (`nil`) branches. `bin/rails test test/services/mcp/tools_test.rb` → 7 runs, 0 failures.

## After merge

Deploy to `stacks.garden3d.net`, then the Phase-1/2 backfill (make Gemini notes an observed source + run the comprehensive per-meeting pass) proceeds per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)