### PR TITLE
Streaming + thread-correct Google Groups crawl (+ retry hardening)

### DIFF
--- a/config/initializers/google_apis_logger.rb
+++ b/config/initializers/google_apis_logger.rb
@@ -1,0 +1,7 @@
+# The google-apis-core client logs full HTTP request/response BODIES at DEBUG level via its
+# own Google::Apis.logger. Our production log level is :debug, so a bulk Gmail crawl (the
+# Google Groups ETL) would otherwise dump every fetched email body into the logs — enormous
+# volume, and a real throughput drag. Cap the Google client's own logger at WARN so the rest
+# of the app's :debug logging is untouched but API request/response bodies stay out of the log.
+require 'google/apis'
+Google::Apis.logger.level = Logger::WARN

--- a/lib/stacks/etl/groups/groups_source.rb
+++ b/lib/stacks/etl/groups/groups_source.rb
@@ -100,7 +100,11 @@ module Stacks
             resp = gmail.list_user_messages('me', q: query_for(group_email), max_results: GMAIL_PAGE, page_token: page)
             Array(resp.messages).each do |ref|
               root, mid = root_for(gmail, ref.id)
-              next if mid.nil? || seen.include?(mid)
+              if mid.nil?
+                Rails.logger.warn("[groups] #{group_email} message #{ref.id} has no Message-ID header; skipped")
+                next
+              end
+              next if seen.include?(mid)
               seen << mid
               (roots[root] ||= []) << ref.id
             rescue StandardError => e

--- a/lib/stacks/etl/groups/groups_source.rb
+++ b/lib/stacks/etl/groups/groups_source.rb
@@ -7,25 +7,31 @@ module Stacks
     module Groups
       # Crawls every group's traffic out of member mailboxes via the Gmail API.
       #
-      # Streaming, memory-bounded design: rather than pull a whole group's year of mail into
-      # memory before assembling anything (which silently blocks for ~an hour on a firehose
-      # list like admin@ and holds tens of thousands of message bodies at once), we discover
-      # thread membership cheaply from the `list` response (Gmail returns a `thread_id` per
-      # message for free), then fetch + assemble + YIELD one Gmail thread at a time and free
-      # it. Peak memory is a single thread (plus a small per-group set of already-seen ids);
-      # Documents land incrementally, so progress is visible and an interrupted run resumes
-      # cleanly (ingest is idempotent on the root Message-ID).
+      # Streaming, memory-bounded, thread-correct design. The naive approach (pull a whole
+      # group's year of mail into memory, then assemble) silently blocks for ~an hour on a
+      # firehose list (admin@: ~9,550 msgs/mailbox/yr) and holds tens of thousands of bodies.
+      # A tempting shortcut — bucket by Gmail's free `thread_id` and yield per Gmail thread —
+      # is WRONG: Gmail splits one logical conversation across several thread_ids (subject
+      # drift, long gaps), so replies keyed to the same RFC822 root land in different Gmail
+      # threads and would be dropped by the root-level dedup.
       #
-      # Cross-mailbox union is approximate under streaming: messages are deduped by RFC822
-      # Message-ID and threads by root across the K crawlers, owner/longest-tenured first. For
-      # normal list traffic (every member receives every message) each mailbox holds the whole
-      # thread, so the first crawler captures it fully and later crawlers dedup away. The only
-      # gap is a thread where a later crawler holds messages the first one lacks (a member who
-      # joined mid-thread) — those extra messages are dropped rather than merged. That is the
-      # deliberate trade for bounded memory + incremental progress.
+      # So we group on the true thread key (RFC822 root) in two cheap passes per mailbox:
+      #   1. list + a metadata-only fetch (headers, no body) per message to learn its root_id,
+      #      bucketing gmail ids under root_id. Holds only ids + headers.
+      #   2. fetch full bodies one root bucket at a time, parse, assemble, YIELD, free.
+      # Peak memory is a per-mailbox root index (ids/strings) plus one thread's bodies;
+      # Documents land incrementally, so progress is visible and an interrupted run resumes
+      # cleanly (ingest is idempotent on the root Message-ID). Cost is ~2x Gmail gets per
+      # message (metadata + raw) — an accepted trade for correctness on a one-time backfill.
+      #
+      # Cross-mailbox union across the K crawlers (owner-first) is still approximate: messages
+      # dedup by Message-ID and threads by root, and a later crawler's extra messages on an
+      # already-seen root are dropped rather than merged (rare: needs a member holding messages
+      # the owner lacks). Within a single mailbox, no messages are lost.
       class GroupsSource
         DEFAULT_SINCE = 30.days
         GMAIL_PAGE = 100
+        META_HEADERS = %w[Message-ID References In-Reply-To].freeze
 
         def initialize(admin_email:, since: nil, until_time: nil, k: 2)
           @admin_email = admin_email
@@ -58,7 +64,7 @@ module Stacks
           seen_msgs = Set.new   # RFC822 Message-IDs already ingested for this group
           seen_roots = Set.new  # thread roots already yielded for this group
           crawlers.each do |member_email|
-            each_gmail_thread(member_email, g[:email]) do |messages|
+            each_logical_thread(member_email, g[:email]) do |messages|
               fresh = messages.reject { |m| m[:message_id].nil? || seen_msgs.include?(m[:message_id]) }
               next if fresh.empty?
               fresh.each { |m| seen_msgs << m[:message_id] }
@@ -82,21 +88,31 @@ module Stacks
           (owners + usable).map { |m| m[:email] }.uniq.first(@k)
         end
 
-        # Yields one array of parsed messages per Gmail thread for this crawler's mailbox.
-        # Discovery (list) is cheap and gives us the thread_id per message for free, so we
-        # bucket message ids by thread WITHOUT fetching bodies, then fetch each thread's bodies
-        # only when we're about to hand it off — bounding peak memory to a single thread.
-        def each_gmail_thread(member_email, group_email)
+        # Yields one array of parsed messages per LOGICAL thread (RFC822 root) for this mailbox.
+        # See the class comment for why grouping is on root_id (from a cheap metadata pass), not
+        # Gmail's thread_id.
+        def each_logical_thread(member_email, group_email)
           gmail = Stacks::Etl::Meet::Auth.gmail_service(sub: member_email)
-          threads = Hash.new { |h, k| h[k] = [] } # thread_id => [gmail message ids]
+          roots = {}         # root_id => [gmail message ids]
+          seen  = Set.new    # Message-IDs already mapped in THIS mailbox
           page = nil
           loop do
             resp = gmail.list_user_messages('me', q: query_for(group_email), max_results: GMAIL_PAGE, page_token: page)
-            Array(resp.messages).each { |ref| threads[ref.thread_id] << ref.id }
+            Array(resp.messages).each do |ref|
+              root, mid = root_for(gmail, ref.id)
+              next if mid.nil? || seen.include?(mid)
+              seen << mid
+              (roots[root] ||= []) << ref.id
+            rescue StandardError => e
+              Rails.logger.warn("[groups] #{group_email} metadata #{ref.id} skipped: #{e.class}: #{e.message.to_s[0, 140]}")
+            end
             page = resp.next_page_token
             break unless page
           end
-          threads.each_value do |gmail_ids|
+          # Heartbeat: pass 1 (metadata) can run a while on a firehose mailbox before pass 2
+          # yields any Document, so log the tally so a long metadata phase reads as progress.
+          Rails.logger.info("[groups] #{group_email} via #{member_email}: #{seen.size} messages across #{roots.size} threads; fetching bodies")
+          roots.each_value do |gmail_ids|
             msgs = gmail_ids.filter_map do |gid|
               raw = gmail.get_user_message('me', gid, format: 'raw').raw
               MessageParser.parse(raw)
@@ -106,6 +122,20 @@ module Stacks
             end
             yield msgs unless msgs.empty?
           end
+        end
+
+        # Cheap header-only fetch -> [root_id, message_id] so we can group by the true thread
+        # root without pulling message bodies.
+        def root_for(gmail, gmail_id)
+          meta = gmail.get_user_message('me', gmail_id, format: 'metadata', metadata_headers: META_HEADERS)
+          h = header_map(meta)
+          mid = h['message-id']
+          root = MessageParser.root_id_from(message_id: mid, references: h['references'], in_reply_to: h['in-reply-to'])
+          [root, mid.to_s.strip.empty? ? nil : MessageParser.bracket(mid)]
+        end
+
+        def header_map(meta)
+          Array(meta&.payload&.headers).each_with_object({}) { |hdr, acc| acc[hdr.name.to_s.downcase] = hdr.value }
         end
 
         def query_for(group_email)

--- a/lib/stacks/etl/groups/groups_source.rb
+++ b/lib/stacks/etl/groups/groups_source.rb
@@ -1,13 +1,28 @@
 # lib/stacks/etl/groups/groups_source.rb
 require 'google/apis/gmail_v1'
+require 'set'
 
 module Stacks
   module Etl
     module Groups
       # Crawls every group's traffic out of member mailboxes via the Gmail API.
-      # Per group: pick up to K impersonable member mailboxes, search each for the
-      # group's mail, dedup messages by RFC822 Message-ID, assemble threads. Memory is
-      # bounded to one group's window at a time; groups are yielded lazily by the caller.
+      #
+      # Streaming, memory-bounded design: rather than pull a whole group's year of mail into
+      # memory before assembling anything (which silently blocks for ~an hour on a firehose
+      # list like admin@ and holds tens of thousands of message bodies at once), we discover
+      # thread membership cheaply from the `list` response (Gmail returns a `thread_id` per
+      # message for free), then fetch + assemble + YIELD one Gmail thread at a time and free
+      # it. Peak memory is a single thread (plus a small per-group set of already-seen ids);
+      # Documents land incrementally, so progress is visible and an interrupted run resumes
+      # cleanly (ingest is idempotent on the root Message-ID).
+      #
+      # Cross-mailbox union is approximate under streaming: messages are deduped by RFC822
+      # Message-ID and threads by root across the K crawlers, owner/longest-tenured first. For
+      # normal list traffic (every member receives every message) each mailbox holds the whole
+      # thread, so the first crawler captures it fully and later crawlers dedup away. The only
+      # gap is a thread where a later crawler holds messages the first one lacks (a member who
+      # joined mid-thread) — those extra messages are dropped rather than merged. That is the
+      # deliberate trade for bounded memory + incremental progress.
       class GroupsSource
         DEFAULT_SINCE = 30.days
         GMAIL_PAGE = 100
@@ -22,7 +37,7 @@ module Stacks
         def each_thread
           active = active_emails
           Workspace.all_groups.each do |g|
-            assemble_group(g, active).each { |n| yield n }
+            stream_group(g, active) { |doc| yield doc }
           end
         end
 
@@ -32,24 +47,32 @@ module Stacks
           Set.new(Stacks::Etl::Meet::Workspace.all_active_user_emails)
         end
 
-        # Discover crawlers, crawl their mailboxes, dedup by Message-ID, and assemble this
-        # group's threads. Rescued as a unit: one group failing (deleted mid-run, a Directory
-        # members error, etc.) logs and yields nothing rather than aborting the whole run.
-        # yield stays in each_thread (outside this rescue) so consumer/ingest errors propagate.
-        def assemble_group(g, active)
+        # Stream one group's threads, deduping across its K crawler mailboxes. Rescued at two
+        # levels: one crawler failing (revoked Gmail access) logs and moves to the next; the
+        # whole group failing (deleted mid-run, a Directory members error) logs and yields
+        # nothing rather than aborting the run. `yield` stays here — outside every rescue — so
+        # a consumer/ingest error still propagates instead of being swallowed.
+        def stream_group(g, active)
           crawlers = pick_crawlers(Workspace.members(g[:email]), active)
-          return [] if crawlers.empty?
-          by_id = {}
+          return if crawlers.empty?
+          seen_msgs = Set.new   # RFC822 Message-IDs already ingested for this group
+          seen_roots = Set.new  # thread roots already yielded for this group
           crawlers.each do |member_email|
-            fetch_group_messages(member_email, g[:email]) { |msg| by_id[msg[:message_id]] ||= msg }
+            each_gmail_thread(member_email, g[:email]) do |messages|
+              fresh = messages.reject { |m| m[:message_id].nil? || seen_msgs.include?(m[:message_id]) }
+              next if fresh.empty?
+              fresh.each { |m| seen_msgs << m[:message_id] }
+              MessageParser.assemble(group_email: g[:email], group_name: g[:name], messages: fresh).each do |doc|
+                next if seen_roots.include?(doc[:external_id])
+                seen_roots << doc[:external_id]
+                yield doc
+              end
+            end
           rescue StandardError => e
             Rails.logger.warn("[groups] #{g[:email]} via #{member_email} skipped: #{e.class}: #{e.message.to_s[0, 140]}")
           end
-          return [] if by_id.empty?
-          MessageParser.assemble(group_email: g[:email], group_name: g[:name], messages: by_id.values)
         rescue StandardError => e
           Rails.logger.warn("[groups] group #{g[:email]} skipped: #{e.class}: #{e.message.to_s[0, 140]}")
-          []
         end
 
         # Owners/managers first, restricted to active internal users we can impersonate.
@@ -59,19 +82,29 @@ module Stacks
           (owners + usable).map { |m| m[:email] }.uniq.first(@k)
         end
 
-        def fetch_group_messages(member_email, group_email)
+        # Yields one array of parsed messages per Gmail thread for this crawler's mailbox.
+        # Discovery (list) is cheap and gives us the thread_id per message for free, so we
+        # bucket message ids by thread WITHOUT fetching bodies, then fetch each thread's bodies
+        # only when we're about to hand it off — bounding peak memory to a single thread.
+        def each_gmail_thread(member_email, group_email)
           gmail = Stacks::Etl::Meet::Auth.gmail_service(sub: member_email)
+          threads = Hash.new { |h, k| h[k] = [] } # thread_id => [gmail message ids]
           page = nil
           loop do
             resp = gmail.list_user_messages('me', q: query_for(group_email), max_results: GMAIL_PAGE, page_token: page)
-            Array(resp.messages).each do |ref|
-              raw = gmail.get_user_message('me', ref.id, format: 'raw').raw
-              yield MessageParser.parse(raw)
-            rescue StandardError => e
-              Rails.logger.warn("[groups] #{group_email} message #{ref.id} skipped: #{e.class}: #{e.message.to_s[0, 140]}")
-            end
+            Array(resp.messages).each { |ref| threads[ref.thread_id] << ref.id }
             page = resp.next_page_token
             break unless page
+          end
+          threads.each_value do |gmail_ids|
+            msgs = gmail_ids.filter_map do |gid|
+              raw = gmail.get_user_message('me', gid, format: 'raw').raw
+              MessageParser.parse(raw)
+            rescue StandardError => e
+              Rails.logger.warn("[groups] #{group_email} message #{gid} skipped: #{e.class}: #{e.message.to_s[0, 140]}")
+              nil
+            end
+            yield msgs unless msgs.empty?
           end
         end
 

--- a/lib/stacks/etl/groups/message_parser.rb
+++ b/lib/stacks/etl/groups/message_parser.rb
@@ -12,13 +12,11 @@ module Stacks
 
         def self.parse(raw)
           m = Mail.read_from_string(raw)
-          refs = Array(m.references).map { |r| bracket(r) }
-          in_reply = m.in_reply_to ? bracket(Array(m.in_reply_to).first) : nil
           mid = bracket(m.message_id)
           from_name, from_email = address_parts(m[:from])
           {
             message_id: mid,
-            root_id: refs.first || in_reply || mid,
+            root_id: root_id_from(message_id: m.message_id, references: m.references, in_reply_to: m.in_reply_to),
             from_name: from_name,
             from_email: from_email,
             to: addresses(m[:to]),
@@ -27,6 +25,17 @@ module Stacks
             date: m.date&.to_time,
             body: strip_quoted(body_text(m))
           }
+        end
+
+        # Thread root = first References entry, else In-Reply-To, else the message's own
+        # Message-ID (all angle-bracket-normalized). Shared by parse (mail-gem values, arrays)
+        # and the crawl's cheap metadata pass (raw header strings), so both derive the SAME
+        # thread key regardless of how Gmail bucketed the message into a thread_id.
+        def self.root_id_from(message_id:, references: nil, in_reply_to: nil)
+          refs = Array(references).flat_map { |r| r.to_s.split }.reject(&:empty?).map { |r| bracket(r) }
+          irt  = Array(in_reply_to).flat_map { |r| r.to_s.split }.reject(&:empty?).map { |r| bracket(r) }.first
+          mid  = message_id.to_s.strip.empty? ? nil : bracket(message_id)
+          refs.first || irt || mid
         end
 
         # messages: parse-hashes already deduped by :message_id. Returns one doc per root.

--- a/lib/stacks/etl/meet/auth.rb
+++ b/lib/stacks/etl/meet/auth.rb
@@ -41,15 +41,25 @@ module Stacks
           service
         end
 
+        # google-apis-core defaults to 0 retries, so without this a transient 429/5xx on a
+        # single Gmail/Directory call would surface to the crawl's per-item rescue and silently
+        # DROP that message. On a bulk backfill (thousands of sequential gets) rate-limit blips
+        # are expected — retries enables the client's built-in exponential backoff so transient
+        # errors recover instead of losing data. The per-item rescue then only catches genuinely
+        # permanent errors (403 no-access, 404).
+        GOOGLE_RETRIES = 5
+
         def self.gmail_service(sub:)
           service = Google::Apis::GmailV1::GmailService.new
           service.authorization = credentials(sub, [GMAIL_SCOPE])
+          service.request_options.retries = GOOGLE_RETRIES
           service
         end
 
         def self.directory_group_service(sub:)
           service = Google::Apis::AdminDirectoryV1::DirectoryService.new
           service.authorization = credentials(sub, DIRECTORY_GROUP_SCOPES)
+          service.request_options.retries = GOOGLE_RETRIES
           service
         end
 

--- a/lib/tasks/etl.rake
+++ b/lib/tasks/etl.rake
@@ -49,8 +49,12 @@ namespace :stacks do
       begin
         days = (args[:days] || 90).to_i
         admin = Stacks::Utils.config.dig(:google_oauth2, :admin_email) || 'hugh@sanctuary.computer'
+        # k:1 for the backfill — the two-pass crawl already costs ~2 Gmail gets/message, and a
+        # second crawler mailbox mostly re-fetches messages that dedup away, so a single
+        # (owner/longest-tenured) mailbox halves the volume for near-identical coverage over a
+        # large historical window. The nightly sync keeps the default k:2 on its tiny window.
         # track:false so the explicit backfill window isn't written back into the ongoing cursor.
-        Stacks::Etl::Groups::Connector.new(admin_email: admin).run(since: days.days.ago, track: false)
+        Stacks::Etl::Groups::Connector.new(admin_email: admin, k: 1).run(since: days.days.ago, track: false)
       rescue => e
         system_task.mark_as_error(e)
       else

--- a/test/lib/stacks/etl/groups/auth_test.rb
+++ b/test/lib/stacks/etl/groups/auth_test.rb
@@ -9,6 +9,7 @@ class Stacks::Etl::Groups::AuthTest < ActiveSupport::TestCase
     svc = Stacks::Etl::Meet::Auth.gmail_service(sub: 'member@sanctuary.computer')
     assert_instance_of Google::Apis::GmailV1::GmailService, svc
     assert_equal fake_creds, svc.authorization
+    assert_equal 5, svc.request_options.retries, 'transient 429/5xx must retry, not silently drop a message'
   end
 
   test 'directory_group_service builds a Directory client with group read-only scopes' do
@@ -19,5 +20,6 @@ class Stacks::Etl::Groups::AuthTest < ActiveSupport::TestCase
     svc = Stacks::Etl::Meet::Auth.directory_group_service(sub: 'admin@sanctuary.computer')
     assert_instance_of Google::Apis::AdminDirectoryV1::DirectoryService, svc
     assert_equal fake_creds, svc.authorization
+    assert_equal 5, svc.request_options.retries
   end
 end

--- a/test/lib/stacks/etl/groups/groups_source_test.rb
+++ b/test/lib/stacks/etl/groups/groups_source_test.rb
@@ -3,14 +3,35 @@ require 'test_helper'
 require 'ostruct'
 
 class Stacks::Etl::Groups::GroupsSourceTest < ActiveSupport::TestCase
+  META = Stacks::Etl::Groups::GroupsSource::META_HEADERS
+
   def raw(mid, from, subject, date, body, references = nil)
     h = +"Message-ID: #{mid}\r\nFrom: #{from}\r\nTo: dev@sanctuary.computer\r\nSubject: #{subject}\r\nDate: #{date}\r\nContent-Type: text/plain\r\n"
     h << "References: #{references}\r\n" if references
     "#{h}\r\n#{body}"
   end
 
-  # A Gmail message list ref carries an id AND a thread_id (the crawl buckets by thread_id).
-  def ref(id, thread_id) = OpenStruct.new(id: id, thread_id: thread_id)
+  # A Gmail message list ref carries an id AND a thread_id (thread_id is intentionally NOT
+  # used for grouping — we group on the RFC822 root from the metadata pass).
+  def ref(id, thread_id = 't') = OpenStruct.new(id: id, thread_id: thread_id)
+
+  # Pass-1 metadata response: payload.headers with the root-relevant headers.
+  def meta(message_id, references = nil, in_reply_to = nil)
+    headers = [OpenStruct.new(name: 'Message-ID', value: message_id)]
+    headers << OpenStruct.new(name: 'References', value: references) if references
+    headers << OpenStruct.new(name: 'In-Reply-To', value: in_reply_to) if in_reply_to
+    OpenStruct.new(payload: OpenStruct.new(headers: headers))
+  end
+
+  # Stub BOTH passes for one message on a gmail mock: metadata (pass 1) + raw (pass 2).
+  def stub_msg(gmail, gid, message_id, from, subject, date, body, references = nil)
+    gmail.stubs(:get_user_message).with('me', gid, format: 'metadata', metadata_headers: META)
+         .returns(meta(message_id, references))
+    gmail.stubs(:get_user_message).with('me', gid, format: 'raw')
+         .returns(OpenStruct.new(raw: raw(message_id, from, subject, date, body, references)))
+  end
+
+  def one_page(*refs) = OpenStruct.new(messages: refs, next_page_token: nil)
 
   test 'dedups a thread received in two mailboxes into one Document (segments unioned once)' do
     Stacks::Etl::Groups::Workspace.stubs(:all_groups).returns([{ email: 'dev@sanctuary.computer', name: 'Dev' }])
@@ -22,19 +43,16 @@ class Stacks::Etl::Groups::GroupsSourceTest < ActiveSupport::TestCase
     Stacks::Etl::Meet::Workspace.stubs(:all_active_user_emails)
       .returns(['alice@sanctuary.computer', 'bob@sanctuary.computer'])
 
-    root  = raw('<a@x>', 'Alice <alice@x.co>', 'Deploy failed', 'Mon, 01 Jun 2026 10:00:00 +0000', 'down')
-    reply = raw('<c@x>', 'Bob <bob@x.co>', 'Re: Deploy failed', 'Mon, 01 Jun 2026 11:00:00 +0000', 'up', '<a@x>')
-
-    # Realistic list traffic: BOTH members received BOTH messages of the one thread.
+    # Both members received both messages of the one thread.
     alice_gmail = mock('alice')
-    alice_gmail.stubs(:list_user_messages).returns(OpenStruct.new(messages: [ref('a1', 't1'), ref('a2', 't1')], next_page_token: nil))
-    alice_gmail.stubs(:get_user_message).with('me', 'a1', format: 'raw').returns(OpenStruct.new(raw: root))
-    alice_gmail.stubs(:get_user_message).with('me', 'a2', format: 'raw').returns(OpenStruct.new(raw: reply))
+    alice_gmail.stubs(:list_user_messages).returns(one_page(ref('a1'), ref('a2')))
+    stub_msg(alice_gmail, 'a1', '<a@x>', 'Alice <alice@x.co>', 'Deploy failed', 'Mon, 01 Jun 2026 10:00:00 +0000', 'down')
+    stub_msg(alice_gmail, 'a2', '<c@x>', 'Bob <bob@x.co>', 'Re: Deploy failed', 'Mon, 01 Jun 2026 11:00:00 +0000', 'up', '<a@x>')
 
     bob_gmail = mock('bob')
-    bob_gmail.stubs(:list_user_messages).returns(OpenStruct.new(messages: [ref('b1', 't9'), ref('b2', 't9')], next_page_token: nil))
-    bob_gmail.stubs(:get_user_message).with('me', 'b1', format: 'raw').returns(OpenStruct.new(raw: root))
-    bob_gmail.stubs(:get_user_message).with('me', 'b2', format: 'raw').returns(OpenStruct.new(raw: reply))
+    bob_gmail.stubs(:list_user_messages).returns(one_page(ref('b1'), ref('b2')))
+    stub_msg(bob_gmail, 'b1', '<a@x>', 'Alice <alice@x.co>', 'Deploy failed', 'Mon, 01 Jun 2026 10:00:00 +0000', 'down')
+    stub_msg(bob_gmail, 'b2', '<c@x>', 'Bob <bob@x.co>', 'Re: Deploy failed', 'Mon, 01 Jun 2026 11:00:00 +0000', 'up', '<a@x>')
 
     Stacks::Etl::Meet::Auth.stubs(:gmail_service).with(sub: 'alice@sanctuary.computer').returns(alice_gmail)
     Stacks::Etl::Meet::Auth.stubs(:gmail_service).with(sub: 'bob@sanctuary.computer').returns(bob_gmail)
@@ -48,35 +66,76 @@ class Stacks::Etl::Groups::GroupsSourceTest < ActiveSupport::TestCase
     assert_equal ['down', 'up'], d[:segments].map { |s| s[:text] }
   end
 
-  test 'streams one Document per Gmail thread (bounded, incremental)' do
+  test 'groups by RFC822 root even when Gmail split the conversation across thread_ids (no message loss)' do
+    # The regression the streaming rewrite must NOT reintroduce: root <a@x> and its reply <c@x>
+    # sit in DIFFERENT Gmail thread_ids (tA, tB) — a real Gmail behaviour on subject drift.
+    # Grouping on root (via the metadata pass) keeps them in one Document with both segments;
+    # grouping on thread_id would have dropped the reply.
     Stacks::Etl::Groups::Workspace.stubs(:all_groups).returns([{ email: 'dev@sanctuary.computer', name: 'Dev' }])
     Stacks::Etl::Groups::Workspace.stubs(:members).with('dev@sanctuary.computer')
       .returns([{ email: 'alice@sanctuary.computer', role: 'OWNER', type: 'USER' }])
     Stacks::Etl::Meet::Workspace.stubs(:all_active_user_emails).returns(['alice@sanctuary.computer'])
 
-    t1 = raw('<a@x>', 'Alice <alice@x.co>', 'Deploy failed', 'Mon, 01 Jun 2026 10:00:00 +0000', 'down')
-    t2 = raw('<b@x>', 'Alice <alice@x.co>', 'Lunch?', 'Mon, 02 Jun 2026 10:00:00 +0000', 'tacos')
-
     gmail = mock('g')
-    # Two DISTINCT Gmail threads in one list page — must yield as two separate Documents.
-    gmail.stubs(:list_user_messages).returns(OpenStruct.new(messages: [ref('m1', 't1'), ref('m2', 't2')], next_page_token: nil))
-    gmail.stubs(:get_user_message).with('me', 'm1', format: 'raw').returns(OpenStruct.new(raw: t1))
-    gmail.stubs(:get_user_message).with('me', 'm2', format: 'raw').returns(OpenStruct.new(raw: t2))
+    gmail.stubs(:list_user_messages).returns(one_page(ref('g1', 'tA'), ref('g2', 'tB')))
+    stub_msg(gmail, 'g1', '<a@x>', 'Alice <alice@x.co>', 'Deploy failed', 'Mon, 01 Jun 2026 10:00:00 +0000', 'down')
+    stub_msg(gmail, 'g2', '<c@x>', 'Bob <bob@x.co>', 'Re: Deploy — status', 'Mon, 01 Jun 2026 11:00:00 +0000', 'up', '<a@x>')
     Stacks::Etl::Meet::Auth.stubs(:gmail_service).returns(gmail)
 
     yielded = []
     Stacks::Etl::Groups::GroupsSource.new(admin_email: 'hugh@sanctuary.computer', k: 1).each_thread { |n| yielded << n }
 
-    assert_equal 2, yielded.size, 'two distinct Gmail threads -> two Documents, streamed separately'
+    assert_equal 1, yielded.size
+    assert_equal '<a@x>', yielded.first[:external_id]
+    assert_equal ['down', 'up'], yielded.first[:segments].map { |s| s[:text] },
+                 'the reply in a different Gmail thread but same RFC822 root must not be lost'
+  end
+
+  test 'streams one Document per logical thread (bounded, incremental)' do
+    Stacks::Etl::Groups::Workspace.stubs(:all_groups).returns([{ email: 'dev@sanctuary.computer', name: 'Dev' }])
+    Stacks::Etl::Groups::Workspace.stubs(:members).with('dev@sanctuary.computer')
+      .returns([{ email: 'alice@sanctuary.computer', role: 'OWNER', type: 'USER' }])
+    Stacks::Etl::Meet::Workspace.stubs(:all_active_user_emails).returns(['alice@sanctuary.computer'])
+
+    gmail = mock('g')
+    gmail.stubs(:list_user_messages).returns(one_page(ref('m1'), ref('m2')))
+    stub_msg(gmail, 'm1', '<a@x>', 'Alice <alice@x.co>', 'Deploy failed', 'Mon, 01 Jun 2026 10:00:00 +0000', 'down')
+    stub_msg(gmail, 'm2', '<b@x>', 'Alice <alice@x.co>', 'Lunch?', 'Mon, 02 Jun 2026 10:00:00 +0000', 'tacos')
+    Stacks::Etl::Meet::Auth.stubs(:gmail_service).returns(gmail)
+
+    yielded = []
+    Stacks::Etl::Groups::GroupsSource.new(admin_email: 'hugh@sanctuary.computer', k: 1).each_thread { |n| yielded << n }
+
+    assert_equal 2, yielded.size, 'two distinct roots -> two Documents'
     assert_equal ['<a@x>', '<b@x>'], yielded.map { |n| n[:external_id] }.sort
     assert(yielded.all? { |d| d[:segments].size == 1 })
   end
 
-  test 'owner-first streaming: a later mailbox extra message on an already-seen thread is not merged' do
-    # alice (OWNER) has only the root; bob (MEMBER) has root + a reply. Under streaming union,
-    # alice's copy of the thread is emitted first, and bob's extra reply for that same root is
-    # deduped-by-root and dropped. This is the deliberate trade for bounded memory — locked
-    # here so it reads as intentional, not a regression.
+  test 'paginates the message list across pages' do
+    Stacks::Etl::Groups::Workspace.stubs(:all_groups).returns([{ email: 'dev@sanctuary.computer', name: 'Dev' }])
+    Stacks::Etl::Groups::Workspace.stubs(:members).with('dev@sanctuary.computer')
+      .returns([{ email: 'alice@sanctuary.computer', role: 'OWNER', type: 'USER' }])
+    Stacks::Etl::Meet::Workspace.stubs(:all_active_user_emails).returns(['alice@sanctuary.computer'])
+
+    gmail = mock('g')
+    gmail.stubs(:list_user_messages).with('me', has_entries(q: instance_of(String), max_results: 100, page_token: nil))
+         .returns(OpenStruct.new(messages: [ref('p1')], next_page_token: 'P2'))
+    gmail.stubs(:list_user_messages).with('me', has_entries(page_token: 'P2'))
+         .returns(OpenStruct.new(messages: [ref('p2')], next_page_token: nil))
+    stub_msg(gmail, 'p1', '<a@x>', 'Alice <alice@x.co>', 'One', 'Mon, 01 Jun 2026 10:00:00 +0000', 'first')
+    stub_msg(gmail, 'p2', '<b@x>', 'Bob <bob@x.co>', 'Two', 'Mon, 02 Jun 2026 10:00:00 +0000', 'second')
+    Stacks::Etl::Meet::Auth.stubs(:gmail_service).returns(gmail)
+
+    yielded = []
+    Stacks::Etl::Groups::GroupsSource.new(admin_email: 'hugh@sanctuary.computer', k: 1).each_thread { |n| yielded << n }
+    assert_equal ['<a@x>', '<b@x>'], yielded.map { |n| n[:external_id] }.sort,
+                 'messages from BOTH list pages must be ingested'
+  end
+
+  test 'owner-first: a later mailbox extra message on an already-seen root is not merged' do
+    # alice (OWNER) has only the root; bob (MEMBER) has root + a reply. alice's copy is emitted
+    # first; bob's extra reply for the same root is deduped-by-root and dropped — the deliberate
+    # cross-mailbox trade for bounded memory (within a mailbox nothing is lost — see the split test).
     Stacks::Etl::Groups::Workspace.stubs(:all_groups).returns([{ email: 'dev@sanctuary.computer', name: 'Dev' }])
     Stacks::Etl::Groups::Workspace.stubs(:members).with('dev@sanctuary.computer').returns([
       { email: 'alice@sanctuary.computer', role: 'OWNER', type: 'USER' },
@@ -85,17 +144,14 @@ class Stacks::Etl::Groups::GroupsSourceTest < ActiveSupport::TestCase
     Stacks::Etl::Meet::Workspace.stubs(:all_active_user_emails)
       .returns(['alice@sanctuary.computer', 'bob@sanctuary.computer'])
 
-    root  = raw('<a@x>', 'Alice <alice@x.co>', 'Deploy failed', 'Mon, 01 Jun 2026 10:00:00 +0000', 'down')
-    reply = raw('<c@x>', 'Bob <bob@x.co>', 'Re: Deploy failed', 'Mon, 01 Jun 2026 11:00:00 +0000', 'up', '<a@x>')
-
     alice_gmail = mock('alice')
-    alice_gmail.stubs(:list_user_messages).returns(OpenStruct.new(messages: [ref('a1', 't1')], next_page_token: nil))
-    alice_gmail.stubs(:get_user_message).with('me', 'a1', format: 'raw').returns(OpenStruct.new(raw: root))
+    alice_gmail.stubs(:list_user_messages).returns(one_page(ref('a1')))
+    stub_msg(alice_gmail, 'a1', '<a@x>', 'Alice <alice@x.co>', 'Deploy failed', 'Mon, 01 Jun 2026 10:00:00 +0000', 'down')
 
     bob_gmail = mock('bob')
-    bob_gmail.stubs(:list_user_messages).returns(OpenStruct.new(messages: [ref('b1', 't9'), ref('b2', 't9')], next_page_token: nil))
-    bob_gmail.stubs(:get_user_message).with('me', 'b1', format: 'raw').returns(OpenStruct.new(raw: root))
-    bob_gmail.stubs(:get_user_message).with('me', 'b2', format: 'raw').returns(OpenStruct.new(raw: reply))
+    bob_gmail.stubs(:list_user_messages).returns(one_page(ref('b1'), ref('b2')))
+    stub_msg(bob_gmail, 'b1', '<a@x>', 'Alice <alice@x.co>', 'Deploy failed', 'Mon, 01 Jun 2026 10:00:00 +0000', 'down')
+    stub_msg(bob_gmail, 'b2', '<c@x>', 'Bob <bob@x.co>', 'Re: Deploy failed', 'Mon, 01 Jun 2026 11:00:00 +0000', 'up', '<a@x>')
 
     Stacks::Etl::Meet::Auth.stubs(:gmail_service).with(sub: 'alice@sanctuary.computer').returns(alice_gmail)
     Stacks::Etl::Meet::Auth.stubs(:gmail_service).with(sub: 'bob@sanctuary.computer').returns(bob_gmail)
@@ -120,7 +176,7 @@ class Stacks::Etl::Groups::GroupsSourceTest < ActiveSupport::TestCase
       .returns(['member@sanctuary.computer', 'owner@sanctuary.computer'])
 
     gmail = mock('g')
-    gmail.stubs(:list_user_messages).returns(OpenStruct.new(messages: [], next_page_token: nil))
+    gmail.stubs(:list_user_messages).returns(one_page)
     # k:1 -> ONLY the OWNER mailbox may be crawled (owner beats member; GROUP + inactive excluded).
     Stacks::Etl::Meet::Auth.expects(:gmail_service).with(sub: 'owner@sanctuary.computer').returns(gmail)
 
@@ -160,10 +216,9 @@ class Stacks::Etl::Groups::GroupsSourceTest < ActiveSupport::TestCase
       .returns([{ email: 'alice@sanctuary.computer', role: 'OWNER', type: 'USER' }])
     Stacks::Etl::Meet::Workspace.stubs(:all_active_user_emails).returns(['alice@sanctuary.computer'])
 
-    root = raw('<a@x>', 'Alice <alice@x.co>', 'Deploy failed', 'Mon, 01 Jun 2026 10:00:00 +0000', 'down')
     gmail = mock('g')
-    gmail.stubs(:list_user_messages).returns(OpenStruct.new(messages: [ref('g_a', 't1')], next_page_token: nil))
-    gmail.stubs(:get_user_message).returns(OpenStruct.new(raw: root))
+    gmail.stubs(:list_user_messages).returns(one_page(ref('g_a')))
+    stub_msg(gmail, 'g_a', '<a@x>', 'Alice <alice@x.co>', 'Deploy failed', 'Mon, 01 Jun 2026 10:00:00 +0000', 'down')
     Stacks::Etl::Meet::Auth.stubs(:gmail_service).returns(gmail)
 
     yielded = []
@@ -181,10 +236,9 @@ class Stacks::Etl::Groups::GroupsSourceTest < ActiveSupport::TestCase
     Stacks::Etl::Meet::Workspace.stubs(:all_active_user_emails)
       .returns(['alice@sanctuary.computer', 'bob@sanctuary.computer'])
 
-    root = raw('<a@x>', 'Alice <alice@x.co>', 'Deploy failed', 'Mon, 01 Jun 2026 10:00:00 +0000', 'down')
     good = mock('alice')
-    good.stubs(:list_user_messages).returns(OpenStruct.new(messages: [ref('g_a', 't1')], next_page_token: nil))
-    good.stubs(:get_user_message).returns(OpenStruct.new(raw: root))
+    good.stubs(:list_user_messages).returns(one_page(ref('g_a')))
+    stub_msg(good, 'g_a', '<a@x>', 'Alice <alice@x.co>', 'Deploy failed', 'Mon, 01 Jun 2026 10:00:00 +0000', 'down')
     bad = mock('bob')
     bad.stubs(:list_user_messages).raises(Google::Apis::ClientError.new('no gmail license'))
 

--- a/test/lib/stacks/etl/groups/groups_source_test.rb
+++ b/test/lib/stacks/etl/groups/groups_source_test.rb
@@ -9,7 +9,10 @@ class Stacks::Etl::Groups::GroupsSourceTest < ActiveSupport::TestCase
     "#{h}\r\n#{body}"
   end
 
-  test 'crawls K members, dedups the same message across mailboxes, yields one thread' do
+  # A Gmail message list ref carries an id AND a thread_id (the crawl buckets by thread_id).
+  def ref(id, thread_id) = OpenStruct.new(id: id, thread_id: thread_id)
+
+  test 'dedups a thread received in two mailboxes into one Document (segments unioned once)' do
     Stacks::Etl::Groups::Workspace.stubs(:all_groups).returns([{ email: 'dev@sanctuary.computer', name: 'Dev' }])
     Stacks::Etl::Groups::Workspace.stubs(:members).with('dev@sanctuary.computer').returns([
       { email: 'alice@sanctuary.computer', role: 'OWNER', type: 'USER' },
@@ -19,18 +22,19 @@ class Stacks::Etl::Groups::GroupsSourceTest < ActiveSupport::TestCase
     Stacks::Etl::Meet::Workspace.stubs(:all_active_user_emails)
       .returns(['alice@sanctuary.computer', 'bob@sanctuary.computer'])
 
-    # Both Alice and Bob received the SAME root message <a@x>; Bob also has reply <c@x>.
-    root = raw('<a@x>', 'Alice <alice@x.co>', 'Deploy failed', 'Mon, 01 Jun 2026 10:00:00 +0000', 'down')
+    root  = raw('<a@x>', 'Alice <alice@x.co>', 'Deploy failed', 'Mon, 01 Jun 2026 10:00:00 +0000', 'down')
     reply = raw('<c@x>', 'Bob <bob@x.co>', 'Re: Deploy failed', 'Mon, 01 Jun 2026 11:00:00 +0000', 'up', '<a@x>')
 
+    # Realistic list traffic: BOTH members received BOTH messages of the one thread.
     alice_gmail = mock('alice')
-    alice_gmail.stubs(:list_user_messages).returns(OpenStruct.new(messages: [OpenStruct.new(id: 'g_a')], next_page_token: nil))
-    alice_gmail.stubs(:get_user_message).with('me', 'g_a', format: 'raw').returns(OpenStruct.new(raw: root))
+    alice_gmail.stubs(:list_user_messages).returns(OpenStruct.new(messages: [ref('a1', 't1'), ref('a2', 't1')], next_page_token: nil))
+    alice_gmail.stubs(:get_user_message).with('me', 'a1', format: 'raw').returns(OpenStruct.new(raw: root))
+    alice_gmail.stubs(:get_user_message).with('me', 'a2', format: 'raw').returns(OpenStruct.new(raw: reply))
 
     bob_gmail = mock('bob')
-    bob_gmail.stubs(:list_user_messages).returns(OpenStruct.new(messages: [OpenStruct.new(id: 'g_a2'), OpenStruct.new(id: 'g_c')], next_page_token: nil))
-    bob_gmail.stubs(:get_user_message).with('me', 'g_a2', format: 'raw').returns(OpenStruct.new(raw: root))
-    bob_gmail.stubs(:get_user_message).with('me', 'g_c', format: 'raw').returns(OpenStruct.new(raw: reply))
+    bob_gmail.stubs(:list_user_messages).returns(OpenStruct.new(messages: [ref('b1', 't9'), ref('b2', 't9')], next_page_token: nil))
+    bob_gmail.stubs(:get_user_message).with('me', 'b1', format: 'raw').returns(OpenStruct.new(raw: root))
+    bob_gmail.stubs(:get_user_message).with('me', 'b2', format: 'raw').returns(OpenStruct.new(raw: reply))
 
     Stacks::Etl::Meet::Auth.stubs(:gmail_service).with(sub: 'alice@sanctuary.computer').returns(alice_gmail)
     Stacks::Etl::Meet::Auth.stubs(:gmail_service).with(sub: 'bob@sanctuary.computer').returns(bob_gmail)
@@ -38,10 +42,70 @@ class Stacks::Etl::Groups::GroupsSourceTest < ActiveSupport::TestCase
     yielded = []
     Stacks::Etl::Groups::GroupsSource.new(admin_email: 'hugh@sanctuary.computer', k: 2).each_thread { |n| yielded << n }
 
-    assert_equal 1, yielded.size, 'the duplicate root across two mailboxes must collapse to one thread'
+    assert_equal 1, yielded.size, "the second mailbox's copy of the thread must dedup away by Message-ID"
     d = yielded.first
     assert_equal '<a@x>', d[:external_id]
     assert_equal ['down', 'up'], d[:segments].map { |s| s[:text] }
+  end
+
+  test 'streams one Document per Gmail thread (bounded, incremental)' do
+    Stacks::Etl::Groups::Workspace.stubs(:all_groups).returns([{ email: 'dev@sanctuary.computer', name: 'Dev' }])
+    Stacks::Etl::Groups::Workspace.stubs(:members).with('dev@sanctuary.computer')
+      .returns([{ email: 'alice@sanctuary.computer', role: 'OWNER', type: 'USER' }])
+    Stacks::Etl::Meet::Workspace.stubs(:all_active_user_emails).returns(['alice@sanctuary.computer'])
+
+    t1 = raw('<a@x>', 'Alice <alice@x.co>', 'Deploy failed', 'Mon, 01 Jun 2026 10:00:00 +0000', 'down')
+    t2 = raw('<b@x>', 'Alice <alice@x.co>', 'Lunch?', 'Mon, 02 Jun 2026 10:00:00 +0000', 'tacos')
+
+    gmail = mock('g')
+    # Two DISTINCT Gmail threads in one list page — must yield as two separate Documents.
+    gmail.stubs(:list_user_messages).returns(OpenStruct.new(messages: [ref('m1', 't1'), ref('m2', 't2')], next_page_token: nil))
+    gmail.stubs(:get_user_message).with('me', 'm1', format: 'raw').returns(OpenStruct.new(raw: t1))
+    gmail.stubs(:get_user_message).with('me', 'm2', format: 'raw').returns(OpenStruct.new(raw: t2))
+    Stacks::Etl::Meet::Auth.stubs(:gmail_service).returns(gmail)
+
+    yielded = []
+    Stacks::Etl::Groups::GroupsSource.new(admin_email: 'hugh@sanctuary.computer', k: 1).each_thread { |n| yielded << n }
+
+    assert_equal 2, yielded.size, 'two distinct Gmail threads -> two Documents, streamed separately'
+    assert_equal ['<a@x>', '<b@x>'], yielded.map { |n| n[:external_id] }.sort
+    assert(yielded.all? { |d| d[:segments].size == 1 })
+  end
+
+  test 'owner-first streaming: a later mailbox extra message on an already-seen thread is not merged' do
+    # alice (OWNER) has only the root; bob (MEMBER) has root + a reply. Under streaming union,
+    # alice's copy of the thread is emitted first, and bob's extra reply for that same root is
+    # deduped-by-root and dropped. This is the deliberate trade for bounded memory — locked
+    # here so it reads as intentional, not a regression.
+    Stacks::Etl::Groups::Workspace.stubs(:all_groups).returns([{ email: 'dev@sanctuary.computer', name: 'Dev' }])
+    Stacks::Etl::Groups::Workspace.stubs(:members).with('dev@sanctuary.computer').returns([
+      { email: 'alice@sanctuary.computer', role: 'OWNER', type: 'USER' },
+      { email: 'bob@sanctuary.computer', role: 'MEMBER', type: 'USER' }
+    ])
+    Stacks::Etl::Meet::Workspace.stubs(:all_active_user_emails)
+      .returns(['alice@sanctuary.computer', 'bob@sanctuary.computer'])
+
+    root  = raw('<a@x>', 'Alice <alice@x.co>', 'Deploy failed', 'Mon, 01 Jun 2026 10:00:00 +0000', 'down')
+    reply = raw('<c@x>', 'Bob <bob@x.co>', 'Re: Deploy failed', 'Mon, 01 Jun 2026 11:00:00 +0000', 'up', '<a@x>')
+
+    alice_gmail = mock('alice')
+    alice_gmail.stubs(:list_user_messages).returns(OpenStruct.new(messages: [ref('a1', 't1')], next_page_token: nil))
+    alice_gmail.stubs(:get_user_message).with('me', 'a1', format: 'raw').returns(OpenStruct.new(raw: root))
+
+    bob_gmail = mock('bob')
+    bob_gmail.stubs(:list_user_messages).returns(OpenStruct.new(messages: [ref('b1', 't9'), ref('b2', 't9')], next_page_token: nil))
+    bob_gmail.stubs(:get_user_message).with('me', 'b1', format: 'raw').returns(OpenStruct.new(raw: root))
+    bob_gmail.stubs(:get_user_message).with('me', 'b2', format: 'raw').returns(OpenStruct.new(raw: reply))
+
+    Stacks::Etl::Meet::Auth.stubs(:gmail_service).with(sub: 'alice@sanctuary.computer').returns(alice_gmail)
+    Stacks::Etl::Meet::Auth.stubs(:gmail_service).with(sub: 'bob@sanctuary.computer').returns(bob_gmail)
+
+    yielded = []
+    Stacks::Etl::Groups::GroupsSource.new(admin_email: 'hugh@sanctuary.computer', k: 2).each_thread { |n| yielded << n }
+
+    assert_equal 1, yielded.size
+    assert_equal ['down'], yielded.first[:segments].map { |s| s[:text] },
+                 'only the owner-mailbox copy is kept once the root is already seen'
   end
 
   test 'pick_crawlers prefers owners, caps at k, excludes non-USER and inactive members' do
@@ -98,7 +162,7 @@ class Stacks::Etl::Groups::GroupsSourceTest < ActiveSupport::TestCase
 
     root = raw('<a@x>', 'Alice <alice@x.co>', 'Deploy failed', 'Mon, 01 Jun 2026 10:00:00 +0000', 'down')
     gmail = mock('g')
-    gmail.stubs(:list_user_messages).returns(OpenStruct.new(messages: [OpenStruct.new(id: 'g_a')], next_page_token: nil))
+    gmail.stubs(:list_user_messages).returns(OpenStruct.new(messages: [ref('g_a', 't1')], next_page_token: nil))
     gmail.stubs(:get_user_message).returns(OpenStruct.new(raw: root))
     Stacks::Etl::Meet::Auth.stubs(:gmail_service).returns(gmail)
 
@@ -119,7 +183,7 @@ class Stacks::Etl::Groups::GroupsSourceTest < ActiveSupport::TestCase
 
     root = raw('<a@x>', 'Alice <alice@x.co>', 'Deploy failed', 'Mon, 01 Jun 2026 10:00:00 +0000', 'down')
     good = mock('alice')
-    good.stubs(:list_user_messages).returns(OpenStruct.new(messages: [OpenStruct.new(id: 'g_a')], next_page_token: nil))
+    good.stubs(:list_user_messages).returns(OpenStruct.new(messages: [ref('g_a', 't1')], next_page_token: nil))
     good.stubs(:get_user_message).returns(OpenStruct.new(raw: root))
     bad = mock('bob')
     bad.stubs(:list_user_messages).raises(Google::Apis::ClientError.new('no gmail license'))

--- a/test/lib/stacks/etl/groups/groups_source_test.rb
+++ b/test/lib/stacks/etl/groups/groups_source_test.rb
@@ -164,6 +164,25 @@ class Stacks::Etl::Groups::GroupsSourceTest < ActiveSupport::TestCase
                  'only the owner-mailbox copy is kept once the root is already seen'
   end
 
+  test 'a message whose metadata has no Message-ID header is skipped, not crashed or misgrouped' do
+    Stacks::Etl::Groups::Workspace.stubs(:all_groups).returns([{ email: 'dev@sanctuary.computer', name: 'Dev' }])
+    Stacks::Etl::Groups::Workspace.stubs(:members).with('dev@sanctuary.computer')
+      .returns([{ email: 'alice@sanctuary.computer', role: 'OWNER', type: 'USER' }])
+    Stacks::Etl::Meet::Workspace.stubs(:all_active_user_emails).returns(['alice@sanctuary.computer'])
+
+    gmail = mock('g')
+    gmail.stubs(:list_user_messages).returns(one_page(ref('g_ok'), ref('g_bad')))
+    stub_msg(gmail, 'g_ok', '<a@x>', 'Alice <alice@x.co>', 'Deploy failed', 'Mon, 01 Jun 2026 10:00:00 +0000', 'down')
+    # g_bad: metadata present but NO Message-ID header -> must be skipped in pass 1 (never body-fetched).
+    gmail.stubs(:get_user_message).with('me', 'g_bad', format: 'metadata', metadata_headers: META)
+         .returns(OpenStruct.new(payload: OpenStruct.new(headers: [OpenStruct.new(name: 'Subject', value: 'no id')])))
+    Stacks::Etl::Meet::Auth.stubs(:gmail_service).returns(gmail)
+
+    yielded = []
+    Stacks::Etl::Groups::GroupsSource.new(admin_email: 'hugh@sanctuary.computer', k: 1).each_thread { |n| yielded << n }
+    assert_equal ['<a@x>'], yielded.map { |n| n[:external_id] }, 'the id-less message is dropped; the valid one still ingests'
+  end
+
   test 'pick_crawlers prefers owners, caps at k, excludes non-USER and inactive members' do
     Stacks::Etl::Groups::Workspace.stubs(:all_groups).returns([{ email: 'dev@sanctuary.computer', name: 'Dev' }])
     Stacks::Etl::Groups::Workspace.stubs(:members).with('dev@sanctuary.computer').returns([

--- a/test/lib/stacks/etl/groups/message_parser_test.rb
+++ b/test/lib/stacks/etl/groups/message_parser_test.rb
@@ -78,4 +78,21 @@ class Stacks::Etl::Groups::MessageParserTest < ActiveSupport::TestCase
     assert_includes m[:body], 'looking into it now'
     refute_includes m[:body], 'old quoted line', 'the quoted tail after "On ... wrote:" must be removed'
   end
+
+  # root_id_from is the shared key used by BOTH the raw parse (mail-gem values: References is an
+  # Array of bare ids, or a String for one) AND the crawl's pass-1 metadata pass (raw header
+  # value: a single space-joined String WITH angle brackets). Both must derive the identical
+  # root or cross-mailbox dedup and the split-thread fix break.
+  test 'root_id_from derives the identical root from the raw-metadata string and the mail-gem array shapes' do
+    assert_equal '<a@x>', P.root_id_from(message_id: '<c@x>', references: '<a@x> <b@x>'), 'metadata string, multi-ref'
+    assert_equal '<a@x>', P.root_id_from(message_id: '<c@x>', references: ['a@x', 'b@x']), 'mail-gem array, multi-ref'
+    assert_equal '<a@x>', P.root_id_from(message_id: '<c@x>', references: 'a@x'), 'mail-gem single-ref String'
+  end
+
+  test 'root_id_from falls back In-Reply-To -> self, and is nil with nothing' do
+    assert_equal '<a@x>', P.root_id_from(message_id: '<c@x>', references: nil, in_reply_to: '<a@x>')
+    assert_equal '<a@x>', P.root_id_from(message_id: '<c@x>', references: '   ', in_reply_to: '<a@x> <b@x>'), 'blank refs -> first In-Reply-To'
+    assert_equal '<r@x>', P.root_id_from(message_id: '<r@x>'), 'no refs / no in-reply-to -> the message is its own root'
+    assert_nil P.root_id_from(message_id: '')
+  end
 end


### PR DESCRIPTION
## Streaming, thread-correct Google Groups crawl (+ retry hardening)

Follow-up to #130. The initial backfill stalled on a firehose list (`admin@`: ~9.5k msgs/mailbox/yr) because the crawl buffered a group's entire year of mail into memory before yielding any thread. This reworks the crawl and hardens it, validated through **three adversarial review rounds** (each caught a real issue) + live smoke tests.

### What changed
- **Streaming, memory-bounded crawl.** Per mailbox: a cheap metadata pass groups messages by **RFC822 root** (not Gmail `thread_id` — Gmail splits conversations on subject drift, which would silently drop replies), then bodies are fetched one thread at a time and yielded incrementally. Peak memory = one thread + a per-mailbox id index. `MessageParser.root_id_from` is shared by the raw parse and the metadata pass so both derive the identical root.
- **Retry/backoff** (`request_options.retries=5`) on the Gmail + Directory services — google-apis-core defaults to 0 retries, so a transient 429/5xx was silently dropping messages. Now recovers via exponential backoff; per-item rescue only drops permanent errors.
- **Backfill runs `k:1`** (owner mailbox) — the two-pass already costs ~2 gets/msg and a 2nd crawler mostly re-fetches messages that dedup away. Nightly sync keeps `k:2` on its tiny window.
- **Quieted `Google::Apis.logger`** (WARN) so the crawl stops dumping email bodies into prod logs (app stays `:debug`).

### Review loop (adversarial)
- **R1:** caught silent message loss — bucketing by `thread_id` but deduping by `root_id`. Fixed (group by root, two-pass).
- **R2:** confirmed the fix; caught the no-retry silent-drop. Fixed (retries + k:1 + test gaps).
- **R3:** verdict **SHIP** — fixes real & correct against the actual google-apis-core API, Meet ETL isolated, no new issues.

### Tests
Full ETL suite green (142 runs / 420 assertions). New tests: root-split-across-Gmail-threads regression, list pagination, `root_id_from` dual-shape, missing-Message-ID skip, retries config. Live-validated on real Gmail (streaming first-doc 21.8s vs ~26 min; two-pass yields correct Documents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
