### PR TITLE
get_document: source + root_message_id (Google Groups backlinks)

### DIFF
--- a/app/services/mcp/get_document_tool.rb
+++ b/app/services/mcp/get_document_tool.rb
@@ -17,8 +17,12 @@ module Mcp
       # segments) is still readable. Callers prefer `segments` for transcripts, `body` for notes.
       body = doc.chunks.order(:position).pluck(:content).join("\n")
       meeting_key = is_meeting ? meeting.id : nil
+      # google_groups: expose the RFC822 root Message-ID (external_id) so an observing agent can
+      # build the precise Gmail deep link (rfc822msgid:<id>). url already carries the group.
+      extra = doc.google_groups? ? { root_message_id: doc.external_id } : {}
       Responses.ok({ id: doc.id, title: doc.title, url: doc.url, occurred_at: doc.occurred_at,
-                     meeting_key: meeting_key, segments: segments, body: body })
+                     source: doc.source, meeting_key: meeting_key, segments: segments, body: body }
+                   .merge(extra))
     end
   end
 end

--- a/docs/optix-member-deactivation-dry-run.md
+++ b/docs/optix-member-deactivation-dry-run.md
@@ -1,0 +1,178 @@
+# Optix: Automated Deactivation of Inactive Members — Dry Run for Team Review
+
+**Status: awaiting team sign-off — no changes have been made to Optix.**
+
+- Dry run performed: **July 10, 2026** (read-only queries against the live Optix API)
+- Proposed by: Stacks automation (`stacks:daily_enterprise_tasks`)
+- Applies to: Index Space's Optix organization
+
+---
+
+## What we're proposing
+
+A daily automated task in Stacks that deactivates (removes) Optix members who no
+longer hold a membership. Today these people accumulate forever as "active" users
+in Optix — 541 active users, of which only ~450 hold a current plan.
+
+Once approved and deployed, this runs automatically every day as part of the
+existing Stacks daily task pipeline. Members removed this way can rejoin at any
+time — re-adding a user with the same email reactivates their existing Optix
+account (booking history, profile, etc. are retained by Optix).
+
+## The rules
+
+A member is deactivated when **all** of the following are true:
+
+1. They are currently an **active user** in Optix.
+2. They have held **at least one membership plan** in the past
+   (people who never had a plan — leads, contacts — are never touched).
+3. They have **no ACTIVE or IN_TRIAL plan** right now.
+4. Their most recent plan **ended or was canceled more than 7 days ago**
+   (the grace period protects people between billing cycles or mid-rejoin).
+5. They are **not an Optix admin**.
+
+Mechanics: removal happens via Optix's official `memberRemove` API with
+`collect_payment: true` — meaning if the member has any pending charges, Optix
+creates an invoice due immediately as part of the removal. This is the same
+operation as clicking "remove member" in the Optix admin dashboard.
+
+## Dry run results
+
+Snapshot of who would be deactivated **if the automation ran today**:
+
+| | |
+|---|---|
+| Total users in Optix | 541 |
+| Would be deactivated today | **75** |
+| Skipped — plan ended within the last 7 days | 2 |
+| Skipped — Optix admin | 1 (Hugh Francis) |
+
+After this first run clears the backlog, the daily run will typically
+deactivate 0–2 people per day (members whose plans ended 8 days prior).
+
+### The 75 members who would be deactivated today
+
+| # | Name | Email | Last plan | Plan status | Ended | Days ago |
+|---|------|-------|-----------|-------------|-------|----------|
+| 1 | Charles Broskoski | cab@are.na | Dedicated Desk (presale) | ENDED | 2023-08-31 | 1043 |
+| 2 | emma warren | 092emma@gmail.com | [Chinatown] Friend | ENDED | 2024-08-11 | 697 |
+| 3 | May Shek | may@boundlessstud.io | [Chinatown] Regular | ENDED | 2024-11-22 | 594 |
+| 4 | Myles Larson | mail@myleslarson.com | [Chinatown] Patron | ENDED | 2024-12-13 | 573 |
+| 5 | Bianca Bramham | bianca@jackywinter.com | [Chinatown] Regular | ENDED | 2025-01-07 | 548 |
+| 6 | Pooja Nitturkar | pooja.nitt@gmail.com | [Chinatown] Regular | ENDED | 2025-01-19 | 536 |
+| 7 | Cory Etzkorn | coryetzkorn@gmail.com | [Chinatown] Patron | ENDED | 2025-02-09 | 515 |
+| 8 | Lucy McKendrick | lucymckendrick@gmail.com | [Chinatown] Fellow | ENDED | 2025-03-09 | 487 |
+| 9 | Cheryl Kao | cheryl@monopo.nyc | [Chinatown] Patron | ENDED | 2025-04-15 | 450 |
+| 10 | Lucy Dayman | lucy@nowhere-nyc.com | [Chinatown] Friend | ENDED | 2025-06-05 | 399 |
+| 11 | Liam Fitzgerald | lfitz258@gmail.com | [Chinatown] Friend | ENDED | 2025-07-28 | 346 |
+| 12 | Annie Zhang | annie.zhang@sanctuary.computer | [Chinatown] Fellow | ENDED | 2025-07-28 | 346 |
+| 13 | Jess De-Graft Quansah | degrj277@newschool.edu | [Chinatown] Friend | ENDED | 2025-08-01 | 342 |
+| 14 | andrew fu | andrewwfu@gmail.com | [Chinatown] Friend | ENDED | 2025-08-12 | 331 |
+| 15 | Nikki D'Ambrosio | naturallynicoletta@gmail.com | [Greenpoint] Regular | CANCELED | 2025-10-23 | 260 |
+| 16 | Rose Rutledge | Rose.rutledge@output.com | Output 4x | ENDED | 2025-11-14 | 237 |
+| 17 | Ane Aranburu | ane.aranburu@output.com | Output 4x | ENDED | 2025-11-14 | 237 |
+| 18 | Rishin Doshi | rishin.doshi@output.com | Output 4x | ENDED | 2025-11-14 | 237 |
+| 19 | Frankie DeGruy | francesadegruy@gmail.com | [Greenpoint] Regular | ENDED | 2025-12-05 | 216 |
+| 20 | Kelly Cavender | kellycavender5@gmail.com | [Greenpoint] Regular | ENDED | 2025-12-07 | 214 |
+| 21 | Sonya Gimon | sgimon@3fwild.com | [Chinatown] Fellow | ENDED | 2025-12-07 | 214 |
+| 22 | Alex Darby | alex@thehybrid.studio | [Chinatown] Regular | ENDED | 2025-12-07 | 214 |
+| 23 | Lauren Slowik | laurenlaceyslowik@gmail.com | [Greenpoint] Regular | ENDED | 2025-12-09 | 212 |
+| 24 | Tina Smith | hello@tinasmith.studio | [Greenpoint] Patron | ENDED | 2025-12-15 | 206 |
+| 25 | B Milder | b@bmilder.studio | [Greenpoint] Patron | CANCELED | 2025-12-16 | 205 |
+| 26 | aliya donn | aliya@kernel.community | [Greenpoint] Friend | ENDED | 2025-12-16 | 205 |
+| 27 | Mac Watrous | macwatrous@gmail.com | [Chinatown] Patron | ENDED | 2025-12-17 | 204 |
+| 28 | emily um | emilyum16@gmail.com | [Greenpoint] Regular | ENDED | 2025-12-19 | 202 |
+| 29 | Alessandro Amato | alessandro@neuehaus.io | [Chinatown] Regular | ENDED | 2025-12-24 | 197 |
+| 30 | Lena Pia Hammerstingl | lenapia@neuehaus.io | [Chinatown] Regular | ENDED | 2025-12-24 | 197 |
+| 31 | Gemma C | astrayproject@proton.me | [Chinatown] Fellow | ENDED | 2025-12-30 | 191 |
+| 32 | Kyra Levau | kyramlevau@gmail.com | $140 | ENDED | 2025-12-31 | 190 |
+| 33 | Tomas Markevicius | hi.tomasm@gmail.com | [Chinatown] Friend | ENDED | 2025-12-31 | 190 |
+| 34 | Michelle Belgrod | michelle.belgrod@gmail.com | [Greenpoint] Fellow | ENDED | 2026-01-09 | 181 |
+| 35 | Marisa Rowland | mhoperowland@gmail.com | [Chinatown] Patron | ENDED | 2026-01-09 | 181 |
+| 36 | kendal kulley | kendal@daisy.so | [Chinatown] Patron | ENDED | 2026-01-11 | 179 |
+| 37 | Victor Pedraza | vpedrazalopez@gmail.com | [Greenpoint] Regular | CANCELED | 2026-01-12 | 178 |
+| 38 | Alexandra Bendek | alexandra.bendek@gmail.com | [Greenpoint] Regular | ENDED | 2026-01-19 | 171 |
+| 39 | Linda Yang | linda@culturalcounsel.com | [Greenpoint] Regular | ENDED | 2026-01-24 | 166 |
+| 40 | Adam Ziel | adam@ziel.today | [Chinatown] Patron | ENDED | 2026-01-26 | 164 |
+| 41 | David Dellamura | david@ddbaagency.com | [Greenpoint] Regular | ENDED | 2026-01-30 | 160 |
+| 42 | Maddie Woods | madelinewoods@icloud.com | [Chinatown] Regular | ENDED | 2026-01-30 | 160 |
+| 43 | Colton Brown | c@lt.email | [Chinatown] Regular | ENDED | 2026-02-04 | 155 |
+| 44 | Lauren Wagner | laurenbwagner@gmail.com | [Chinatown] Friend | ENDED | 2026-02-07 | 152 |
+| 45 | Laura Lu | lauraelu@gmail.com | [Greenpoint] Regular | ENDED | 2026-02-23 | 136 |
+| 46 | Andy Nagashima | andykainagashima@gmail.com | [Greenpoint] Patron | ENDED | 2026-02-24 | 135 |
+| 47 | Angelica Moody | angelicamoody3@gmail.com | [Greenpoint] Friend | ENDED | 2026-02-27 | 132 |
+| 48 | Artem Ivanov | ivanovart8@gmail.com | [Chinatown] Regular | ENDED | 2026-02-27 | 132 |
+| 49 | Megan Arizmendi | mearizmendi1@gmail.com | [Chinatown] Friend | ENDED | 2026-03-03 | 128 |
+| 50 | Mary Bibbey | mary@joinorderly.com | Discounted Fellow Plan | ENDED | 2026-03-13 | 118 |
+| 51 | Jessica Dimcevski | Jessica@blurrbureau.com | [Greenpoint] Week Pass | ENDED | 2026-03-23 | 108 |
+| 52 | Ned Hardy | ned@two.studio | [Chinatown] Fellow | ENDED | 2026-03-24 | 107 |
+| 53 | Lucy Dellar | lucy.dellar@gmail.com | [Chinatown] Friend | ENDED | 2026-03-24 | 107 |
+| 54 | Erik Ruuska | erikruuska@gmail.com | [Chinatown] Friend | ENDED | 2026-03-31 | 100 |
+| 55 | Andres Rabellino | andres.rabellino@gmail.com | [Greenpoint] Fellow | ENDED | 2026-04-01 | 99 |
+| 56 | Daniel Morrow | danmorrow@gmail.com | [Greenpoint] Friend | ENDED | 2026-04-01 | 99 |
+| 57 | Drew Litowitz | dlitowit@gmail.com | [Greenpoint] Friend | ENDED | 2026-04-10 | 90 |
+| 58 | Max Smouha | maxsmouha@gmail.com | [Chinatown] Regular | ENDED | 2026-04-16 | 84 |
+| 59 | Steven Phillips | hello@steven-phillips.com | [Greenpoint] Friend | ENDED | 2026-04-25 | 75 |
+| 60 | Francis Barth | francis@trestle.inc | [Chinatown] Regular | ENDED | 2026-04-27 | 73 |
+| 61 | Sam Wlody | swlody@gmail.com | [Greenpoint] Friend | ENDED | 2026-04-28 | 72 |
+| 62 | Sophie Chen | sophie@offmenumag.com | Weekly Pass | ENDED | 2026-05-02 | 68 |
+| 63 | Morry Kolman | wttdotm@gmail.com | [Chinatown] Fellow | ENDED | 2026-05-10 | 60 |
+| 64 | Lauren McCurry | lauren@ballet-season.com | [Chinatown] Friend | ENDED | 2026-05-13 | 57 |
+| 65 | Claire Gustavson | claire.gustavson@gmail.com | [Greenpoint] Fellow | ENDED | 2026-05-15 | 55 |
+| 66 | Rita Juarez | rita@ritajuarez.com | [Greenpoint] Patron | ENDED | 2026-05-16 | 54 |
+| 67 | diego funken | diego@funken.work | [Greenpoint] Patron | ENDED | 2026-05-20 | 50 |
+| 68 | Nico Salinas | nico@funken.work | [Greenpoint] Patron | ENDED | 2026-05-20 | 50 |
+| 69 | Daniel Brenners | danbrenners@gmail.com | [Greenpoint] Friend | ENDED | 2026-05-27 | 43 |
+| 70 | Ben Perez | benperez1227@gmail.com | 2 Weeks | ENDED | 2026-05-29 | 41 |
+| 71 | Aaron Free | aaa2141@gmail.com | [Chinatown] Friend | ENDED | 2026-05-31 | 39 |
+| 72 | Jackson Strambi | jackson@seekeasy.ai | [Chinatown] Fellow | ENDED | 2026-06-05 | 34 |
+| 73 | Hoyd Breton | hi@hoydbreton.com | [Greenpoint] Patron | ENDED | 2026-06-19 | 20 |
+| 74 | Andy Lee | andylulee1013@gmail.com | [Chinatown] Patron | ENDED | 2026-06-22 | 17 |
+| 75 | Roman Bellisari | romanbellisari@gmail.com | [Chinatown] Fellow | ENDED | 2026-06-30 | 9 |
+
+### Skipped — within the 7-day grace period (would be deactivated in the coming days)
+
+2 members whose plans ended fewer than 8 days ago. They'll be picked up by a
+future daily run if they don't renew.
+
+### Skipped — Optix admins
+
+| Name | Email | Last plan | Ended | Days ago |
+|------|-------|-----------|-------|----------|
+| Hugh Francis | hugh@sanctuary.computer | [Chinatown] Patron | 2026-04-16 | 84 |
+
+## What deactivation does (and doesn't do)
+
+- **Does:** removes the member from the Optix organization — they lose app and
+  space access, and stop appearing as an active member. If they have pending
+  charges, an invoice is created and due immediately (`collect_payment: true`).
+- **Doesn't:** delete their account or history. Optix retains the user; adding
+  them again by email reactivates them.
+- **Reversible:** yes — any removal can be undone by re-inviting the member.
+
+## Safeguards
+
+- Never touches Optix admins.
+- Never touches anyone who never held a plan (leads/contacts are out of scope).
+- 7-day grace period after a plan ends.
+- Each daily run logs exactly who was deactivated; failures are reported through
+  Stacks' existing error reporting (Sentry + SystemTask status).
+- Runs only for the Index Space enterprise inside `stacks:daily_enterprise_tasks`.
+
+## Questions for the team before we deploy
+
+1. Does anyone on the list above need to stay active (e.g. informal arrangements,
+   staff on comp'd access, partners)? Reply with names and we'll remove them from
+   the first run — and tell us the rule so we can encode it.
+2. Is `collect_payment: true` right? Anyone on this list with lingering pending
+   charges will get an invoice due immediately when they're removed.
+3. Is 7 days the right grace period?
+
+## Sign-off
+
+- [ ] Index Space team lead
+- [ ] Operations
+- [ ] Engineering
+
+Once checked off, engineering will deploy the automation and it will begin
+running daily.

--- a/docs/superpowers/plans/2026-07-10-google-groups-observations-source.md
+++ b/docs/superpowers/plans/2026-07-10-google-groups-observations-source.md
@@ -1,0 +1,159 @@
+# Google Groups Observations Source — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Make the Google Groups email corpus an *observed* source in stacksbot — salient threads become Notion Observations with an accurate Gmail backlink.
+
+**Architecture:** Part A adds one field (`root_message_id`) to the stacks `get_document` MCP response so an observing agent can build the precise `rfc822msgid` backlink. Part B authors Notion rows in stacksbot (a `google-groups` Sources row + a disabled `Observe: Google Groups` Job) and one rubric line — no stacksbot code; the sync reconcilers materialize them.
+
+**Tech Stack:** Ruby on Rails 6.1 (stacks MCP tools, Minitest); Notion (stacksbot Sources/Jobs DBs + `observe` skill) via the Notion MCP.
+
+## Global Constraints
+
+- `get_document` response for a `google_groups` doc MUST include `root_message_id == doc.external_id` and `source == "google_groups"`; for non-Groups docs `root_message_id` is omitted and `meeting_key`/`segments` are unchanged.
+- Do NOT change `Document#url` (avoids a 39k-row backfill; agent builds the Gmail link from `root_message_id`). Do NOT expose `group_email` (`url` already carries the group).
+- Source Key format: `stacks:groups:<root_message_id>`. Observation `Source` value: `Google Groups` (plain — no per-group tag).
+- Backlink Source Ref: primary `https://mail.google.com/mail/#search/rfc822msgid:<URL-encoded root_message_id>`; secondary = the doc's `url`.
+- Scope: all groups (no denylist); forward-only rolling **7-day** window on `occurred_at`; thread-grain.
+- Notion rows authored **Draft/disabled** (Sources `Status: Draft`; Job Enable unchecked). Nothing activates until `observe` is enabled org-wide.
+- Notion DB IDs: Sources `9090b15496114236ba7a641d660c6e8c`; Jobs `329131fea2c78015ba3eed7476974b9b`; Observations `390131fea2c7808bb216c38b46c3ba55`.
+
+---
+
+## Part A — stacks MCP change
+
+### Task 1: `get_document` returns `root_message_id` (+ `source`) for Groups docs
+
+**Files:**
+- Modify: `app/services/mcp/get_document_tool.rb`
+- Test: `test/services/mcp/get_document_tool_test.rb` (create if absent; else add to the existing MCP tool test)
+
+**Interfaces:**
+- Produces: `get_document(id)` response now includes `source:` always, and `root_message_id:` for `google_groups` docs (= `Document#external_id`).
+
+- [ ] **Step 1: Write the failing test**
+
+```ruby
+# test/services/mcp/get_document_tool_test.rb
+require 'test_helper'
+
+class Mcp::GetDocumentToolTest < ActiveSupport::TestCase
+  test 'google_groups doc exposes root_message_id and source; meet doc does not expose root_message_id' do
+    gg = Document.create!(source: :google_groups, external_id: '<root@x>',
+                          excluded: :not_excluded, excluded_reason: :none,
+                          url: 'https://groups.google.com/a/sanctuary.computer/g/dev', title: 'T')
+    gg.chunks.create!(source: :google_groups, position: 0, content: 'hello')
+    res = Mcp::GetDocumentTool.call(id: gg.id, server_context: nil)
+    payload = res[:content] ? JSON.parse(res[:content].first[:text], symbolize_names: true) : res
+    assert_equal '<root@x>', payload[:root_message_id]
+    assert_equal 'google_groups', payload[:source]
+    assert_equal [], payload[:segments]
+
+    m = Meeting.create!(meet_source: :meet_api, meet_conference_record_id: 'cr/z')
+    md = Document.create!(source: :meet, external_id: 'cr/z', source_record: m,
+                          excluded: :not_excluded, excluded_reason: :none, title: 'M')
+    md.chunks.create!(source: :meet, position: 0, content: 'hi')
+    mres = Mcp::GetDocumentTool.call(id: md.id, server_context: nil)
+    mpayload = mres[:content] ? JSON.parse(mres[:content].first[:text], symbolize_names: true) : mres
+    assert_nil mpayload[:root_message_id]
+    assert_equal 'meet', mpayload[:source]
+  end
+end
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `bin/rails test test/services/mcp/get_document_tool_test.rb`
+Expected: FAIL — `root_message_id`/`source` missing from the payload.
+(If `Responses.ok` shape differs, adjust how `payload` is extracted — inspect one real `Mcp::GetDocumentTool.call` return first and match it; keep the assertions.)
+
+- [ ] **Step 3: Implement**
+
+In `app/services/mcp/get_document_tool.rb`, replace the final `Responses.ok({...})` with:
+
+```ruby
+      extra = doc.google_groups? ? { root_message_id: doc.external_id } : {}
+      Responses.ok({ id: doc.id, title: doc.title, url: doc.url, occurred_at: doc.occurred_at,
+                     source: doc.source, meeting_key: meeting_key, segments: segments, body: body }
+                   .merge(extra))
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bin/rails test test/services/mcp/get_document_tool_test.rb`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/mcp/get_document_tool.rb test/services/mcp/get_document_tool_test.rb
+git commit -m "feat(mcp): get_document returns source + root_message_id (for Groups backlinks)"
+```
+
+### Task 1b: Ship Part A
+
+- [ ] Run the MCP tool suite: `bin/rails test test/services/mcp/` — expect green.
+- [ ] Push branch `groups-observations-source`, open PR to `main`, merge, deploy (`git push production main`), verify the release SHA. (No migration.)
+- [ ] Smoke: `heroku run rails runner "puts Mcp::GetDocumentTool.call(id: Document.google_groups.first.id, server_context: nil).inspect" --app g3d-stacks` → response includes `root_message_id`.
+
+---
+
+## Part B — stacksbot / Notion authoring (via Notion MCP)
+
+> These tasks author Notion rows/skill text; "verification" replaces unit tests. Fetch each DB's schema first (`notion-fetch` on the DB id) so property names/types are exact before writing.
+
+### Task 2: Sources DB row — `Google Groups`
+
+**Files:** none (Notion). Target DB `9090b15496114236ba7a641d660c6e8c`.
+
+- [ ] **Step 1:** `notion-fetch` the Sources DB (`9090b15496114236ba7a641d660c6e8c`) to read its property schema and open an existing row (e.g. Twist) to copy the exact property names + `## Fetch`/`## Source Key`/`## Source Ref`/`## Search`/`## Cite` body structure.
+
+- [ ] **Step 2:** Create a new page in the Sources DB with properties: `Name = "Google Groups"`, `Slug = "google-groups"`, `Backing Tool = "stacks MCP"`, `Cite Label = "Google Groups"`, `Status = "Draft"` (match the real property names/types from Step 1). Body = the contract verbatim from the spec §B1 (Fetch, Source Key `stacks:groups:<root_message_id>`, the two Source Ref links, Search/Cite stubs).
+
+- [ ] **Step 3 (verify):** `notion-fetch` the new row; confirm properties + body render, and that the body headings match the level the `sources-reconciler` expects (from the Twist row you copied). Confirm `Status = Draft` (won't materialize into the always-loaded `sources` skill until `Active`).
+
+### Task 3: Jobs DB row — `Observe: Google Groups` (disabled)
+
+**Files:** none (Notion). Target DB `329131fea2c78015ba3eed7476974b9b`.
+
+- [ ] **Step 1:** `notion-fetch` the Jobs DB and an existing "Observe: …" job (or the Twist observe job) to copy property names (`Name`, `Cron`, `Deliver To`, the Enable/Active checkbox) and the body template.
+
+- [ ] **Step 2:** Create a new Job page: `Name = "Observe: Google Groups"`, `Cron = "0 6 * * *"`, `Deliver To = "none"`, Enable/Active **unchecked**. Body = spec §B2 (load `observe`, run for `google-groups`, Output → Observations DB, Deliver To none).
+
+- [ ] **Step 3 (verify):** `notion-fetch` the job; confirm it is **disabled** (so the cron reconciler will not schedule it) and the source slug in the body is `google-groups`.
+
+### Task 4: Rubric tuning in the `observe` skill
+
+**Files:** none (Notion). The `observe` skill lives in the stacksbot Skills DB (materialized to `workspace/skills/observe/SKILL.md`).
+
+- [ ] **Step 1:** Locate the `observe` skill in Notion (search the Skills DB for "observe"). Read its Salience rubric section.
+
+- [ ] **Step 2:** Add two lines to the rubric (do not restructure): (a) "Automated/transactional/notification mail (Sentry, CI/deploy, QuickBooks, Mailchimp, calendar invites, `no-reply@`) is LOW salience — reject fast unless it carries a real decision/risk/ask." (b) "Inbound inquiries on `hello@`/`info@`-style lists are lead signals worth recording." Keep them source-agnostic (they help all sources, not just Groups).
+
+- [ ] **Step 3 (verify):** `notion-fetch` the skill page; confirm the two lines are present and the rest of the rubric is intact.
+
+### Task 5: Document the go-live steps
+
+**Files:**
+- Modify (stacks repo): append a short "Observations" note to `docs/meet-etl-deploy.md` OR create `docs/google-groups-observations-golive.md`.
+
+- [ ] **Step 1:** Write the manual go-live checklist (not automated — the `observe` machinery is disabled by design): (1) flip the `google-groups` Sources row `Status → Active` (materializes it into the `sources` skill); (2) enable the `observe` skill + the `Observe: Google Groups` Job when ready; (3) run once manually, confirm rows land in the Observations DB with `Source = Google Groups`, `Source Key stacks:groups:<root>`, working Gmail backlink; (4) re-run → zero new rows (idempotence); (5) confirm a Sentry/QuickBooks thread is rejected.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/
+git commit -m "docs(groups): Google Groups observations source go-live checklist"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** Part A field addition → Task 1; deploy → Task 1b; Sources row → Task 2; Observe Job → Task 3; rubric tuning → Task 4; activation/go-live → Task 5; out-of-scope items (historical backfill, last-activity window, per-message grain, sender attribution, Recall) are explicitly deferred in the spec and not tasked. No gaps.
+
+**Placeholder scan:** none — Task 1 carries full code; Notion tasks carry the exact properties/body from the spec and a "fetch schema first" step so names are exact. The only intentional runtime-derived value is `payload` extraction in the test (Step 2 tells the implementer to match the real `Responses.ok` shape).
+
+**Type/name consistency:** `root_message_id` (= `Document#external_id`), `source`, Source Key `stacks:groups:<root_message_id>`, `Source = Google Groups`, DB ids — all identical across spec and every task.
+
+**Scope check:** two subsystems (stacks code, Notion authoring) but one coherent, small feature; fine for one plan executed A→B (B depends on A being deployed so the backlink field is live before the source is enabled).

--- a/docs/superpowers/specs/2026-07-10-google-groups-observations-source-design.md
+++ b/docs/superpowers/specs/2026-07-10-google-groups-observations-source-design.md
@@ -1,0 +1,170 @@
+# Google Groups as an Observations Source — Design
+
+**Goal:** Make the Google Groups email corpus an *observed* source in stacksbot, so its salient
+signals (leads, client/partner risks, decisions, unanswered asks) land as rows in the Notion
+Observations DB — alongside the existing (drafted) Twist/corpus observation machinery. Each
+observation carries an **accurate backlink to the exact email thread**.
+
+Two repos:
+- **Part A — `stacks` (this repo):** one small MCP addition so an observing agent can build the
+  precise backlink. Shipped as a normal PR (TDD).
+- **Part B — `stacksbot` + Notion:** author a `google-groups` Sources row (the `## Fetch`
+  contract) and a disabled `Observe: Google Groups` Job, and tune the salience rubric for email.
+  No stacksbot *code* — the sync reconcilers materialize Notion rows into the always-loaded
+  `sources` skill; the `observe` skill (source-agnostic) reads the contract.
+
+## Why (decisions already made)
+
+- **The corpus is already exposed via MCP, source-agnostically.** `search` / `list_documents` /
+  `get_document` query `corpus_eligible` across all sources; `google_groups` (~39k threads,
+  backfilled) is already searchable/retrievable. No change needed for retrieval — only for
+  *observing*.
+- **The observations system lives in `stacksbot`, not here.** It reads this corpus via the
+  read-only stacks MCP, applies a salience rubric, and writes rows to a Notion Observations DB.
+  Adding a source = a Notion Sources row + an Observe Job + rubric tuning (the Twist pattern).
+- **Scope: all groups, rubric filters noise.** No denylist. The ongoing job works a bounded
+  rolling window, and the rubric treats automated/notification mail (Sentry, CI/deploy,
+  QuickBooks, Mailchimp, `no-reply@`) as low-salience so it is rejected fast. (`dev@` + `admin@`
+  are ~60% of volume and almost pure automation — they'll mostly produce nothing, which is fine.)
+- **Forward-only to start.** Enable the daily rolling-window job now; defer the ~39k historical
+  backfill until the rubric's yield is proven. (A historical backfill is a later, separate
+  Workflow.)
+- **Grain: thread-level.** One observation per salient thread. Source Key
+  `stacks:groups:<root_message_id>` (deterministic → overlapping windows dedup naturally).
+- **Backlink: accurate.** Primary Source Ref is the Gmail `rfc822msgid` deep link (opens the
+  exact thread, built from the RFC822 `root_message_id` we store). Secondary is the group
+  archive page (`get_document`'s existing `url`). Because the accurate link carries the group
+  context on click, the `Source` tag stays the plain value **"Google Groups"** — no per-group
+  tag, no select-option sprawl.
+  - *Honest caveat:* the Gmail link opens in the viewer's own Gmail and resolves for anyone who
+    received that list's mail (i.e. the internal team, who are largely on these lists). It is not
+    a universally-resolvable public permalink — a true Google Groups per-thread permalink is not
+    derivable from Gmail data (the conversation id is a Groups-internal token we never receive).
+
+## Part A — `stacks` MCP change (the only code here)
+
+`get_document` already returns `{ id, title, url, occurred_at, meeting_key, segments, body }`,
+and for a Groups doc `url` is already the group archive page. The observing agent additionally
+needs the RFC822 root Message-ID to build the precise Gmail link. That value is
+`Document#external_id` for `google_groups` docs.
+
+**Change:** `app/services/mcp/get_document_tool.rb` — add `source` (generally useful) and, for
+Groups docs, `root_message_id` to the response:
+
+```ruby
+extra = doc.google_groups? ? { root_message_id: doc.external_id } : {}
+Responses.ok({ id: doc.id, title: doc.title, url: doc.url, occurred_at: doc.occurred_at,
+               source: doc.source, meeting_key: meeting_key, segments: segments, body: body }
+             .merge(extra))
+```
+
+- `segments: []` and `meeting_key: nil` for Groups docs (unchanged — email isn't speaker-
+  segmented and its `source_record` is a `GoogleGroupThread`, not a `Meeting`). The observe
+  agent reads `body`.
+- `list_documents` is **unchanged** — it already accepts `source:` + `occurred_after:` and
+  returns `{ id, title, source, occurred_at }`, which is all the enumeration step needs.
+- **Not doing:** changing `Document#url` to the Gmail link (would need a 39k-row backfill and
+  alters existing search citations — YAGNI; the agent builds the Gmail link from
+  `root_message_id`). `group_email` is **not** exposed — `url` already carries the group.
+
+**Test** (`test/services/mcp/get_document_tool_test.rb` or the existing MCP tool tests):
+a `google_groups` Document's `get_document` response includes `root_message_id == external_id`
+and `source == "google_groups"`; a `meet` Document's response omits `root_message_id` and still
+carries `meeting_key`/`segments`.
+
+### The window wrinkle (accepted for v1)
+
+`Document#occurred_at` = the thread's **first** message date (deliberate). So
+`list_documents(occurred_after: <7d>)` catches threads that *started* in the window and will
+**miss** an old thread that gets a fresh reply today. Acceptable for v1 (most salient email
+threads start and resolve within days) and keeps cost bounded. Fixing it later = a small
+stacks-side change to filter/expose `GoogleGroupThread#last_message_at`; out of scope here.
+
+## Part B — stacksbot / Notion authoring
+
+### B1. Sources DB row — `Google Groups`
+
+New row in the stacksbot Sources DB (`9090b15496114236ba7a641d660c6e8c`):
+`Name: Google Groups` · `Slug: google-groups` · `Backing Tool: stacks MCP` ·
+`Cite Label: Google Groups` · `Status: Draft`. Body:
+
+```markdown
+## Fetch
+Enumerate recent Google Groups email threads via the stacks MCP:
+- list_documents(source: "google_groups", occurred_after: <now − 7 days>), paging by offset
+  until fewer than `limit` come back.
+- For each id, get_document(id) → { title, url, occurred_at, root_message_id, body }.
+Normalize each thread to { id: root_message_id, timestamp: occurred_at, text: body,
+  url: <Source Ref below> }. Sender attribution isn't exposed for email (segments: []); judge
+  salience on `body`, and treat the group (from `url`) as context.
+Automated/notification mail — Sentry, CI/deploy, QuickBooks/Intuit, Mailchimp, calendar
+invites, `no-reply@`/`notifications@` senders — is LOW salience: reject fast unless the body
+carries a genuine decision, commitment, risk, or an ask directed at the team.
+
+## Source Key
+stacks:groups:<root_message_id>
+
+## Source Ref
+Primary (exact thread): https://mail.google.com/mail/#search/rfc822msgid:<URL-encoded root_message_id>
+Secondary (browse in Google Groups): the document's `url` (the group's archive page).
+
+## Search   (stub — for future Recall)
+stacks MCP search(query, source: "google_groups", mode: "hybrid", limit: 8); fall back to
+keyword mode if semantic times out.
+
+## Cite     (stub — for future Recall)
+Same two links as Source Ref.
+```
+
+`Source` value written on each Observation = **"Google Groups"** (matches `Cite Label`; one new
+select option on the Observations DB `Source` property).
+
+### B2. Observe Job — `Observe: Google Groups`
+
+New row in the stacksbot Jobs DB (`329131fea2c78015ba3eed7476974b9b`):
+`Name: Observe: Google Groups` · `Cron: 0 6 * * *` (daily 06:00 ET — email is lower-velocity than
+Twist) · `Deliver To: none` (silent) · **disabled** (Enable unchecked). Body:
+
+```markdown
+# Observe: Google Groups
+## Procedure
+1. Load the `observe` skill.
+2. Run it for source `google-groups`.
+## Output
+New rows in Observations DB (390131fea2c7808bb216c38b46c3ba55).
+## Deliver To
+none
+```
+
+### B3. Rubric tuning
+
+The `observe` skill's salience rubric already excludes routine chatter. Add one email-specific
+line (in the skill, in Notion): *automated/transactional/notification mail is low-salience;* and
+one inclusion emphasis: *inbound inquiries on `hello@`/`info@`-type lists are lead signals — the
+exact thing to record.* No structural change to the rubric.
+
+### B4. Activation
+
+Author B1–B3 as **Draft/disabled**. They go live when the `observe` machinery is enabled
+org-wide (it isn't yet — Google Groups would be among the first corpus sources observed). This
+stages the source and validates the corpus→observe path without turning on an autonomous sensor
+prematurely.
+
+## Testing / validation
+
+- **Part A:** unit test on the `get_document` response (above); manual MCP call against a real
+  `google_groups` doc confirms `root_message_id` present and the Gmail `rfc822msgid` link opens
+  the thread.
+- **Part B:** with the source enabled in a controlled run — (1) run `observe` for `google-groups`
+  once, confirm salient threads become Observations with `Source Key stacks:groups:<root>`,
+  `Source = Google Groups`, and a working Gmail backlink; (2) re-run immediately with no new
+  activity → **zero** new rows (deterministic-key idempotence); (3) confirm an automated
+  Sentry/QuickBooks thread is rejected (no observation).
+
+## Out of scope (v1)
+
+- Historical backfill of the ~39k threads (later Workflow).
+- Last-activity windowing (`GoogleGroupThread#last_message_at`) — v1 windows on thread start.
+- Per-message grain and thread-*state* observations (Twist's `:idle`-style keys).
+- Sender attribution via MCP (`document_contacts`) — judge on `body` for v1.
+- Recall wiring (the `## Search`/`## Cite` stubs are authored but Recall itself is separate).

--- a/test/services/mcp/get_document_tool_test.rb
+++ b/test/services/mcp/get_document_tool_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class Mcp::GetDocumentToolTest < ActiveSupport::TestCase
+  test 'google_groups doc exposes source + root_message_id (for the Gmail backlink); segments empty' do
+    gg = Document.create!(source: :google_groups, external_id: '<root@x>',
+                          excluded: :not_excluded, excluded_reason: :none,
+                          url: 'https://groups.google.com/a/sanctuary.computer/g/dev', title: 'Deploy chatter')
+    gg.chunks.create!(source: :google_groups, position: 0, content: 'the api is down')
+
+    payload = mcp_payload(Mcp::GetDocumentTool.call(id: gg.id, server_context: {}))
+
+    assert_equal 'google_groups', payload['source']
+    assert_equal '<root@x>', payload['root_message_id'], 'observe needs the RFC822 root to build the rfc822msgid link'
+    assert_equal [], payload['segments'], 'email threads are not speaker-segmented'
+    assert_equal 'the api is down', payload['body']
+    assert_equal 'https://groups.google.com/a/sanctuary.computer/g/dev', payload['url'], 'url is the Groups-browse link'
+  end
+
+  test 'meet doc keeps meeting_key/segments and does NOT expose root_message_id' do
+    m = Meeting.create!(meet_source: :meet_api, meet_conference_record_id: 'cr/z')
+    md = Document.create!(source: :meet, external_id: 'cr/z', source_record: m,
+                          excluded: :not_excluded, excluded_reason: :none, title: 'Team sync')
+    md.chunks.create!(source: :meet, position: 0, content: 'we shipped it')
+
+    payload = mcp_payload(Mcp::GetDocumentTool.call(id: md.id, server_context: {}))
+
+    assert_equal 'meet', payload['source']
+    assert_nil payload['root_message_id'], 'root_message_id is google_groups-only'
+    assert_equal md.source_record.id, payload['meeting_key']
+  end
+end


### PR DESCRIPTION
## get_document exposes source + root_message_id (Google Groups backlinks)

Small MCP addition so the stacksbot **observe** layer can turn Google Groups threads into observations with an accurate backlink.

- `get_document` now returns `source` (always) and, for `google_groups` docs, `root_message_id` (= the RFC822 root `external_id`). An observing agent builds the precise Gmail deep link `https://mail.google.com/mail/#search/rfc822msgid:<root_message_id>` (exact thread); the existing `url` is the group-archive "browse in Groups" link.
- Non-Groups docs are unchanged (`meeting_key`/`segments` intact; no `root_message_id`).
- No `url` change (avoids a 39k-row backfill), no `group_email` (url already carries the group).

Part A of the "Google Groups as an observations source" spec (`docs/superpowers/specs/2026-07-10-google-groups-observations-source-design.md`). Part B is Notion authoring in stacksbot.

Tests: MCP suite green (65 runs / 221 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
