### PR TITLE
Optix: report deactivation run summary to Twist

### DIFF
--- a/lib/stacks/notifications.rb
+++ b/lib/stacks/notifications.rb
@@ -54,11 +54,21 @@ class Stacks::Notifications
     def report_optix_deactivation_run(result)
       return if result.deactivated.empty? && result.skipped.empty? && result.errors.empty?
 
-      twist.add_comment_to_thread(
+      response = twist.add_comment_to_thread(
         TWIST_EXCEPTIONS_THREAD_ID,
         optix_deactivation_body(result),
         [TWIST_EXCEPTION_NOTIFY_USER_ID]
       )
+
+      # HTTParty doesn't raise on HTTP error statuses. This report is the
+      # durable surface for skipped members — a silently-swallowed Twist
+      # failure (expired token, archived thread) would defeat its purpose,
+      # so convert API-level failures into an exception the caller's rescue
+      # turns into log + Sentry.
+      code = response.try(:code)
+      raise "Twist comment failed: HTTP #{code}" if code && !(200..299).cover?(code)
+
+      response
     end
 
     def optix_deactivation_body(result)
@@ -86,6 +96,7 @@ class Stacks::Notifications
 
       lines.join("\n")
     end
+    private :optix_deactivation_body
 
     def make_notifications!
       task_count = Stacks::TaskBuilder.new.task_count

--- a/lib/stacks/notifications.rb
+++ b/lib/stacks/notifications.rb
@@ -42,6 +42,51 @@ class Stacks::Notifications
       notification
     end
 
+    # How many deactivated emails to list before truncating — skips/errors
+    # are always listed in full (they're the actionable part).
+    OPTIX_DEACTIVATION_LIST_CAP = 50
+
+    # Posts a summary of an Optix inactive-member deactivation run
+    # (Stacks::Optix::DeactivateInactiveMembers::Result) to the same Twist
+    # thread + notify-user as exceptions. Skipped members need manual
+    # handling in Optix, and Heroku's log retention is too short to rely on —
+    # this is their durable surface. Silent when the run did nothing.
+    def report_optix_deactivation_run(result)
+      return if result.deactivated.empty? && result.skipped.empty? && result.errors.empty?
+
+      twist.add_comment_to_thread(
+        TWIST_EXCEPTIONS_THREAD_ID,
+        optix_deactivation_body(result),
+        [TWIST_EXCEPTION_NOTIFY_USER_ID]
+      )
+    end
+
+    def optix_deactivation_body(result)
+      lines = []
+      lines << "**Optix inactive-member deactivation run**"
+      lines << "#{result.deactivated.length} deactivated, #{result.skipped.length} skipped, #{result.errors.length} errored."
+
+      if result.deactivated.any?
+        shown = result.deactivated.first(OPTIX_DEACTIVATION_LIST_CAP)
+        line = "**Deactivated:** #{shown.map { |d| d[:email] }.join(", ")}"
+        overflow = result.deactivated.length - shown.length
+        line += " (+#{overflow} more)" if overflow.positive?
+        lines << line
+      end
+
+      if result.skipped.any?
+        lines << "**Skipped (needs manual handling in Optix):**"
+        result.skipped.each { |s| lines << "- #{s[:email]} — #{s[:reason]}" }
+      end
+
+      if result.errors.any?
+        lines << "**Errors (will retry tomorrow):**"
+        result.errors.each { |e| lines << "- #{e[:email]} — #{e[:error]}" }
+      end
+
+      lines.join("\n")
+    end
+
     def make_notifications!
       task_count = Stacks::TaskBuilder.new.task_count
       return if task_count == 0

--- a/lib/stacks/optix.rb
+++ b/lib/stacks/optix.rb
@@ -49,12 +49,25 @@ class Stacks::Optix
   # Daily automation entrypoint (called from Enterprise#daily_tasks for Index).
   # Uses OptixOrganization.first — consistent with the single-tenant assumption
   # documented on OptixOrganization and in stacks.rake.
+  #
+  # Reports the run summary (deactivations, members skipped for manual
+  # handling, errors) to Twist. Removals already happened by then, so a
+  # notification failure is logged + Sentried but never fails the run.
   def self.deactivate_inactive_members!(grace_days: 7, collect_payment: true)
-    Stacks::Optix::DeactivateInactiveMembers.call(
+    result = Stacks::Optix::DeactivateInactiveMembers.call(
       client: new(OptixOrganization.first),
       grace_days: grace_days,
       collect_payment: collect_payment,
     )
+
+    begin
+      Stacks::Notifications.report_optix_deactivation_run(result)
+    rescue => e
+      Rails.logger.error("[Stacks::Optix.deactivate_inactive_members!] failed to report run to Twist: #{e.class}: #{e.message}")
+      Sentry.capture_exception(e) if defined?(Sentry)
+    end
+
+    result
   end
 
   # ---------- credentials (currently global; per-org in the future) ----------

--- a/test/lib/stacks/notifications_test.rb
+++ b/test/lib/stacks/notifications_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+
+class StacksNotificationsOptixDeactivationTest < ActiveSupport::TestCase
+  def result(deactivated: [], skipped: [], errors: [])
+    Stacks::Optix::DeactivateInactiveMembers::Result.new(
+      deactivated: deactivated, skipped: skipped, errors: errors,
+    )
+  end
+
+  test "posts a Twist comment to the exceptions thread with counts, skips, and errors" do
+    r = result(
+      deactivated: [{ user_id: "50", member_id: 1050, email: "a@b.c", name: "A B", invoice_total: 0.0 }],
+      skipped: [{ user_id: "51", email: "s@b.c", reason: "no member_id mapping (no invoices on record)" }],
+      errors: [{ user_id: "52", email: "e@b.c", error: "Stacks::Optix::ApiError: boom" }],
+    )
+
+    captured = nil
+    twist = mock
+    twist.expects(:add_comment_to_thread).with do |thread_id, content, recipients|
+      captured = { thread_id: thread_id, content: content, recipients: recipients }
+      true
+    end
+    Stacks::Notifications.stubs(:twist).returns(twist)
+
+    Stacks::Notifications.report_optix_deactivation_run(r)
+
+    assert_equal Stacks::Notifications::TWIST_EXCEPTIONS_THREAD_ID, captured[:thread_id]
+    assert_equal [Stacks::Notifications::TWIST_EXCEPTION_NOTIFY_USER_ID], captured[:recipients]
+    assert_includes captured[:content], "1 deactivated"
+    assert_includes captured[:content], "1 skipped"
+    assert_includes captured[:content], "1 errored"
+    assert_includes captured[:content], "a@b.c"
+    assert_includes captured[:content], "s@b.c — no member_id mapping (no invoices on record)"
+    assert_includes captured[:content], "e@b.c — Stacks::Optix::ApiError: boom"
+  end
+
+  test "a run with nothing to report posts nothing" do
+    Stacks::Notifications.expects(:twist).never
+    Stacks::Notifications.report_optix_deactivation_run(result)
+  end
+
+  test "caps the deactivated email list at 50" do
+    deactivated = Array.new(51) { |i| { user_id: i.to_s, email: "m#{i}@x.c", invoice_total: 0.0 } }
+
+    content = nil
+    twist = mock
+    twist.expects(:add_comment_to_thread).with { |_thread_id, c, _recipients| content = c; true }
+    Stacks::Notifications.stubs(:twist).returns(twist)
+
+    Stacks::Notifications.report_optix_deactivation_run(result(deactivated: deactivated))
+
+    assert_includes content, "m49@x.c"
+    refute_includes content, "m50@x.c"
+    assert_includes content, "+1 more"
+  end
+end

--- a/test/lib/stacks/notifications_test.rb
+++ b/test/lib/stacks/notifications_test.rb
@@ -34,6 +34,16 @@ class StacksNotificationsOptixDeactivationTest < ActiveSupport::TestCase
     assert_includes captured[:content], "e@b.c — Stacks::Optix::ApiError: boom"
   end
 
+  test "a non-2xx Twist response raises so the caller's rescue can log + Sentry it" do
+    r = result(skipped: [{ user_id: "51", email: "s@b.c", reason: "no member_id mapping" }])
+    twist = mock
+    twist.expects(:add_comment_to_thread).returns(stub(code: 500))
+    Stacks::Notifications.stubs(:twist).returns(twist)
+
+    err = assert_raises(RuntimeError) { Stacks::Notifications.report_optix_deactivation_run(r) }
+    assert_match(/HTTP 500/, err.message)
+  end
+
   test "a run with nothing to report posts nothing" do
     Stacks::Notifications.expects(:twist).never
     Stacks::Notifications.report_optix_deactivation_run(result)

--- a/test/lib/stacks/optix_test.rb
+++ b/test/lib/stacks/optix_test.rb
@@ -72,3 +72,25 @@ class StacksOptixMemberRemovalTest < ActiveSupport::TestCase
     assert_match(/not configured/, err.message)
   end
 end
+
+class StacksOptixDeactivateClassMethodTest < ActiveSupport::TestCase
+  def empty_result
+    Stacks::Optix::DeactivateInactiveMembers::Result.new(deactivated: [], skipped: [], errors: [])
+  end
+
+  test "deactivate_inactive_members! reports the run to Twist and returns the result" do
+    result = empty_result
+    Stacks::Optix::DeactivateInactiveMembers.stubs(:call).returns(result)
+    Stacks::Notifications.expects(:report_optix_deactivation_run).with(result).once
+
+    assert_same result, Stacks::Optix.deactivate_inactive_members!
+  end
+
+  test "a notification failure does not break the run" do
+    result = empty_result
+    Stacks::Optix::DeactivateInactiveMembers.stubs(:call).returns(result)
+    Stacks::Notifications.stubs(:report_optix_deactivation_run).raises(RuntimeError.new("twist down"))
+
+    assert_same result, Stacks::Optix.deactivate_inactive_members!
+  end
+end


### PR DESCRIPTION
## Summary

Follow-up to #134. The deactivation run's outcome (deactivated / skipped / errored members) previously surfaced only as Heroku log lines — with no log drain configured, the ~7 known unmappable members would warn daily, invisibly, forever. This posts a run summary to the **same Twist thread + notify-user as exception reports**.

- New `Stacks::Notifications.report_optix_deactivation_run(result)` — counts summary, deactivated emails (capped at 50 + "+N more"), skipped and error lists in full (they're the actionable part). Silent when the run did nothing.
- Wired into `Stacks::Optix.deactivate_inactive_members!` after the service call. Removals have already happened by then, so a notification failure is rescued (log + Sentry) and never fails the run.
- Hardening from review: HTTParty doesn't raise on HTTP error statuses, so a non-2xx Twist response (expired token, archived thread) now raises into that rescue instead of silently swallowing the report — the exact failure mode this feature exists to prevent.

## Testing

TDD throughout (6 new tests: content/thread/recipients, silence-on-empty, 50-cap boundary, non-2xx raise, wiring + notification-failure isolation).
Full suite: **693 runs, 1,787 assertions, 0 failures, 0 errors** (2 pre-existing skips).

## Note

Persistent skips re-post daily until someone handles them in Optix — intentional (that's the nagging this exists for).