### PR TITLE
Record timestamped source_events on every contact API post

### DIFF
--- a/app/controllers/api/contacts_controller.rb
+++ b/app/controllers/api/contacts_controller.rb
@@ -20,10 +20,31 @@ class Api::ContactsController < ApiController
       sources: [*contact.sources, *(params["sources"] || [])].uniq,
       metadata: contact.metadata.deep_merge(api_contact_metadata_blob)
     )
+    record_source_events!(contact, params["sources"] || [])
     head :ok
   end
 
   private
+
+  # Appends { added_at: now() } to source_events[source] for every posted source,
+  # even when the source is already in the deduped sources array — this is the
+  # view counter. jsonb_set at the SQL level so concurrent posts cannot lose events.
+  def record_source_events!(contact, sources)
+    Array(sources).each do |source|
+      Contact.where(id: contact.id).update_all([
+        <<~SQL.squish,
+          source_events = jsonb_set(
+            source_events,
+            ARRAY[?],
+            COALESCE(source_events->?, '[]'::jsonb)
+              || jsonb_build_array(jsonb_build_object('added_at', now())),
+            true
+          )
+        SQL
+        source.to_s, source.to_s
+      ])
+    end
+  end
 
   def api_contact_metadata_blob
     payload = api_contact_request_payload_hash

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -12,7 +12,18 @@ class Contact < ApplicationRecord
   scope :sources_cont, ->(value) { where("array_to_string(sources, ' ') ILIKE ?", "%#{value}%") }
 
   def self.ransackable_attributes(auth_object = nil)
-    super - %w[sources metadata]
+    super - %w[sources metadata source_events]
+  end
+
+  # Unions per-source event lists ({source => [{"added_at" => ts}, ...]}),
+  # keeping each list sorted by added_at, so a survivor keeps the full view
+  # history when duplicate contacts merge.
+  def self.merge_source_events(events_list)
+    events_list.compact.each_with_object({}) do |events, acc|
+      events.each do |source, entries|
+        acc[source] = [*acc[source], *entries].sort_by { |e| e['added_at'].to_s }
+      end
+    end
   end
 
   def self.ransackable_scopes(*)
@@ -38,6 +49,9 @@ class Contact < ApplicationRecord
       rescue ActiveRecord::RecordNotUnique => e
         if existing_contact = Contact.find_by(apollo_id: apollo_contact["id"])
           self.sources = [*self.sources, *existing_contact.sources].uniq
+          self.source_events = Contact.merge_source_events(
+            [self.source_events, existing_contact.source_events]
+          )
           existing_contact.destroy!
           puts "~~~> will retry for #{self.email}"
           retry
@@ -88,6 +102,7 @@ class Contact < ApplicationRecord
     losers = dupes[1..]
 
     merged_sources = dupes.flat_map(&:sources).compact.uniq
+    merged_source_events = Contact.merge_source_events(dupes.map(&:source_events))
     merged_apollo_id = dupes.map(&:apollo_id).compact.first
     merged_display_name = dupes.map(&:display_name).compact.first
 
@@ -105,6 +120,7 @@ class Contact < ApplicationRecord
 
       survivor.update!(
         sources: merged_sources,
+        source_events: merged_source_events,
         apollo_id: merged_apollo_id,
         display_name: survivor.display_name.presence || merged_display_name,
       )

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -50,18 +50,26 @@ class Contact < ApplicationRecord
         if existing_contact = Contact.find_by(apollo_id: apollo_contact["id"])
           # Merge from row-locked reads (id order, matching dedupe!) so a
           # concurrent source_events append isn't lost mid-merge.
+          merged = false
           ActiveRecord::Base.transaction do
             locked = Contact.where(id: [id, existing_contact.id]).lock.order(:id).index_by(&:id)
+            fresh_self = locked[id]
             fresh_existing = locked[existing_contact.id]
-            self.sources = [*locked[id].sources, *fresh_existing&.sources].uniq
-            self.source_events = Contact.merge_source_events(
-              [locked[id].source_events, fresh_existing&.source_events]
-            )
-            # Destroy before save!: self still carries the conflicting
-            # apollo_id, so saving first would re-trip the unique index.
-            fresh_existing&.destroy!
-            save!
+            if fresh_self
+              self.sources = [*fresh_self.sources, *fresh_existing&.sources].uniq
+              self.source_events = Contact.merge_source_events(
+                [fresh_self.source_events, fresh_existing&.source_events]
+              )
+              # Destroy before save!: self still carries the conflicting
+              # apollo_id, so saving first would re-trip the unique index.
+              fresh_existing&.destroy!
+              save!
+              merged = true
+            end
           end
+          # If our own row vanished (concurrent dedupe!), there is nothing
+          # left to sync — bail rather than retrying forever.
+          return unless merged
           puts "~~~> will retry for #{self.email}"
           retry
         else
@@ -114,33 +122,38 @@ class Contact < ApplicationRecord
       # delete would otherwise be silently dropped.
       dupes = Contact.where(id: dupe_ids).lock.order(:id).to_a
       survivor = dupes.first
-      losers = dupes[1..]
 
-      merged_sources = dupes.flat_map(&:sources).compact.uniq
-      merged_source_events = Contact.merge_source_events(dupes.map(&:source_events))
-      merged_apollo_id = dupes.map(&:apollo_id).compact.first
-      merged_display_name = dupes.map(&:display_name).compact.first
+      # A concurrent dedupe! may have already merged and deleted these rows
+      # between the pluck and the lock — nothing left to do here.
+      if dupes.length > 1
+        losers = dupes[1..]
 
-      losers.each do |loser|
-        CONTACT_REFERENCES.each do |table, fk, scope_cols|
-          repoint_references!(table, fk, scope_cols, from: loser.id, to: survivor.id)
+        merged_sources = dupes.flat_map(&:sources).compact.uniq
+        merged_source_events = Contact.merge_source_events(dupes.map(&:source_events))
+        merged_apollo_id = dupes.map(&:apollo_id).compact.first
+        merged_display_name = dupes.map(&:display_name).compact.first
+
+        losers.each do |loser|
+          CONTACT_REFERENCES.each do |table, fk, scope_cols|
+            repoint_references!(table, fk, scope_cols, from: loser.id, to: survivor.id)
+          end
         end
+
+        # Delete the losers BEFORE reassigning their attributes onto the survivor.
+        # contacts.apollo_id has a unique index, so assigning a loser's apollo_id to
+        # the survivor while that loser still exists would violate the constraint.
+        Contact.where(id: losers.map(&:id)).delete_all
+
+        survivor.update!(
+          sources: merged_sources,
+          source_events: merged_source_events,
+          apollo_id: merged_apollo_id,
+          display_name: survivor.display_name.presence || merged_display_name,
+        )
       end
-
-      # Delete the losers BEFORE reassigning their attributes onto the survivor.
-      # contacts.apollo_id has a unique index, so assigning a loser's apollo_id to
-      # the survivor while that loser still exists would violate the constraint.
-      Contact.where(id: losers.map(&:id)).delete_all
-
-      survivor.update!(
-        sources: merged_sources,
-        source_events: merged_source_events,
-        apollo_id: merged_apollo_id,
-        display_name: survivor.display_name.presence || merged_display_name,
-      )
     end
 
-    survivor.reload
+    survivor ? survivor.reload : self
   end
 
   private

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -48,11 +48,20 @@ class Contact < ApplicationRecord
         self.update(apollo_id: apollo_contact["id"], apollo_data: apollo_contact)
       rescue ActiveRecord::RecordNotUnique => e
         if existing_contact = Contact.find_by(apollo_id: apollo_contact["id"])
-          self.sources = [*self.sources, *existing_contact.sources].uniq
-          self.source_events = Contact.merge_source_events(
-            [self.source_events, existing_contact.source_events]
-          )
-          existing_contact.destroy!
+          # Merge from row-locked reads (id order, matching dedupe!) so a
+          # concurrent source_events append isn't lost mid-merge.
+          ActiveRecord::Base.transaction do
+            locked = Contact.where(id: [id, existing_contact.id]).lock.order(:id).index_by(&:id)
+            fresh_existing = locked[existing_contact.id]
+            self.sources = [*locked[id].sources, *fresh_existing&.sources].uniq
+            self.source_events = Contact.merge_source_events(
+              [locked[id].source_events, fresh_existing&.source_events]
+            )
+            # Destroy before save!: self still carries the conflicting
+            # apollo_id, so saving first would re-trip the unique index.
+            fresh_existing&.destroy!
+            save!
+          end
           puts "~~~> will retry for #{self.email}"
           retry
         else
@@ -92,21 +101,26 @@ class Contact < ApplicationRecord
   def dedupe!
     self.update(sources: self.sources.uniq)
 
-    dupes = Contact
+    dupe_ids = Contact
       .where("LOWER(email) = ?", email.downcase)
       .order(:id)
-      .to_a
-    return self unless dupes.length > 1
+      .pluck(:id)
+    return self unless dupe_ids.length > 1
 
-    survivor = dupes.first
-    losers = dupes[1..]
-
-    merged_sources = dupes.flat_map(&:sources).compact.uniq
-    merged_source_events = Contact.merge_source_events(dupes.map(&:source_events))
-    merged_apollo_id = dupes.map(&:apollo_id).compact.first
-    merged_display_name = dupes.map(&:display_name).compact.first
-
+    survivor = nil
     ActiveRecord::Base.transaction do
+      # Row-lock the duplicates and merge from the locked reads: an API post
+      # appending to a loser's source_events between an unlocked load and the
+      # delete would otherwise be silently dropped.
+      dupes = Contact.where(id: dupe_ids).lock.order(:id).to_a
+      survivor = dupes.first
+      losers = dupes[1..]
+
+      merged_sources = dupes.flat_map(&:sources).compact.uniq
+      merged_source_events = Contact.merge_source_events(dupes.map(&:source_events))
+      merged_apollo_id = dupes.map(&:apollo_id).compact.first
+      merged_display_name = dupes.map(&:display_name).compact.first
+
       losers.each do |loser|
         CONTACT_REFERENCES.each do |table, fk, scope_cols|
           repoint_references!(table, fk, scope_cols, from: loser.id, to: survivor.id)

--- a/app/serializers/api/contact_serializer.rb
+++ b/app/serializers/api/contact_serializer.rb
@@ -1,3 +1,3 @@
 class Api::ContactSerializer < ActiveModel::Serializer
-  attributes :email, :sources, :metadata
+  attributes :email, :sources, :metadata, :source_events
 end

--- a/db/migrate/20260710200715_add_source_events_to_contacts.rb
+++ b/db/migrate/20260710200715_add_source_events_to_contacts.rb
@@ -1,0 +1,5 @@
+class AddSourceEventsToContacts < ActiveRecord::Migration[6.1]
+  def change
+    add_column :contacts, :source_events, :jsonb, default: {}, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_07_09_000001) do
+ActiveRecord::Schema.define(version: 2026_07_10_200715) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -145,6 +145,7 @@ ActiveRecord::Schema.define(version: 2026_07_09_000001) do
     t.jsonb "apollo_data", default: {}
     t.jsonb "metadata", default: {}, null: false
     t.string "display_name"
+    t.jsonb "source_events", default: {}, null: false
     t.index ["apollo_id"], name: "index_contacts_on_apollo_id", unique: true
     t.index ["email"], name: "index_contacts_on_email", unique: true
   end

--- a/test/controllers/api/contacts_controller_test.rb
+++ b/test/controllers/api/contacts_controller_test.rb
@@ -126,6 +126,51 @@ class Api::ContactsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "landing", contact.metadata["funnel"]
   end
 
+  test "index includes source_events so callers can read view counts" do
+    api_key = { "X-Api-Key" => Stacks::Utils.config[:stacks][:private_api_key] }
+    email = "view-counts@example.com"
+
+    2.times do
+      post "/api/contacts", headers: api_key,
+        params: { email: email, sources: ["fundraising"] }, as: :json
+    end
+
+    get "/api/contacts", headers: api_key, params: { source: "fundraising" }
+    assert_response :success
+    row = JSON.parse(response.body).first
+    assert_equal 2, row["source_events"]["fundraising"].length
+  end
+
+  test "appends a timestamped source event on every post, even for duplicate sources" do
+    api_key = { "X-Api-Key" => Stacks::Utils.config[:stacks][:private_api_key] }
+    email = "views@example.com"
+
+    post "/api/contacts", headers: api_key,
+      params: { email: email, sources: %w[newsletter fundraising] }, as: :json
+    post "/api/contacts", headers: api_key,
+      params: { email: email, sources: ["fundraising"] }, as: :json
+
+    assert_response :success
+    contact = Contact.find_by!(email: email)
+    assert_equal %w[newsletter fundraising], contact.sources
+    assert_equal 1, contact.source_events["newsletter"].length
+    assert_equal 2, contact.source_events["fundraising"].length
+    contact.source_events.values.flatten.each do |event|
+      assert_equal ["added_at"], event.keys
+      assert Time.iso8601(event["added_at"])
+    end
+  end
+
+  test "records no source events when no sources are posted" do
+    post "/api/contacts",
+      headers: { "X-Api-Key" => Stacks::Utils.config[:stacks][:private_api_key] },
+      params: { email: "no-events@example.com" },
+      as: :json
+
+    assert_response :success
+    assert_equal({}, Contact.find_by!(email: "no-events@example.com").source_events)
+  end
+
   test "top-level keys outside metadata are not stored in contact metadata" do
     email = "no-leak@sanctuary.computer"
 

--- a/test/models/contact_test.rb
+++ b/test/models/contact_test.rb
@@ -106,6 +106,30 @@ class ContactDedupeTest < ActiveSupport::TestCase
       result.source_events['a'].map { |e| e['added_at'] }
     )
   end
+
+  test 'merges source_events across three duplicates, including empty ones' do
+    keep = Contact.create!(
+      email: 'tri@gmail.com',
+      source_events: { 'a' => [{ 'added_at' => '2026-06-02T00:00:00Z' }] }
+    )
+    Contact.create!(
+      email: 'TRI@gmail.com',
+      source_events: {
+        'a' => [{ 'added_at' => '2026-06-01T00:00:00Z' }],
+        'b' => [{ 'added_at' => '2026-06-03T00:00:00Z' }],
+      }
+    )
+    Contact.create!(email: 'Tri@Gmail.com')
+
+    result = keep.dedupe!
+
+    assert_equal 2, result.source_events['a'].length
+    assert_equal 1, result.source_events['b'].length
+    assert_equal(
+      %w[2026-06-01T00:00:00Z 2026-06-02T00:00:00Z],
+      result.source_events['a'].map { |e| e['added_at'] }
+    )
+  end
 end
 
 class ContactSyncToApolloTest < ActiveSupport::TestCase
@@ -131,7 +155,7 @@ class ContactSyncToApolloTest < ActiveSupport::TestCase
 
     assert_equal 'apollo-x', contact.apollo_id
     assert_nil Contact.find_by(id: existing.id)
-    assert_equal %w[b], contact.sources.sort & %w[b]
+    assert_equal %w[a b], contact.sources.sort
     assert_equal 1, contact.source_events['b'].length
     assert_equal 1, contact.source_events['a'].length
   end

--- a/test/models/contact_test.rb
+++ b/test/models/contact_test.rb
@@ -81,4 +81,66 @@ class ContactDedupeTest < ActiveSupport::TestCase
     assert_equal solo.id, solo.dedupe!.id
     assert_equal 1, Contact.where(email: 'solo@gmail.com').count
   end
+
+  test 'merges source_events from duplicates into the survivor' do
+    keep = Contact.create!(
+      email: 'events@gmail.com',
+      sources: ['a'],
+      source_events: { 'a' => [{ 'added_at' => '2026-06-01T00:00:00Z' }] }
+    )
+    Contact.create!(
+      email: 'EVENTS@gmail.com',
+      sources: %w[a b],
+      source_events: {
+        'a' => [{ 'added_at' => '2026-06-02T00:00:00Z' }],
+        'b' => [{ 'added_at' => '2026-06-03T00:00:00Z' }],
+      }
+    )
+
+    result = keep.dedupe!
+
+    assert_equal 2, result.source_events['a'].length
+    assert_equal 1, result.source_events['b'].length
+    assert_equal(
+      %w[2026-06-01T00:00:00Z 2026-06-02T00:00:00Z],
+      result.source_events['a'].map { |e| e['added_at'] }
+    )
+  end
+end
+
+class ContactSyncToApolloTest < ActiveSupport::TestCase
+  test 'merges source_events from the destroyed apollo-duplicate' do
+    existing = Contact.create!(
+      email: 'other@gmail.com',
+      apollo_id: 'apollo-x',
+      sources: ['b'],
+      source_events: { 'b' => [{ 'added_at' => '2026-06-01T00:00:00Z' }] }
+    )
+    contact = Contact.create!(
+      email: 'me@gmail.com',
+      sources: ['a'],
+      source_events: { 'a' => [{ 'added_at' => '2026-06-02T00:00:00Z' }] }
+    )
+    fake_apollo = Object.new
+    def fake_apollo.search_by_email(email)
+      [{ 'id' => 'apollo-x', 'email' => email }]
+    end
+
+    contact.sync_to_apollo!(fake_apollo)
+    contact.reload
+
+    assert_equal 'apollo-x', contact.apollo_id
+    assert_nil Contact.find_by(id: existing.id)
+    assert_equal %w[b], contact.sources.sort & %w[b]
+    assert_equal 1, contact.source_events['b'].length
+    assert_equal 1, contact.source_events['a'].length
+  end
+end
+
+class ContactRansackTest < ActiveSupport::TestCase
+  test 'excludes jsonb/array columns from ransackable attributes' do
+    refute_includes Contact.ransackable_attributes, 'sources'
+    refute_includes Contact.ransackable_attributes, 'metadata'
+    refute_includes Contact.ransackable_attributes, 'source_events'
+  end
 end


### PR DESCRIPTION
## Summary
The contacts API dedups the `sources` array, so repeat posts of the same `(email, source)` were invisible — there was no way to count how many times someone re-triggered a source (e.g. repeat views of the intelligence.family fundraising gate, which posts `g3d:family_intelligence:fundraising-viewed` on every verified page load).

This adds a server-owned view log:

- **`contacts.source_events`** — new jsonb column, `{ "<source>": [{ "added_at": "<timestamp>" }, ...] }`. Deliberately a dedicated column rather than a key in `metadata`, because the API deep-merges *client-supplied* metadata — callers could forge or clobber a log stored there.
- **`Api::ContactsController#create`** appends an `{ added_at: now() }` event for every posted source on every request — including sources already present in the deduped `sources` array. The append is a SQL-level `jsonb_set` so concurrent posts can't lose events (no read-modify-write in Ruby).
- **`Api::ContactSerializer`** exposes `source_events`, so `GET /api/contacts?source=...` returns per-contact view counts and timestamps directly.

`sources` remains the deduped set it always was; nothing changes for existing callers.

## Adversarial review (multi-agent, 3 rounds — all findings fixed)
- **Round 1** (8 finder angles → 8 verified verdicts): confirmed that `Contact#dedupe!` and the `sync_to_apollo!` `RecordNotUnique` rescue destroyed duplicate rows without merging their `source_events` (view history silently lost), and that `source_events` was missing from the `ransackable_attributes` exclusion list alongside `sources`/`metadata`. Both fixed (`f8ac6ea`). Refuted: altitude/model-method relocation, `create_missing` flag removal (it's load-bearing), serializer shape-break, malformed-`sources` junk keys (pre-existing input behavior), failed-update inconsistency.
- **Round 2**: the merge fix computed merged attributes from rows loaded *before* the transaction, so an API post appending to a loser mid-dedupe was lost. Both merge paths now read under `SELECT … FOR UPDATE` (id order) inside the transaction (`e01603e`) — this also fixes the same pre-existing race for `sources`. Added a 3-way dedupe merge test.
- **Round 3**: the locking change could crash on concurrently-deleted rows (empty `dupes` → `nil.each`; vanished self → `nil.sources`, with infinite-retry risk). Guarded with bounded fallbacks (`5d7c629`).

## Known non-findings (accepted)
- One `UPDATE` per posted source (payloads are 1–2 sources).
- `GET /api/contacts` index has no pagination — pre-existing; `source_events` makes rows somewhat heavier (~30 bytes/event). Worth a follow-up if a source ever accumulates thousands of contacts.
- ETL (`etl:meet`), admin CSV import, and admin edits don't log events — by design: `source_events` is a view counter for API posts, not a universal audit log.

## Notes
- `db/schema.rb` was hand-edited (version bump + the new column only) — the auto-dump wanted to clobber the intentionally-omitted pgvector/tsvector sections.
- Consumer side: intelligence.family PR #11 (`/api/gate-status`) posts the viewed source on each verified page load; this PR is what makes those repeats countable. No deploy-ordering hazard — payloads are unchanged, counting simply starts when this lands.

## Tests
TDD throughout. `bin/rails test` — **700 runs, 1818 assertions, 0 failures** (2 pre-existing skips). New coverage: repeat-post appends, no-sources posts nothing, index exposes the log, 2-way and 3-way dedupe merges (incl. empty maps), sync_to_apollo! rescue-path merge, ransack exclusions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)