### PR TITLE
feat(mcp): get_resourcing_projections — read-only projection-plane tool

### DIFF
--- a/app/services/mcp/get_resourcing_projections_tool.rb
+++ b/app/services/mcp/get_resourcing_projections_tool.rb
@@ -1,14 +1,14 @@
 module Mcp
-  class GetRunnProjectionsTool < MCP::Tool
-    tool_name 'get_runn_projections'
-    description 'Runn PROJECTION plane: forward planned assignments (minutes_per_day, placeholders), ' \
+  class GetResourcingProjectionsTool < MCP::Tool
+    tool_name 'get_resourcing_projections'
+    description 'The resourcing PROJECTION plane: forward planned assignments (minutes_per_day, placeholders), ' \
                 'people, and projects with the tentative flag (is_confirmed=false), window-filtered ' \
-                'from today. Where a Runn project maps to a ProjectTracker, its snapshot dates and ' \
-                'hours are joined for divergence checks. Live read of the Runn API; never touches actuals.'
+                'from today. Where a project maps to a ProjectTracker, its snapshot dates and ' \
+                'hours are joined for divergence checks. Live read of the resourcing tool; never touches actuals.'
     input_schema(
       properties: {
         window_days: { type: 'number', description: 'Horizon in days from today (default 90). Assignments overlapping [today, today + window_days] are returned.' },
-        include_archived: { type: 'boolean', description: 'Default false. Include archived Runn projects (and their assignments).' },
+        include_archived: { type: 'boolean', description: 'Default false. Include archived projects (and their assignments).' },
       },
       required: []
     )
@@ -47,7 +47,7 @@ module Mcp
         projects: projects.map { |p|
           tracker = trackers_by_runn_id[p["id"]]
           {
-            runn_id: p["id"],
+            id: p["id"],
             name: p["name"],
             is_confirmed: p["isConfirmed"],
             is_archived: p["isArchived"],
@@ -68,11 +68,11 @@ module Mcp
         people: runn.get_people
           .reject { |p| p["isArchived"] && !include_archived }
           .map { |p|
-            # deliberately no email — assignments join on runn_id; former-staff
+            # deliberately no email — assignments join on id; former-staff
             # emails don't belong on this surface (matches get_studio_health's
             # precedent of excluding per-person contact detail)
             {
-              runn_id: p["id"],
+              id: p["id"],
               name: [p["firstName"], p["lastName"]].compact.join(" "),
               is_archived: p["isArchived"],
             }
@@ -93,10 +93,10 @@ module Mcp
         },
       })
     rescue StandardError => e
-      Rails.logger.warn("[Mcp::GetRunnProjectionsTool] #{e.class}: #{e.message}")
+      Rails.logger.warn("[Mcp::GetResourcingProjectionsTool] #{e.class}: #{e.message}")
       Sentry.capture_exception(e) if defined?(Sentry)
       # never echo upstream/internal error bodies to the caller
-      Responses.error("get_runn_projections failed; the error was logged")
+      Responses.error("get_resourcing_projections failed; the error was logged")
     end
   end
 end

--- a/app/services/mcp/get_runn_projections_tool.rb
+++ b/app/services/mcp/get_runn_projections_tool.rb
@@ -1,0 +1,102 @@
+module Mcp
+  class GetRunnProjectionsTool < MCP::Tool
+    tool_name 'get_runn_projections'
+    description 'Runn PROJECTION plane: forward planned assignments (minutes_per_day, placeholders), ' \
+                'people, and projects with the tentative flag (is_confirmed=false), window-filtered ' \
+                'from today. Where a Runn project maps to a ProjectTracker, its snapshot dates and ' \
+                'hours are joined for divergence checks. Live read of the Runn API; never touches actuals.'
+    input_schema(
+      properties: {
+        window_days: { type: 'number', description: 'Horizon in days from today (default 90). Assignments overlapping [today, today + window_days] are returned.' },
+        include_archived: { type: 'boolean', description: 'Default false. Include archived Runn projects (and their assignments).' },
+      },
+      required: []
+    )
+    annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true)
+
+    def self.call(window_days: 90, include_archived: false, server_context:)
+      # Request path: no 429 sleep-retry (a rate limit must never park a web
+      # worker), and the window is clamped to sane bounds.
+      runn = Stacks::Runn.new(max_retries: 0)
+      window_days = window_days.to_f.finite? ? window_days.to_i.clamp(1, 365) : 90
+      today = Time.zone.today
+      horizon = today + window_days.days
+
+      projects = runn.get_projects.reject { |p| p["isTemplate"] }
+      projects = projects.reject { |p| p["isArchived"] } unless include_archived
+      project_ids = projects.map { |p| p["id"] }.to_set
+
+      assignments = runn.get_assignments.select do |a|
+        next false if a["isTemplate"]
+        next false unless project_ids.include?(a["projectId"])
+
+        start_date = begin; Date.parse(a["startDate"].to_s); rescue ArgumentError, TypeError; nil; end
+        end_date   = begin; Date.parse(a["endDate"].to_s);   rescue ArgumentError, TypeError; nil; end
+        next false if start_date.nil? || end_date.nil?
+
+        end_date >= today && start_date <= horizon
+      end
+
+      trackers_by_runn_id = ProjectTracker
+        .where(runn_project_id: project_ids.to_a)
+        .index_by(&:runn_project_id)
+
+      Responses.ok({
+        as_of: today.iso8601,
+        window: { start: today.iso8601, end: horizon.iso8601 },
+        projects: projects.map { |p|
+          tracker = trackers_by_runn_id[p["id"]]
+          {
+            runn_id: p["id"],
+            name: p["name"],
+            is_confirmed: p["isConfirmed"],
+            is_archived: p["isArchived"],
+            client_id: p["clientId"],
+            budget: p["budget"],
+            pricing_model: p["pricingModel"],
+            url: "https://app.runn.io/projects/#{p['id']}",
+            project_tracker: tracker && {
+              id: tracker.id,
+              name: tracker.name,
+              snapshot_start_date: tracker.snapshot&.dig("first_forecast_assignment_start_date"),
+              snapshot_end_date: tracker.snapshot&.dig("last_forecast_assignment_end_date"),
+              hours_total: tracker.snapshot&.dig("hours_total"),
+              hours_free: tracker.snapshot&.dig("hours_free"),
+            },
+          }
+        },
+        people: runn.get_people
+          .reject { |p| p["isArchived"] && !include_archived }
+          .map { |p|
+            # deliberately no email — assignments join on runn_id; former-staff
+            # emails don't belong on this surface (matches get_studio_health's
+            # precedent of excluding per-person contact detail)
+            {
+              runn_id: p["id"],
+              name: [p["firstName"], p["lastName"]].compact.join(" "),
+              is_archived: p["isArchived"],
+            }
+          },
+        assignments: assignments.map { |a|
+          {
+            id: a["id"],
+            person_id: a["personId"],
+            project_id: a["projectId"],
+            role_id: a["roleId"],
+            start_date: a["startDate"],
+            end_date: a["endDate"],
+            minutes_per_day: a["minutesPerDay"],
+            is_placeholder: a["isPlaceholder"],
+            is_active: a["isActive"],
+            note: a["note"],
+          }
+        },
+      })
+    rescue StandardError => e
+      Rails.logger.warn("[Mcp::GetRunnProjectionsTool] #{e.class}: #{e.message}")
+      Sentry.capture_exception(e) if defined?(Sentry)
+      # never echo upstream/internal error bodies to the caller
+      Responses.error("get_runn_projections failed; the error was logged")
+    end
+  end
+end

--- a/app/services/mcp/server.rb
+++ b/app/services/mcp/server.rb
@@ -21,6 +21,7 @@ module Mcp
       Mcp::ListOpenAdminTasksTool,
       Mcp::ListProjectsAtRiskTool,
       Mcp::GetStudioHealthTool,
+      Mcp::GetRunnProjectionsTool,
     ].freeze
 
     def self.build

--- a/app/services/mcp/server.rb
+++ b/app/services/mcp/server.rb
@@ -21,7 +21,7 @@ module Mcp
       Mcp::ListOpenAdminTasksTool,
       Mcp::ListProjectsAtRiskTool,
       Mcp::GetStudioHealthTool,
-      Mcp::GetRunnProjectionsTool,
+      Mcp::GetResourcingProjectionsTool,
     ].freeze
 
     def self.build

--- a/lib/stacks/runn.rb
+++ b/lib/stacks/runn.rb
@@ -122,7 +122,7 @@ class Stacks::Runn
   end
 
   # Projection-plane reads: planned (forward) assignments. Read-only — backs
-  # the get_runn_projections MCP tool; the actuals write path above is
+  # the get_resourcing_projections MCP tool; the actuals write path above is
   # untouched and nothing here writes to Runn.
   def get_assignments
     values = []
@@ -142,7 +142,7 @@ class Stacks::Runn
   # Runn splits assignments around scheduled leave, so leave that OVERLAPS
   # an assignment means the leave was filed after the allocation — the
   # divergence the resourcing sweep looks for. STAGED: not yet called by
-  # get_runn_projections (N-per-person live calls are too heavy for the
+  # get_resourcing_projections (N-per-person live calls are too heavy for the
   # synchronous MCP path) — the sweep currently reads leave from Runn
   # directly; this lands here so a future batched read has one home.
   def get_leave_for_person(person_id)

--- a/lib/stacks/runn.rb
+++ b/lib/stacks/runn.rb
@@ -110,6 +110,41 @@ class Stacks::Runn
     values
   end
 
+  # Projection-plane reads: planned (forward) assignments and scheduled
+  # leave. Read-only — these back the get_runn_projections MCP tool; the
+  # actuals write path above is untouched and nothing here writes to Runn.
+  def get_assignments
+    values = []
+    next_cursor = nil
+    loop do
+      response = handle_response {
+        self.class.get("/assignments?limit=200&cursor=#{next_cursor}", headers: @headers)
+      }
+      values = [*values, *response["values"]]
+      next_cursor = response["nextCursor"]
+      break if next_cursor.nil?
+    end
+    values
+  end
+
+  # Leave is only exposed per person (GET /people/:id/time-offs/leave).
+  # Runn splits assignments around scheduled leave, so leave that OVERLAPS
+  # an assignment means the leave was filed after the allocation — exactly
+  # the divergence the resourcing sweep looks for.
+  def get_leave_for_person(person_id)
+    values = []
+    next_cursor = nil
+    loop do
+      response = handle_response {
+        self.class.get("/people/#{person_id}/time-offs/leave?limit=200&cursor=#{next_cursor}", headers: @headers)
+      }
+      values = [*values, *response["values"]]
+      next_cursor = response["nextCursor"]
+      break if next_cursor.nil?
+    end
+    values
+  end
+
   def sync_projects!(all_projects = get_projects())
     data = all_projects.map do |c|
       {

--- a/lib/stacks/runn.rb
+++ b/lib/stacks/runn.rb
@@ -2,7 +2,11 @@ class Stacks::Runn
   include HTTParty
   base_uri 'https://api.runn.io'
 
-  def initialize()
+  # max_retries: 429 backoff count. The cron-side sync keeps the historical
+  # 5×61s behavior; request-path callers (MCP tools) MUST pass 0 so a Runn
+  # rate-limit can never park a web worker in sleep().
+  def initialize(max_retries: 5)
+    @max_retries = max_retries
     @headers = {
       "Accept": "application/json",
       "Content-Type": "application/json",
@@ -19,8 +23,15 @@ class Stacks::Runn
       raise response.to_s unless response.success?
       response
     rescue => e
-      raise e unless JSON.parse(e.try(:message))["statusCode"] == 429
-      raise e unless retry_count < 5
+      # non-JSON error bodies (HTML 502s etc.) must re-raise the ORIGINAL
+      # error, not a JSON::ParserError that masks it
+      is_rate_limited = begin
+        JSON.parse(e.try(:message).to_s)["statusCode"] == 429
+      rescue JSON::ParserError, TypeError, NoMethodError
+        false
+      end
+      raise e unless is_rate_limited
+      raise e unless retry_count < @max_retries
 
       retry_count += 1
       puts "~~~> Sleeping 61.seconds then retrying for the #{retry_count} time"
@@ -110,15 +121,15 @@ class Stacks::Runn
     values
   end
 
-  # Projection-plane reads: planned (forward) assignments and scheduled
-  # leave. Read-only — these back the get_runn_projections MCP tool; the
-  # actuals write path above is untouched and nothing here writes to Runn.
+  # Projection-plane reads: planned (forward) assignments. Read-only — backs
+  # the get_runn_projections MCP tool; the actuals write path above is
+  # untouched and nothing here writes to Runn.
   def get_assignments
     values = []
     next_cursor = nil
     loop do
       response = handle_response {
-        self.class.get("/assignments?limit=200&cursor=#{next_cursor}", headers: @headers)
+        self.class.get("/assignments?limit=200&cursor=#{CGI.escape(next_cursor.to_s)}", headers: @headers)
       }
       values = [*values, *response["values"]]
       next_cursor = response["nextCursor"]
@@ -129,14 +140,18 @@ class Stacks::Runn
 
   # Leave is only exposed per person (GET /people/:id/time-offs/leave).
   # Runn splits assignments around scheduled leave, so leave that OVERLAPS
-  # an assignment means the leave was filed after the allocation — exactly
-  # the divergence the resourcing sweep looks for.
+  # an assignment means the leave was filed after the allocation — the
+  # divergence the resourcing sweep looks for. STAGED: not yet called by
+  # get_runn_projections (N-per-person live calls are too heavy for the
+  # synchronous MCP path) — the sweep currently reads leave from Runn
+  # directly; this lands here so a future batched read has one home.
   def get_leave_for_person(person_id)
+    person_id = Integer(person_id) # path-injection guard: callers may pass agent-derived input
     values = []
     next_cursor = nil
     loop do
       response = handle_response {
-        self.class.get("/people/#{person_id}/time-offs/leave?limit=200&cursor=#{next_cursor}", headers: @headers)
+        self.class.get("/people/#{person_id}/time-offs/leave?limit=200&cursor=#{CGI.escape(next_cursor.to_s)}", headers: @headers)
       }
       values = [*values, *response["values"]]
       next_cursor = response["nextCursor"]

--- a/test/integration/mcp_endpoint_test.rb
+++ b/test/integration/mcp_endpoint_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class McpEndpointTest < ActionDispatch::IntegrationTest
+  include ActiveSupport::Testing::TimeHelpers
+
   TOOLS_LIST_REQUEST = {
     jsonrpc: "2.0",
     id: 1,
@@ -55,8 +57,74 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
     assert body.key?("result"), "Expected JSON-RPC result key, got: #{body.inspect}"
     tool_names = body["result"]["tools"].map { |t| t["name"] }
     assert_includes tool_names, "search", "Expected 'search' tool in: #{tool_names.inspect}"
-    assert_equal %w[get_ar_aging get_document get_studio_health list_documents list_open_admin_tasks list_overdue_invoices list_projects_at_risk list_sources search], tool_names.sort,
+    assert_equal %w[get_ar_aging get_document get_runn_projections get_studio_health list_documents list_open_admin_tasks list_overdue_invoices list_projects_at_risk list_sources search], tool_names.sort,
       "Expected all registered tools, got: #{tool_names.inspect}"
+  end
+
+  test "tools/call round-trip for get_runn_projections window-filters and joins trackers" do
+    travel_to Time.zone.parse("2026-07-15 12:00:00") # midnight-proof: tool + test must agree on "today"
+    today = Time.zone.today
+    Stacks::Runn.any_instance.stubs(:get_projects).returns([
+      { "id" => 91_100, "name" => "Mapped Project", "isConfirmed" => true, "isArchived" => false, "isTemplate" => false, "clientId" => 5, "budget" => 100_000, "pricingModel" => "tm" },
+      { "id" => 91_200, "name" => "Tentative Deal", "isConfirmed" => false, "isArchived" => false, "isTemplate" => false, "clientId" => 6, "budget" => nil, "pricingModel" => "tm" },
+      { "id" => 91_300, "name" => "Old Archived", "isConfirmed" => true, "isArchived" => true, "isTemplate" => false, "clientId" => 7, "budget" => nil, "pricingModel" => "tm" },
+    ])
+    Stacks::Runn.any_instance.stubs(:get_people).returns([
+      { "id" => 10, "firstName" => "Ada", "lastName" => "Lovelace", "email" => "ada@example.com", "isArchived" => false },
+      { "id" => 11, "firstName" => "Old", "lastName" => "Timer", "email" => "old@example.com", "isArchived" => true },
+    ])
+    Stacks::Runn.any_instance.stubs(:get_assignments).returns([
+      { "id" => 1, "personId" => 10, "projectId" => 91_100, "roleId" => 7, "startDate" => (today - 5).iso8601, "endDate" => (today + 10).iso8601, "minutesPerDay" => 480, "isPlaceholder" => false, "isActive" => true, "isTemplate" => false, "note" => "" },
+      { "id" => 2, "personId" => 10, "projectId" => 91_100, "roleId" => 7, "startDate" => (today - 90).iso8601, "endDate" => (today - 30).iso8601, "minutesPerDay" => 480, "isPlaceholder" => false, "isActive" => true, "isTemplate" => false, "note" => "" },
+      { "id" => 3, "personId" => 10, "projectId" => 91_300, "roleId" => 7, "startDate" => today.iso8601, "endDate" => (today + 5).iso8601, "minutesPerDay" => 240, "isPlaceholder" => true, "isActive" => true, "isTemplate" => false, "note" => "" },
+      # boundary pins: ends exactly today (in), starts exactly at the horizon (in), nil start (dropped)
+      { "id" => 4, "personId" => 10, "projectId" => 91_100, "roleId" => 7, "startDate" => (today - 10).iso8601, "endDate" => today.iso8601, "minutesPerDay" => 240, "isPlaceholder" => false, "isActive" => true, "isTemplate" => false, "note" => "" },
+      { "id" => 5, "personId" => 10, "projectId" => 91_100, "roleId" => 7, "startDate" => (today + 90).iso8601, "endDate" => (today + 120).iso8601, "minutesPerDay" => 240, "isPlaceholder" => false, "isActive" => true, "isTemplate" => false, "note" => "" },
+      { "id" => 6, "personId" => 10, "projectId" => 91_100, "roleId" => 7, "startDate" => nil, "endDate" => (today + 10).iso8601, "minutesPerDay" => 240, "isPlaceholder" => false, "isActive" => true, "isTemplate" => false, "note" => "" },
+    ])
+
+    RunnProject.create!(runn_id: 91_100, name: "Mapped Project", data: {})
+    tracker = ProjectTracker.new(
+      name: "Mapped Tracker",
+      runn_project_id: 91_100,
+      snapshot: { "first_forecast_assignment_start_date" => (today - 30).iso8601,
+                  "last_forecast_assignment_end_date" => (today + 20).iso8601,
+                  "hours_total" => 400.0, "hours_free" => 12.5 }
+    )
+    assert tracker.save(validate: false), "test tracker should persist"
+
+    payload = call_tool("get_runn_projections")
+
+    assert_equal 2, payload["projects"].size, "archived project should be excluded by default"
+    mapped = payload["projects"].find { |p| p["runn_id"] == 91_100 }
+    tentative = payload["projects"].find { |p| p["runn_id"] == 91_200 }
+    assert_equal true, mapped["is_confirmed"]
+    assert_equal "Mapped Tracker", mapped.dig("project_tracker", "name")
+    assert_equal (today + 20).iso8601, mapped.dig("project_tracker", "snapshot_end_date")
+    assert_equal false, tentative["is_confirmed"]
+    assert_nil tentative["project_tracker"]
+
+    assert_equal [1, 4, 5], payload["assignments"].map { |a| a["id"] }.sort,
+      "past (2), archived-project (3) and nil-date (6) drop; today-boundary (4) and horizon-boundary (5) stay"
+    assert_equal 480, payload["assignments"].first["minutes_per_day"]
+    assert_equal true, payload["assignments"].first.key?("is_placeholder")
+    assert_equal ["Ada Lovelace"], payload["people"].map { |p| p["name"] },
+      "archived people must be excluded by default"
+    assert payload["people"].none? { |p| p.key?("email") }, "emails must not appear on this surface"
+    assert_equal today.iso8601, payload["as_of"]
+    assert_equal (today + 90).iso8601, payload.dig("window", "end")
+  end
+
+  test "get_runn_projections clamps a hostile window_days" do
+    Stacks::Runn.any_instance.stubs(:get_projects).returns([])
+    Stacks::Runn.any_instance.stubs(:get_people).returns([])
+    Stacks::Runn.any_instance.stubs(:get_assignments).returns([])
+
+    payload = call_tool("get_runn_projections", { window_days: 100_000 })
+    assert_equal (Time.zone.today + 365).iso8601, payload.dig("window", "end"), "window must clamp to 365 days"
+
+    payload = call_tool("get_runn_projections", { window_days: -5 })
+    assert_equal (Time.zone.today + 1).iso8601, payload.dig("window", "end"), "window must clamp up to 1 day"
   end
 
   test "POST tools/call for get_ar_aging returns a parseable report" do

--- a/test/integration/mcp_endpoint_test.rb
+++ b/test/integration/mcp_endpoint_test.rb
@@ -57,11 +57,11 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
     assert body.key?("result"), "Expected JSON-RPC result key, got: #{body.inspect}"
     tool_names = body["result"]["tools"].map { |t| t["name"] }
     assert_includes tool_names, "search", "Expected 'search' tool in: #{tool_names.inspect}"
-    assert_equal %w[get_ar_aging get_document get_runn_projections get_studio_health list_documents list_open_admin_tasks list_overdue_invoices list_projects_at_risk list_sources search], tool_names.sort,
+    assert_equal %w[get_ar_aging get_document get_resourcing_projections get_studio_health list_documents list_open_admin_tasks list_overdue_invoices list_projects_at_risk list_sources search], tool_names.sort,
       "Expected all registered tools, got: #{tool_names.inspect}"
   end
 
-  test "tools/call round-trip for get_runn_projections window-filters and joins trackers" do
+  test "tools/call round-trip for get_resourcing_projections window-filters and joins trackers" do
     travel_to Time.zone.parse("2026-07-15 12:00:00") # midnight-proof: tool + test must agree on "today"
     today = Time.zone.today
     Stacks::Runn.any_instance.stubs(:get_projects).returns([
@@ -93,11 +93,11 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
     )
     assert tracker.save(validate: false), "test tracker should persist"
 
-    payload = call_tool("get_runn_projections")
+    payload = call_tool("get_resourcing_projections")
 
     assert_equal 2, payload["projects"].size, "archived project should be excluded by default"
-    mapped = payload["projects"].find { |p| p["runn_id"] == 91_100 }
-    tentative = payload["projects"].find { |p| p["runn_id"] == 91_200 }
+    mapped = payload["projects"].find { |p| p["id"] == 91_100 }
+    tentative = payload["projects"].find { |p| p["id"] == 91_200 }
     assert_equal true, mapped["is_confirmed"]
     assert_equal "Mapped Tracker", mapped.dig("project_tracker", "name")
     assert_equal (today + 20).iso8601, mapped.dig("project_tracker", "snapshot_end_date")
@@ -115,15 +115,15 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
     assert_equal (today + 90).iso8601, payload.dig("window", "end")
   end
 
-  test "get_runn_projections clamps a hostile window_days" do
+  test "get_resourcing_projections clamps a hostile window_days" do
     Stacks::Runn.any_instance.stubs(:get_projects).returns([])
     Stacks::Runn.any_instance.stubs(:get_people).returns([])
     Stacks::Runn.any_instance.stubs(:get_assignments).returns([])
 
-    payload = call_tool("get_runn_projections", { window_days: 100_000 })
+    payload = call_tool("get_resourcing_projections", { window_days: 100_000 })
     assert_equal (Time.zone.today + 365).iso8601, payload.dig("window", "end"), "window must clamp to 365 days"
 
-    payload = call_tool("get_runn_projections", { window_days: -5 })
+    payload = call_tool("get_resourcing_projections", { window_days: -5 })
     assert_equal (Time.zone.today + 1).iso8601, payload.dig("window", "end"), "window must clamp up to 1 day"
   end
 

--- a/test/lib/stacks/runn_test.rb
+++ b/test/lib/stacks/runn_test.rb
@@ -94,6 +94,44 @@ class Stacks::RunnTest < ActiveSupport::TestCase
     assert_equal parsed, result
   end
 
+  # --------------------------------------------------------------------------
+  # get_assignments / get_leave_for_person (projection-plane reads)
+  # --------------------------------------------------------------------------
+
+  def paged_response(values, next_cursor)
+    r = mock("response")
+    r.stubs(:success?).returns(true)
+    r.stubs(:[]).with("values").returns(values)
+    r.stubs(:[]).with("nextCursor").returns(next_cursor)
+    r
+  end
+
+  test "get_assignments paginates with cursor until exhausted" do
+    page1 = paged_response([{ "id" => 1, "personId" => 10 }], "abc")
+    page2 = paged_response([{ "id" => 2, "personId" => 11 }], nil)
+
+    requested_paths = []
+    Stacks::Runn.expects(:get).twice.with do |path, _opts|
+      requested_paths << path
+      true
+    end.returns(page1, page2)
+
+    result = @runn.get_assignments
+
+    assert_equal ["/assignments?limit=200&cursor=", "/assignments?limit=200&cursor=abc"], requested_paths
+    assert_equal [1, 2], result.map { |a| a["id"] }
+  end
+
+  test "get_leave_for_person hits the per-person leave endpoint" do
+    page = paged_response([{ "id" => 5, "startDate" => "2026-08-03", "endDate" => "2026-08-07" }], nil)
+
+    Stacks::Runn.expects(:get).once.with do |path, _opts|
+      path == "/people/869358/time-offs/leave?limit=200&cursor="
+    end.returns(page)
+
+    assert_equal [5], @runn.get_leave_for_person(869358).map { |l| l["id"] }
+  end
+
   test "create_project respects pricing_model and is_confirmed overrides" do
     response = mock("response")
     response.stubs(:success?).returns(true)

--- a/test/lib/stacks/runn_test.rb
+++ b/test/lib/stacks/runn_test.rb
@@ -122,6 +122,27 @@ class Stacks::RunnTest < ActiveSupport::TestCase
     assert_equal [1, 2], result.map { |a| a["id"] }
   end
 
+  test "max_retries: 0 raises immediately on a 429 — no sleep, no second request" do
+    runn = Stacks::Runn.new(max_retries: 0)
+    response = mock("response")
+    response.stubs(:success?).returns(false)
+    response.stubs(:to_s).returns('{"statusCode":429}')
+    Stacks::Runn.expects(:get).once.returns(response)
+    runn.expects(:sleep).never
+
+    assert_raises(RuntimeError) { runn.get_assignments }
+  end
+
+  test "non-JSON error bodies re-raise the original error, not a JSON::ParserError" do
+    response = mock("response")
+    response.stubs(:success?).returns(false)
+    response.stubs(:to_s).returns("<html>502 Bad Gateway</html>")
+    Stacks::Runn.expects(:get).once.returns(response)
+
+    error = assert_raises(RuntimeError) { @runn.get_assignments }
+    assert_includes error.message, "502 Bad Gateway"
+  end
+
   test "get_leave_for_person hits the per-person leave endpoint" do
     page = paged_response([{ "id" => 5, "startDate" => "2026-08-03", "endDate" => "2026-08-07" }], nil)
 


### PR DESCRIPTION
Adds the R1 read layer for the **Runn Forecasting OODA loop** (spec + consumer: sanctuarycomputer/stacksbot#43): `Stacks::Runn#get_assignments` + `#get_leave_for_person` (cursor-paginated, read-only) and an MCP tool `get_resourcing_projections` on the existing read-only `/api/mcp` surface.

## What the tool returns
Forward planned assignments window-filtered to `[today, today + window_days]` (default 90, clamped 1–365), non-archived people (no emails), and projects with the `is_confirmed` tentative flag — each joined to its `ProjectTracker` (unique `runn_project_id` index verified) for snapshot end dates + hours. Actuals, rates, and money are untouched; the nightly `ProjectTrackerForecastToRunnSyncTask` path is not modified (full suite: **697 runs, 0F/0E**).

## Hardening (from a 2-lens adversarial review: correctness + security/invariants)
- **No in-request 429 sleep**: `Stacks::Runn.new(max_retries: 0)` on the web path; cron keeps its historical 5×61s backoff. `handle_response` no longer masks non-JSON error bodies with `JSON::ParserError`.
- **No internals leakage**: generic error responses (message logged + Sentry'd, never echoed).
- **Param safety**: `window_days` clamped; `Integer()` guard on `person_id`; cursors CGI-escaped.
- Boundary-pinned, time-frozen integration tests (today/horizon edges, nil dates, hostile `window_days`, archived-people gating).

## Noted follow-ups (out of scope, from review)
- Server-side `startDate`/`endDate` filters on `/assignments` once Runn's overlap semantics are verified (full-history fetch is ~7 pages today).
- Business-timezone alignment for `today` across all MCP tools (all currently share the `Time.zone`/UTC convention).
- Pre-existing: non-constant-time `X-Api-Key` compare in `ApiController`.

`get_leave_for_person` is staged (documented as such) — the sweep reads leave directly for now; a future batched read gets one home here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
