### PR TITLE
Show source add-count + timestamps on the contact page

### DIFF
--- a/app/admin/contacts.rb
+++ b/app/admin/contacts.rb
@@ -59,6 +59,36 @@ ActiveAdmin.register Contact do
       row :created_at
       row :updated_at
     end
+
+    panel "Source Events" do
+      events = resource.source_events || {}
+      if events.blank?
+        para "No source events recorded yet."
+      else
+        rows = events.map do |source, entries|
+          times = Array(entries)
+            .map { |e| e.is_a?(Hash) ? e["added_at"] : nil }
+            .compact
+            .map { |t| Time.iso8601(t) rescue nil }
+            .compact
+            .sort
+          { source: source, count: times.length, times: times }
+        end.sort_by { |r| [-r[:count], r[:source]] }
+
+        table_for rows do
+          column("Source") { |r| r[:source] }
+          column("Times added") { |r| "#{r[:count]}×" }
+          column("When") do |r|
+            ul do
+              r[:times].each do |t|
+                li "#{t.utc.strftime('%b %-d, %Y %H:%M UTC')} " \
+                   "(#{ApplicationController.helpers.time_ago_in_words(t)} ago)"
+              end
+            end
+          end
+        end
+      end
+    end
   end
 
   index download_links: [:csv] do

--- a/test/integration/admin_contact_source_events_test.rb
+++ b/test/integration/admin_contact_source_events_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class AdminContactSourceEventsTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @admin = AdminUser.create!(
+      email: "admin-#{SecureRandom.hex(4)}@example.com",
+      password: 'password12345',
+      password_confirmation: 'password12345',
+      roles: ['admin']
+    )
+    sign_in @admin
+  end
+
+  test 'contact show lists each source with its add count and timestamps' do
+    contact = Contact.create!(
+      email: 'viewer@example.com',
+      sources: ['g3d:family_intelligence:fundraising-viewed'],
+      source_events: {
+        'g3d:family_intelligence:fundraising-viewed' => [
+          { 'added_at' => '2026-06-01T00:00:00Z' },
+          { 'added_at' => '2026-06-02T12:30:00Z' },
+        ],
+      }
+    )
+
+    get "/admin/contacts/#{contact.id}"
+
+    assert_response :success
+    assert_includes response.body, 'Source Events'
+    assert_includes response.body, 'g3d:family_intelligence:fundraising-viewed'
+    assert_includes response.body, '2×', 'shows the add count'
+    assert_includes response.body, 'Jun 1, 2026', 'shows the first timestamp'
+    assert_includes response.body, 'Jun 2, 2026', 'shows the second timestamp'
+  end
+
+  test 'contact show notes when there are no source events' do
+    contact = Contact.create!(email: 'noevents@example.com')
+
+    get "/admin/contacts/#{contact.id}"
+
+    assert_response :success
+    assert_includes response.body, 'No source events recorded yet.'
+  end
+end


### PR DESCRIPTION
## Summary
Makes it easy to see, on a contact's admin show page, **how many times and when** each source was added — reading the `source_events` jsonb the contacts API now records (per-view `{added_at}` events).

Adds a **Source Events** panel below the attributes table:
- One row per source, sorted most-frequent first.
- **Times added** column shows the count (e.g. `3×`).
- **When** column lists every timestamp, formatted (`Jun 2, 2026 12:30 UTC`) with a relative age (`10 minutes ago`).
- Empty state: "No source events recorded yet."

## Example
```
Source Events
Source                                       | Times added | When
g3d:family_intelligence:fundraising-viewed   | 3×          | Jun 1, 2026 00:00 UTC (about 1 month ago)
                                                             Jun 2, 2026 12:30 UTC (about 1 month ago)
                                                             Jul 11, 2026 18:35 UTC (10 minutes ago)
g3d:family_intelligence                      | 1×          | May 15, 2026 09:00 UTC (…)
```

## Tests
TDD: integration test signs in as an admin and asserts the populated panel (source, count, timestamps) and the empty-state message. `bin/rails test` for the touched areas (admin/contact/api) — 29 runs, 0 failures.

Admin-view only — no schema change, no migration, safe to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)