### PR TITLE
feat(mcp): /api/mcp/write — resourcing projection write surface + recent_actuals

### DIFF
--- a/app/controllers/api/mcp_write_controller.rb
+++ b/app/controllers/api/mcp_write_controller.rb
@@ -1,0 +1,34 @@
+class Api::McpWriteController < ApiController
+  skip_before_action :verify_authenticity_token
+  before_action :check_mcp_key_configured!
+  before_action :check_private_api_key!
+
+  def handle
+    Rails.logger.info("[Mcp::WriteServer] #{request.method} /api/mcp/write from #{request.remote_ip}")
+
+    transport = MCP::Server::Transports::StreamableHTTPTransport.new(
+      Mcp::WriteServer.build,
+      stateless: true,
+      enable_json_response: true
+    )
+
+    # Rewind in case Rails consumed the body during parameter parsing.
+    request.body.rewind
+    status, headers, body = transport.handle_request(request)
+
+    body_str = body.first
+    if body_str
+      render json: body_str, status: status
+    else
+      head status
+    end
+  end
+
+  private
+
+  def check_mcp_key_configured!
+    if Stacks::Utils.config.dig(:stacks, :private_api_key).to_s.strip.empty?
+      raise Stacks::Errors::Unauthorized.new('MCP API key not configured')
+    end
+  end
+end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -6,7 +6,10 @@ class ApiController < ActionController::Base
   end
 
   def check_private_api_key!
-    if request.headers["X-Api-Key"] != Stacks::Utils.config[:stacks][:private_api_key]
+    # constant-time compare: this key now gates a mutation surface too
+    provided = request.headers["X-Api-Key"].to_s
+    expected = Stacks::Utils.config[:stacks][:private_api_key].to_s
+    unless ActiveSupport::SecurityUtils.secure_compare(provided, expected)
       raise Stacks::Errors::Unauthorized.new('Invalid API Key')
     end
   end

--- a/app/services/mcp/archive_project_tool.rb
+++ b/app/services/mcp/archive_project_tool.rb
@@ -1,0 +1,38 @@
+module Mcp
+  class ArchiveProjectTool < MCP::Tool
+    tool_name 'archive_project'
+    description 'WRITE: archive (or unarchive) a projection project. Refuses CONFIRMED projects ' \
+                'unless allow_confirmed is true — archiving real engagements is a human-signed act. ' \
+                'Intended for dead-deal tentative shells.'
+    input_schema(
+      properties: {
+        project_id: { type: 'number' },
+        is_archived: { type: 'boolean', description: 'true to archive, false to restore' },
+        allow_confirmed: { type: 'boolean', description: 'Required true to touch a confirmed project' },
+      },
+      required: %w[project_id is_archived]
+    )
+    annotations(read_only_hint: false, destructive_hint: true, idempotent_hint: true)
+
+    def self.call(project_id:, is_archived:, allow_confirmed: false, server_context:)
+      pid = WriteValidation.integer!("project_id", project_id)
+
+      # the nightly-synced mirror is the cheap source of truth for the flag
+      mirror = RunnProject.find_by(runn_id: pid)
+      if mirror&.is_confirmed && !allow_confirmed
+        raise ArgumentError, "project #{pid} is confirmed; archiving it requires allow_confirmed: true"
+      end
+
+      WriteGuard.check!
+      before = mirror && { runn_id: mirror.runn_id, name: mirror.name, is_archived: mirror.is_archived, is_confirmed: mirror.is_confirmed }
+      project = Stacks::Runn.new(max_retries: 0).update_project(pid, is_archived: is_archived)
+      Responses.ok({ before: before, after: project })
+    rescue ArgumentError, WriteGuard::CapExceeded => e
+      Responses.error(e.message)
+    rescue StandardError => e
+      Rails.logger.warn("[Mcp::ArchiveProjectTool] #{e.class}: #{e.message}")
+      Sentry.capture_exception(e) if defined?(Sentry)
+      Responses.error("archive_project failed; the error was logged")
+    end
+  end
+end

--- a/app/services/mcp/archive_project_tool.rb
+++ b/app/services/mcp/archive_project_tool.rb
@@ -6,7 +6,7 @@ module Mcp
                 'Intended for dead-deal tentative shells.'
     input_schema(
       properties: {
-        project_id: { type: 'number' },
+        project_id: { type: 'integer' },
         is_archived: { type: 'boolean', description: 'true to archive, false to restore' },
         allow_confirmed: { type: 'boolean', description: 'Required true to touch a confirmed project' },
       },
@@ -17,10 +17,15 @@ module Mcp
     def self.call(project_id:, is_archived:, allow_confirmed: false, server_context:)
       pid = WriteValidation.integer!("project_id", project_id)
 
-      # the nightly-synced mirror is the cheap source of truth for the flag
+      # FAIL CLOSED: the nightly-synced mirror is the cheap source of truth,
+      # and only a mirror row that explicitly says is_confirmed=false unlocks
+      # the unguarded path. A missing row (project newer than the last sync)
+      # or a nil flag is treated as confirmed.
       mirror = RunnProject.find_by(runn_id: pid)
-      if mirror&.is_confirmed && !allow_confirmed
-        raise ArgumentError, "project #{pid} is confirmed; archiving it requires allow_confirmed: true"
+      explicitly_tentative = mirror && mirror.is_confirmed == false
+      if !explicitly_tentative && !allow_confirmed
+        reason = mirror.nil? ? "is not in the nightly mirror yet" : "is confirmed"
+        raise ArgumentError, "project #{pid} #{reason}; archiving it requires allow_confirmed: true"
       end
 
       WriteGuard.check!

--- a/app/services/mcp/create_assignment_tool.rb
+++ b/app/services/mcp/create_assignment_tool.rb
@@ -7,12 +7,12 @@ module Mcp
                 'the replacement first, then delete_assignment the old one.'
     input_schema(
       properties: {
-        person_id: { type: 'number' },
-        project_id: { type: 'number' },
-        role_id: { type: 'number' },
+        person_id: { type: 'integer' },
+        project_id: { type: 'integer' },
+        role_id: { type: 'integer' },
         start_date: { type: 'string', description: 'YYYY-MM-DD' },
         end_date: { type: 'string', description: 'YYYY-MM-DD' },
-        minutes_per_day: { type: 'number', description: '0-1440; 480 = full day' },
+        minutes_per_day: { type: 'integer', description: '0-1440; 480 = full day' },
         note: { type: 'string' },
       },
       required: %w[person_id project_id role_id start_date end_date minutes_per_day]
@@ -20,14 +20,19 @@ module Mcp
     annotations(read_only_hint: false, destructive_hint: false, idempotent_hint: false)
 
     def self.call(person_id:, project_id:, role_id:, start_date:, end_date:, minutes_per_day:, note: nil, server_context:)
+      # validate EVERYTHING before consuming a cap slot
       WriteValidation.date_range!(start_date, end_date)
       minutes = WriteValidation.minutes!(minutes_per_day)
+      pid = WriteValidation.integer!("person_id", person_id)
+      prid = WriteValidation.integer!("project_id", project_id)
+      rid = WriteValidation.integer!("role_id", role_id)
+      note = WriteValidation.short_string!("note", note, 2000) unless note.nil?
       WriteGuard.check!
 
       segments = Stacks::Runn.new(max_retries: 0).create_assignment(
-        person_id: WriteValidation.integer!("person_id", person_id),
-        project_id: WriteValidation.integer!("project_id", project_id),
-        role_id: WriteValidation.integer!("role_id", role_id),
+        person_id: pid,
+        project_id: prid,
+        role_id: rid,
         start_date: start_date,
         end_date: end_date,
         minutes_per_day: minutes,

--- a/app/services/mcp/create_assignment_tool.rb
+++ b/app/services/mcp/create_assignment_tool.rb
@@ -1,0 +1,45 @@
+module Mcp
+  class CreateAssignmentTool < MCP::Tool
+    tool_name 'create_assignment'
+    description 'WRITE: create a planned (projection) assignment — person, project, role, date range, ' \
+                'minutes_per_day (480 = full day). The provider auto-splits around its own scheduled ' \
+                'leave and returns each segment. There is no update: to change an assignment, create ' \
+                'the replacement first, then delete_assignment the old one.'
+    input_schema(
+      properties: {
+        person_id: { type: 'number' },
+        project_id: { type: 'number' },
+        role_id: { type: 'number' },
+        start_date: { type: 'string', description: 'YYYY-MM-DD' },
+        end_date: { type: 'string', description: 'YYYY-MM-DD' },
+        minutes_per_day: { type: 'number', description: '0-1440; 480 = full day' },
+        note: { type: 'string' },
+      },
+      required: %w[person_id project_id role_id start_date end_date minutes_per_day]
+    )
+    annotations(read_only_hint: false, destructive_hint: false, idempotent_hint: false)
+
+    def self.call(person_id:, project_id:, role_id:, start_date:, end_date:, minutes_per_day:, note: nil, server_context:)
+      WriteValidation.date_range!(start_date, end_date)
+      minutes = WriteValidation.minutes!(minutes_per_day)
+      WriteGuard.check!
+
+      segments = Stacks::Runn.new(max_retries: 0).create_assignment(
+        person_id: WriteValidation.integer!("person_id", person_id),
+        project_id: WriteValidation.integer!("project_id", project_id),
+        role_id: WriteValidation.integer!("role_id", role_id),
+        start_date: start_date,
+        end_date: end_date,
+        minutes_per_day: minutes,
+        note: note,
+      )
+      Responses.ok({ before: nil, after: segments })
+    rescue ArgumentError, WriteGuard::CapExceeded => e
+      Responses.error(e.message)
+    rescue StandardError => e
+      Rails.logger.warn("[Mcp::CreateAssignmentTool] #{e.class}: #{e.message}")
+      Sentry.capture_exception(e) if defined?(Sentry)
+      Responses.error("create_assignment failed; the error was logged")
+    end
+  end
+end

--- a/app/services/mcp/create_placeholder_tool.rb
+++ b/app/services/mcp/create_placeholder_tool.rb
@@ -6,7 +6,7 @@ module Mcp
                 '~24h — call create_assignment for it immediately. Returns the placeholder person ' \
                 'id to assign.'
     input_schema(
-      properties: { role_id: { type: 'number' } },
+      properties: { role_id: { type: 'integer' } },
       required: %w[role_id]
     )
     annotations(read_only_hint: false, destructive_hint: false, idempotent_hint: false)

--- a/app/services/mcp/create_placeholder_tool.rb
+++ b/app/services/mcp/create_placeholder_tool.rb
@@ -1,0 +1,28 @@
+module Mcp
+  class CreatePlaceholderTool < MCP::Tool
+    tool_name 'create_placeholder'
+    description 'WRITE: create a placeholder "person" for an unfilled role on a shell/project. ' \
+                'IMPORTANT: the provider garbage-collects placeholders with no assignment within ' \
+                '~24h — call create_assignment for it immediately. Returns the placeholder person ' \
+                'id to assign.'
+    input_schema(
+      properties: { role_id: { type: 'number' } },
+      required: %w[role_id]
+    )
+    annotations(read_only_hint: false, destructive_hint: false, idempotent_hint: false)
+
+    def self.call(role_id:, server_context:)
+      rid = WriteValidation.integer!("role_id", role_id)
+      WriteGuard.check!
+
+      placeholder = Stacks::Runn.new(max_retries: 0).create_placeholder(role_id: rid)
+      Responses.ok({ before: nil, after: placeholder })
+    rescue ArgumentError, WriteGuard::CapExceeded => e
+      Responses.error(e.message)
+    rescue StandardError => e
+      Rails.logger.warn("[Mcp::CreatePlaceholderTool] #{e.class}: #{e.message}")
+      Sentry.capture_exception(e) if defined?(Sentry)
+      Responses.error("create_placeholder failed; the error was logged")
+    end
+  end
+end

--- a/app/services/mcp/create_tentative_project_tool.rb
+++ b/app/services/mcp/create_tentative_project_tool.rb
@@ -1,0 +1,35 @@
+module Mcp
+  class CreateTentativeProjectTool < MCP::Tool
+    tool_name 'create_tentative_project'
+    description 'WRITE: create a TENTATIVE (unconfirmed) project shell for pipeline work. Name should ' \
+                'carry the lead marker, e.g. "Globex Redesign [lead:<notion-page-id>]", so the sweep ' \
+                'can match shells to leads. Tentative-only by design: is_confirmed is not accepted here.'
+    input_schema(
+      properties: {
+        name: { type: 'string' },
+        client_id: { type: 'number' },
+        pricing_model: { type: 'string', description: '"tm" (default), "fp", or "nb"' },
+      },
+      required: %w[name client_id]
+    )
+    annotations(read_only_hint: false, destructive_hint: false, idempotent_hint: false)
+
+    PRICING_MODELS = %w[tm fp nb].freeze
+
+    def self.call(name:, client_id:, pricing_model: 'tm', server_context:)
+      raise ArgumentError, 'name must be non-empty' if name.to_s.strip.empty?
+      raise ArgumentError, "pricing_model must be one of #{PRICING_MODELS.join(', ')}" unless PRICING_MODELS.include?(pricing_model)
+      cid = WriteValidation.integer!("client_id", client_id)
+      WriteGuard.check!
+
+      project = Stacks::Runn.new(max_retries: 0).create_project(name.to_s.strip, cid, pricing_model: pricing_model, is_confirmed: false)
+      Responses.ok({ before: nil, after: project })
+    rescue ArgumentError, WriteGuard::CapExceeded => e
+      Responses.error(e.message)
+    rescue StandardError => e
+      Rails.logger.warn("[Mcp::CreateTentativeProjectTool] #{e.class}: #{e.message}")
+      Sentry.capture_exception(e) if defined?(Sentry)
+      Responses.error("create_tentative_project failed; the error was logged")
+    end
+  end
+end

--- a/app/services/mcp/create_tentative_project_tool.rb
+++ b/app/services/mcp/create_tentative_project_tool.rb
@@ -7,7 +7,7 @@ module Mcp
     input_schema(
       properties: {
         name: { type: 'string' },
-        client_id: { type: 'number' },
+        client_id: { type: 'integer' },
         pricing_model: { type: 'string', description: '"tm" (default), "fp", or "nb"' },
       },
       required: %w[name client_id]
@@ -18,11 +18,12 @@ module Mcp
 
     def self.call(name:, client_id:, pricing_model: 'tm', server_context:)
       raise ArgumentError, 'name must be non-empty' if name.to_s.strip.empty?
+      name = WriteValidation.short_string!("name", name.to_s.strip, 255)
       raise ArgumentError, "pricing_model must be one of #{PRICING_MODELS.join(', ')}" unless PRICING_MODELS.include?(pricing_model)
       cid = WriteValidation.integer!("client_id", client_id)
       WriteGuard.check!
 
-      project = Stacks::Runn.new(max_retries: 0).create_project(name.to_s.strip, cid, pricing_model: pricing_model, is_confirmed: false)
+      project = Stacks::Runn.new(max_retries: 0).create_project(name, cid, pricing_model: pricing_model, is_confirmed: false)
       Responses.ok({ before: nil, after: project })
     rescue ArgumentError, WriteGuard::CapExceeded => e
       Responses.error(e.message)

--- a/app/services/mcp/delete_assignment_tool.rb
+++ b/app/services/mcp/delete_assignment_tool.rb
@@ -1,0 +1,27 @@
+module Mcp
+  class DeleteAssignmentTool < MCP::Tool
+    tool_name 'delete_assignment'
+    description 'WRITE: delete a planned (projection) assignment by id. The provider has no ' \
+                'single-assignment read, so keep your own copy of the record as revert material ' \
+                'BEFORE deleting (the sweep world / finding payload carries it).'
+    input_schema(
+      properties: { assignment_id: { type: 'number' } },
+      required: %w[assignment_id]
+    )
+    annotations(read_only_hint: false, destructive_hint: true, idempotent_hint: true)
+
+    def self.call(assignment_id:, server_context:)
+      id = WriteValidation.integer!("assignment_id", assignment_id)
+      WriteGuard.check!
+
+      Stacks::Runn.new(max_retries: 0).delete_assignment(id)
+      Responses.ok({ deleted_assignment_id: id, after: nil })
+    rescue ArgumentError, WriteGuard::CapExceeded => e
+      Responses.error(e.message)
+    rescue StandardError => e
+      Rails.logger.warn("[Mcp::DeleteAssignmentTool] #{e.class}: #{e.message}")
+      Sentry.capture_exception(e) if defined?(Sentry)
+      Responses.error("delete_assignment failed; the error was logged")
+    end
+  end
+end

--- a/app/services/mcp/delete_assignment_tool.rb
+++ b/app/services/mcp/delete_assignment_tool.rb
@@ -5,7 +5,7 @@ module Mcp
                 'single-assignment read, so keep your own copy of the record as revert material ' \
                 'BEFORE deleting (the sweep world / finding payload carries it).'
     input_schema(
-      properties: { assignment_id: { type: 'number' } },
+      properties: { assignment_id: { type: 'integer' } },
       required: %w[assignment_id]
     )
     annotations(read_only_hint: false, destructive_hint: true, idempotent_hint: true)

--- a/app/services/mcp/get_resourcing_projections_tool.rb
+++ b/app/services/mcp/get_resourcing_projections_tool.rb
@@ -3,8 +3,9 @@ module Mcp
     tool_name 'get_resourcing_projections'
     description 'The resourcing PROJECTION plane: forward planned assignments (minutes_per_day, placeholders), ' \
                 'people, and projects with the tentative flag (is_confirmed=false), window-filtered ' \
-                'from today. Where a project maps to a ProjectTracker, its snapshot dates and ' \
-                'hours are joined for divergence checks. Live read of the resourcing tool; never touches actuals.'
+                'from today. Where a project maps to a ProjectTracker, its snapshot dates, hours, and ' \
+                'recent_actuals (who actually worked it in the trailing 3 weeks, at what cadence) are ' \
+                'joined — the extrapolation fuel for unprojected work. Live read; never touches actuals-the-plane.'
     input_schema(
       properties: {
         window_days: { type: 'number', description: 'Horizon in days from today (default 90). Assignments overlapping [today, today + window_days] are returned.' },
@@ -13,6 +14,8 @@ module Mcp
       required: []
     )
     annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true)
+
+    RECENT_WINDOW_DAYS = 21
 
     def self.call(window_days: 90, include_archived: false, server_context:)
       # Request path: no 429 sleep-retry (a rate limit must never park a web
@@ -26,8 +29,11 @@ module Mcp
       projects = projects.reject { |p| p["isArchived"] } unless include_archived
       project_ids = projects.map { |p| p["id"] }.to_set
 
-      assignments = runn.get_assignments.select do |a|
-        next false if a["isTemplate"]
+      # full history retained: recent_actuals derives last-known roles from it
+      raw_assignments = runn.get_assignments.reject { |a| a["isTemplate"] }
+      raw_people = runn.get_people
+
+      assignments = raw_assignments.select do |a|
         next false unless project_ids.include?(a["projectId"])
 
         start_date = begin; Date.parse(a["startDate"].to_s); rescue ArgumentError, TypeError; nil; end
@@ -40,6 +46,8 @@ module Mcp
       trackers_by_runn_id = ProjectTracker
         .where(runn_project_id: project_ids.to_a)
         .index_by(&:runn_project_id)
+
+      recent_actuals_by_runn_id = recent_actuals(trackers_by_runn_id, raw_people, raw_assignments, today)
 
       Responses.ok({
         as_of: today.iso8601,
@@ -55,6 +63,7 @@ module Mcp
             budget: p["budget"],
             pricing_model: p["pricingModel"],
             url: "https://app.runn.io/projects/#{p['id']}",
+            recent_actuals: recent_actuals_by_runn_id[p["id"]] || [],
             project_tracker: tracker && {
               id: tracker.id,
               name: tracker.name,
@@ -65,7 +74,7 @@ module Mcp
             },
           }
         },
-        people: runn.get_people
+        people: raw_people
           .reject { |p| p["isArchived"] && !include_archived }
           .map { |p|
             # deliberately no email — assignments join on id; former-staff
@@ -98,5 +107,66 @@ module Mcp
       # never echo upstream/internal error bodies to the caller
       Responses.error("get_resourcing_projections failed; the error was logged")
     end
+
+    # Who actually worked each tracker-mapped project in the trailing window,
+    # at what observed cadence — from the local Forecast mirror (zero provider
+    # calls). Emails are matched internally and never emitted. role_id is the
+    # person's most recent historical assignment role (same project preferred)
+    # so extrapolated projections can be created without guessing roles.
+    def self.recent_actuals(trackers_by_runn_id, raw_people, raw_assignments, today)
+      cutoff = today - RECENT_WINDOW_DAYS
+      runn_id_by_email = raw_people.each_with_object({}) do |p, h|
+        email = (p["email"] || "").downcase
+        h[email] = p["id"] unless email.empty?
+      end
+      name_by_person_id = raw_people.each_with_object({}) do |p, h|
+        h[p["id"]] = [p["firstName"], p["lastName"]].compact.join(" ")
+      end
+      history_by_person = raw_assignments.group_by { |a| a["personId"] }
+
+      trackers_by_runn_id.each_with_object({}) do |(runn_id, tracker), out|
+        entries = {}
+        tracker.forecast_assignments
+          .includes(:forecast_person, :forecast_project)
+          .where("forecast_assignments.end_date >= ?", cutoff)
+          .each do |fa|
+            next if fa.is_time_off?
+            next if fa.allocation.nil?
+
+            person_id = runn_id_by_email[(fa.forecast_person&.email || "").downcase]
+            next if person_id.nil?
+
+            window_start = [fa.start_date, cutoff].max
+            window_end = [fa.end_date, today].min
+            next if window_start > window_end
+            weekdays = (window_start..window_end).count { |d| (1..5).cover?(d.wday) }
+            next if weekdays.zero?
+
+            entry = (entries[person_id] ||= { minutes: 0.0, weekdays: 0, last: window_end })
+            entry[:minutes] += (fa.allocation / 60.0) * weekdays
+            entry[:weekdays] += weekdays
+            entry[:last] = [entry[:last], window_end].max
+          end
+
+        out[runn_id] = entries.map do |person_id, entry|
+          history = history_by_person[person_id] || []
+          same_project = history.select { |a| a["projectId"] == runn_id }
+          latest = (same_project.presence || history).max_by { |a| a["endDate"].to_s }
+          {
+            person_id: person_id,
+            name: name_by_person_id[person_id],
+            avg_minutes_per_day: (entry[:minutes] / entry[:weekdays]).round,
+            last_active_on: entry[:last].iso8601,
+            role_id: latest && latest["roleId"],
+          }
+        end.sort_by { |e| -e[:avg_minutes_per_day] }
+      end
+    rescue StandardError => e
+      # recent_actuals is enrichment — its failure degrades, never breaks, the read
+      Rails.logger.warn("[Mcp::GetResourcingProjectionsTool] recent_actuals failed: #{e.class}: #{e.message}")
+      Sentry.capture_exception(e) if defined?(Sentry)
+      {}
+    end
+    private_class_method :recent_actuals
   end
 end

--- a/app/services/mcp/get_resourcing_projections_tool.rb
+++ b/app/services/mcp/get_resourcing_projections_tool.rb
@@ -115,23 +115,27 @@ module Mcp
     # so extrapolated projections can be created without guessing roles.
     def self.recent_actuals(trackers_by_runn_id, raw_people, raw_assignments, today)
       cutoff = today - RECENT_WINDOW_DAYS
-      runn_id_by_email = raw_people.each_with_object({}) do |p, h|
-        email = (p["email"] || "").downcase
-        h[email] = p["id"] unless email.empty?
-      end
+      # archived people last so an active rehire with the same email wins the index
+      runn_id_by_email = raw_people
+        .sort_by { |p| p["isArchived"] ? 1 : 0 }
+        .each_with_object({}) do |p, h|
+          email = (p["email"] || "").downcase
+          h[email] = p["id"] if !email.empty? && (!h.key?(email) || !p["isArchived"])
+        end
       name_by_person_id = raw_people.each_with_object({}) do |p, h|
         h[p["id"]] = [p["firstName"], p["lastName"]].compact.join(" ")
       end
       history_by_person = raw_assignments.group_by { |a| a["personId"] }
 
       trackers_by_runn_id.each_with_object({}) do |(runn_id, tracker), out|
-        entries = {}
+        # per person: date → minutes, so overlapping ForecastAssignments SUM
+        # on shared days instead of diluting the average
+        minutes_by_person_day = Hash.new { |h, k| h[k] = Hash.new(0.0) }
         tracker.forecast_assignments
-          .includes(:forecast_person, :forecast_project)
+          .includes(:forecast_person, forecast_project: :forecast_client)
           .where("forecast_assignments.end_date >= ?", cutoff)
           .each do |fa|
             next if fa.is_time_off?
-            next if fa.allocation.nil?
 
             person_id = runn_id_by_email[(fa.forecast_person&.email || "").downcase]
             next if person_id.nil?
@@ -139,24 +143,25 @@ module Mcp
             window_start = [fa.start_date, cutoff].max
             window_end = [fa.end_date, today].min
             next if window_start > window_end
-            weekdays = (window_start..window_end).count { |d| (1..5).cover?(d.wday) }
-            next if weekdays.zero?
 
-            entry = (entries[person_id] ||= { minutes: 0.0, weekdays: 0, last: window_end })
-            entry[:minutes] += (fa.allocation / 60.0) * weekdays
-            entry[:weekdays] += weekdays
-            entry[:last] = [entry[:last], window_end].max
+            # nil allocation means full-time in Forecast's own semantics
+            # (see ForecastAssignment#allocation_in_seconds)
+            daily_minutes = (fa.allocation || Stacks::System.singleton_class::EIGHT_HOURS_IN_SECONDS) / 60.0
+            (window_start..window_end).each do |d|
+              next unless (1..5).cover?(d.wday)
+              minutes_by_person_day[person_id][d] += daily_minutes
+            end
           end
 
-        out[runn_id] = entries.map do |person_id, entry|
+        out[runn_id] = minutes_by_person_day.map do |person_id, by_day|
           history = history_by_person[person_id] || []
           same_project = history.select { |a| a["projectId"] == runn_id }
           latest = (same_project.presence || history).max_by { |a| a["endDate"].to_s }
           {
             person_id: person_id,
             name: name_by_person_id[person_id],
-            avg_minutes_per_day: (entry[:minutes] / entry[:weekdays]).round,
-            last_active_on: entry[:last].iso8601,
+            avg_minutes_per_day: (by_day.values.sum / by_day.size).round,
+            last_active_on: by_day.keys.max.iso8601,
             role_id: latest && latest["roleId"],
           }
         end.sort_by { |e| -e[:avg_minutes_per_day] }

--- a/app/services/mcp/write_guard.rb
+++ b/app/services/mcp/write_guard.rb
@@ -1,0 +1,24 @@
+module Mcp
+  # Runaway circuit breaker for the write surface — NOT a trust gate.
+  # Caps total mutations per calendar day so a stuck agent loop can't
+  # rewrite the projection plane 10,000 times overnight.
+  module WriteGuard
+    DAILY_CAP = 500
+
+    class CapExceeded < StandardError; end
+
+    def self.check!
+      key = "mcp_write_count:#{Date.today.iso8601}"
+      count = Rails.cache.increment(key, 1, initial: 1, expires_in: 48.hours)
+      # increment can return nil on some cache stores when the key is fresh —
+      # fall back to a read-modify-write
+      if count.nil?
+        count = (Rails.cache.read(key) || 0) + 1
+        Rails.cache.write(key, count, expires_in: 48.hours)
+      end
+      return count unless count > DAILY_CAP
+
+      raise CapExceeded, "daily write cap (#{DAILY_CAP}) reached; refusing further mutations until tomorrow"
+    end
+  end
+end

--- a/app/services/mcp/write_guard.rb
+++ b/app/services/mcp/write_guard.rb
@@ -1,21 +1,21 @@
 module Mcp
   # Runaway circuit breaker for the write surface — NOT a trust gate.
-  # Caps total mutations per calendar day so a stuck agent loop can't
-  # rewrite the projection plane 10,000 times overnight.
+  # Caps mutations per calendar day so a stuck agent loop can't rewrite the
+  # projection plane 10,000 times overnight. Deliberate slop: the counter is
+  # a per-process MemoryStore (effective cap = DAILY_CAP × puma workers per
+  # dyno), read-modify-write races undercount slightly, and LRU eviction can
+  # reset it mid-day. All fine for a breaker; none of it is a guarantee.
   module WriteGuard
     DAILY_CAP = 500
 
     class CapExceeded < StandardError; end
 
     def self.check!
-      key = "mcp_write_count:#{Date.today.iso8601}"
-      count = Rails.cache.increment(key, 1, initial: 1, expires_in: 48.hours)
-      # increment can return nil on some cache stores when the key is fresh —
-      # fall back to a read-modify-write
-      if count.nil?
-        count = (Rails.cache.read(key) || 0) + 1
-        Rails.cache.write(key, count, expires_in: 48.hours)
-      end
+      # Rails 6.1 MemoryStore#increment returns nil for a missing key (and
+      # has no initial: kwarg), so plain read-modify-write is the honest path.
+      key = "mcp_write_count:#{Time.zone.today.iso8601}"
+      count = (Rails.cache.read(key) || 0) + 1
+      Rails.cache.write(key, count, expires_in: 48.hours)
       return count unless count > DAILY_CAP
 
       raise CapExceeded, "daily write cap (#{DAILY_CAP}) reached; refusing further mutations until tomorrow"

--- a/app/services/mcp/write_server.rb
+++ b/app/services/mcp/write_server.rb
@@ -1,0 +1,29 @@
+unless defined?(MCP::Server)
+  mcp_gem = Gem.loaded_specs['mcp']
+  raise "mcp gem not found in Gem.loaded_specs; cannot resolve MCP::Server" unless mcp_gem
+  require File.join(mcp_gem.gem_dir, 'lib', 'mcp', 'server')
+end
+
+module Mcp
+  # The WRITE surface (/api/mcp/write). Deliberately disjoint from
+  # Mcp::Server (/api/mcp), which stays read-only forever. Only
+  # projection-plane tools exist here — actuals, rates, and money have no
+  # tools, so no composition can reach them.
+  class WriteServer
+    TOOLS = [
+      Mcp::CreateAssignmentTool,
+      Mcp::DeleteAssignmentTool,
+      Mcp::CreateTentativeProjectTool,
+      Mcp::ArchiveProjectTool,
+      Mcp::CreatePlaceholderTool,
+    ].freeze
+
+    def self.build
+      MCP::Server.new(
+        name: "stacks-write",
+        version: "1.0.0",
+        tools: TOOLS
+      )
+    end
+  end
+end

--- a/app/services/mcp/write_validation.rb
+++ b/app/services/mcp/write_validation.rb
@@ -1,0 +1,33 @@
+module Mcp
+  # Shared validation floor for write tools. Raises ArgumentError with a
+  # caller-safe message (no internals) — tools rescue and return it verbatim.
+  module WriteValidation
+    ISO_DATE = /\A\d{4}-\d{2}-\d{2}\z/.freeze
+
+    def self.integer!(name, value)
+      Integer(value)
+    rescue ArgumentError, TypeError
+      raise ArgumentError, "#{name} must be an integer id"
+    end
+
+    def self.date!(name, value)
+      raise ArgumentError, "#{name} must be a YYYY-MM-DD date" unless value.to_s.match?(ISO_DATE)
+      Date.parse(value.to_s)
+    rescue Date::Error
+      raise ArgumentError, "#{name} must be a valid YYYY-MM-DD date"
+    end
+
+    def self.date_range!(start_date, end_date)
+      s = date!("start_date", start_date)
+      e = date!("end_date", end_date)
+      raise ArgumentError, "start_date must be on or before end_date" if s > e
+      [s, e]
+    end
+
+    def self.minutes!(value)
+      m = integer!("minutes_per_day", value)
+      raise ArgumentError, "minutes_per_day must be between 0 and 1440" unless (0..1440).cover?(m)
+      m
+    end
+  end
+end

--- a/app/services/mcp/write_validation.rb
+++ b/app/services/mcp/write_validation.rb
@@ -5,9 +5,18 @@ module Mcp
     ISO_DATE = /\A\d{4}-\d{2}-\d{2}\z/.freeze
 
     def self.integer!(name, value)
+      # Integer(4.5) truncates rather than raising — a fractional id must
+      # never silently mutate the neighboring entity
+      raise ArgumentError, "#{name} must be an integer" if value.is_a?(Numeric) && value != value.to_i
       Integer(value)
     rescue ArgumentError, TypeError
-      raise ArgumentError, "#{name} must be an integer id"
+      raise ArgumentError, "#{name} must be an integer"
+    end
+
+    def self.short_string!(name, value, max)
+      s = value.to_s
+      raise ArgumentError, "#{name} must be #{max} characters or fewer" if s.length > max
+      s
     end
 
     def self.date!(name, value)
@@ -17,10 +26,13 @@ module Mcp
       raise ArgumentError, "#{name} must be a valid YYYY-MM-DD date"
     end
 
+    MAX_RANGE_DAYS = 366
+
     def self.date_range!(start_date, end_date)
       s = date!("start_date", start_date)
       e = date!("end_date", end_date)
       raise ArgumentError, "start_date must be on or before end_date" if s > e
+      raise ArgumentError, "date range must be #{MAX_RANGE_DAYS} days or fewer" if (e - s).to_i > MAX_RANGE_DAYS
       [s, e]
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,5 +17,6 @@ Rails.application.routes.draw do
     resources :profit_share_passes, only: [:index]
     resources :contacts, only: [:create, :index]
     match '/mcp', to: 'mcp#handle', via: [:post, :get, :delete]
+    match '/mcp/write', to: 'mcp_write#handle', via: [:post, :get, :delete]
   end
 end

--- a/lib/stacks/runn.rb
+++ b/lib/stacks/runn.rb
@@ -160,6 +160,52 @@ class Stacks::Runn
     values
   end
 
+  # --------------------------------------------------------------------------
+  # Projection-plane WRITES. Consumed only by the /api/mcp/write tools —
+  # planned assignments, tentative shells, placeholders. Runn has no
+  # assignment-update endpoint: changes are delete + recreate (the caller's
+  # concern). Nothing here touches actuals or rates.
+  # --------------------------------------------------------------------------
+
+  def create_assignment(person_id:, project_id:, role_id:, start_date:, end_date:, minutes_per_day:, note: nil, is_billable: nil)
+    body = {
+      "personId" => Integer(person_id),
+      "projectId" => Integer(project_id),
+      "roleId" => Integer(role_id),
+      "startDate" => start_date,
+      "endDate" => end_date,
+      "minutesPerDay" => Integer(minutes_per_day),
+      "note" => note,
+      "isBillable" => is_billable,
+    }.compact
+    handle_response {
+      self.class.post("/assignments", { body: JSON.dump(body), headers: @headers })
+    }.parsed_response
+  end
+
+  def delete_assignment(assignment_id)
+    assignment_id = Integer(assignment_id)
+    handle_response {
+      self.class.delete("/assignments/#{assignment_id}", headers: @headers)
+    }.parsed_response
+  end
+
+  def update_project(project_id, is_archived: nil, is_confirmed: nil)
+    project_id = Integer(project_id)
+    body = { "isArchived" => is_archived, "isConfirmed" => is_confirmed }.compact
+    handle_response {
+      self.class.patch("/projects/#{project_id}", { body: JSON.dump(body), headers: @headers })
+    }.parsed_response
+  end
+
+  # Placeholder "person" (names are Runn-generated). Runn garbage-collects
+  # placeholders with no assignment within ~24h — callers must assign fast.
+  def create_placeholder(role_id:)
+    handle_response {
+      self.class.post("/placeholders", { body: JSON.dump({ "roleId" => Integer(role_id) }), headers: @headers })
+    }.parsed_response
+  end
+
   def sync_projects!(all_projects = get_projects())
     data = all_projects.map do |c|
       {

--- a/lib/stacks/runn.rb
+++ b/lib/stacks/runn.rb
@@ -192,6 +192,7 @@ class Stacks::Runn
 
   def update_project(project_id, is_archived: nil, is_confirmed: nil)
     project_id = Integer(project_id)
+    raise ArgumentError, "update_project: no fields to update" if is_archived.nil? && is_confirmed.nil?
     body = { "isArchived" => is_archived, "isConfirmed" => is_confirmed }.compact
     handle_response {
       self.class.patch("/projects/#{project_id}", { body: JSON.dump(body), headers: @headers })

--- a/test/integration/mcp_endpoint_test.rb
+++ b/test/integration/mcp_endpoint_test.rb
@@ -115,6 +115,54 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
     assert_equal (today + 90).iso8601, payload.dig("window", "end")
   end
 
+  test "get_resourcing_projections computes recent_actuals from the Forecast mirror" do
+    travel_to Time.zone.parse("2026-07-15 12:00:00")
+    today = Time.zone.today
+
+    Stacks::Runn.any_instance.stubs(:get_projects).returns([
+      { "id" => 92_100, "name" => "Actuals Project", "isConfirmed" => true, "isArchived" => false, "isTemplate" => false, "clientId" => 5, "budget" => nil, "pricingModel" => "tm" },
+    ])
+    Stacks::Runn.any_instance.stubs(:get_people).returns([
+      { "id" => 30, "firstName" => "Fresh", "lastName" => "Worker", "email" => "fresh@example.com", "isArchived" => false },
+      { "id" => 31, "firstName" => "Stale", "lastName" => "Worker", "email" => "stale@example.com", "isArchived" => false },
+    ])
+    # one HISTORICAL (pre-window) assignment pins Fresh Worker's last-known role
+    Stacks::Runn.any_instance.stubs(:get_assignments).returns([
+      { "id" => 900, "personId" => 30, "projectId" => 92_100, "roleId" => 7, "startDate" => (today - 200).iso8601, "endDate" => (today - 100).iso8601, "minutesPerDay" => 480, "isPlaceholder" => false, "isActive" => true, "isTemplate" => false, "note" => "" },
+    ])
+
+    RunnProject.create!(runn_id: 92_100, name: "Actuals Project", data: {})
+    tracker = ProjectTracker.new(name: "Actuals Tracker", runn_project_id: 92_100,
+      snapshot: { "last_forecast_assignment_end_date" => (today + 30).iso8601 })
+    assert tracker.save(validate: false)
+
+    # Forecast models key on forecast_id (the upstream Harvest Forecast id)
+    fclient = ForecastClient.create!(forecast_id: 70_001, name: "Actuals Client")
+    fproject = ForecastProject.create!(forecast_id: 70_100, name: "Actuals Project", code: "ACT-1", forecast_client: fclient)
+    ProjectTrackerForecastProject.create!(project_tracker: tracker, forecast_project: fproject)
+    fresh = ForecastPerson.create!(forecast_id: 70_030, email: "fresh@example.com", first_name: "Fresh", last_name: "Worker")
+    stale = ForecastPerson.create!(forecast_id: 70_031, email: "stale@example.com", first_name: "Stale", last_name: "Worker")
+    # fresh: 480 min/day (28800s) over the last two weeks — inside the 21d window
+    ForecastAssignment.create!(forecast_person: fresh, forecast_project: fproject,
+      start_date: today - 14, end_date: today - 1, allocation: 28_800)
+    # stale: activity entirely before the window
+    ForecastAssignment.create!(forecast_person: stale, forecast_project: fproject,
+      start_date: today - 90, end_date: today - 40, allocation: 28_800)
+
+    payload = call_tool("get_resourcing_projections")
+
+    project = payload["projects"].find { |p| p["id"] == 92_100 }
+    actuals = project["recent_actuals"]
+    assert_equal 1, actuals.size, "only in-window people appear; got: #{actuals.inspect}"
+    entry = actuals.first
+    assert_equal 30, entry["person_id"]
+    assert_equal "Fresh Worker", entry["name"]
+    assert_equal 480, entry["avg_minutes_per_day"]
+    assert_equal (today - 1).iso8601, entry["last_active_on"]
+    assert_equal 7, entry["role_id"], "role comes from the most recent historical assignment"
+    assert entry.keys.exclude?("email"), "no emails on the surface"
+  end
+
   test "get_resourcing_projections clamps a hostile window_days" do
     Stacks::Runn.any_instance.stubs(:get_projects).returns([])
     Stacks::Runn.any_instance.stubs(:get_people).returns([])

--- a/test/integration/mcp_endpoint_test.rb
+++ b/test/integration/mcp_endpoint_test.rb
@@ -145,6 +145,10 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
     # fresh: 480 min/day (28800s) over the last two weeks — inside the 21d window
     ForecastAssignment.create!(forecast_person: fresh, forecast_project: fproject,
       start_date: today - 14, end_date: today - 1, allocation: 28_800)
+    # overlapping second FA (240 min/day over the last week) must SUM on shared
+    # days: 10 weekdays × 480 + 5 weekdays × 240 = 6000 over 10 days → 600 avg
+    ForecastAssignment.create!(forecast_person: fresh, forecast_project: fproject,
+      start_date: today - 7, end_date: today - 1, allocation: 14_400)
     # stale: activity entirely before the window
     ForecastAssignment.create!(forecast_person: stale, forecast_project: fproject,
       start_date: today - 90, end_date: today - 40, allocation: 28_800)
@@ -157,7 +161,7 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
     entry = actuals.first
     assert_equal 30, entry["person_id"]
     assert_equal "Fresh Worker", entry["name"]
-    assert_equal 480, entry["avg_minutes_per_day"]
+    assert_equal 600, entry["avg_minutes_per_day"], "overlapping assignments must sum per day, not dilute the mean"
     assert_equal (today - 1).iso8601, entry["last_active_on"]
     assert_equal 7, entry["role_id"], "role comes from the most recent historical assignment"
     assert entry.keys.exclude?("email"), "no emails on the surface"

--- a/test/integration/mcp_write_endpoint_test.rb
+++ b/test/integration/mcp_write_endpoint_test.rb
@@ -1,0 +1,147 @@
+require 'test_helper'
+
+class McpWriteEndpointTest < ActionDispatch::IntegrationTest
+  WRITE_TOOLS = %w[archive_project create_assignment create_placeholder create_tentative_project delete_assignment].freeze
+
+  MCP_HEADERS = {
+    "Content-Type" => "application/json",
+    "Accept" => "application/json"
+  }.freeze
+
+  def api_key_headers
+    MCP_HEADERS.merge("X-Api-Key" => Stacks::Utils.config[:stacks][:private_api_key])
+  end
+
+  def tools_list(path)
+    post path, headers: api_key_headers,
+      params: { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }.to_json
+    assert_response :success
+    JSON.parse(response.body)["result"]["tools"].map { |t| t["name"] }
+  end
+
+  def call_tool(name, arguments = {})
+    post "/api/mcp/write", headers: api_key_headers,
+      params: { jsonrpc: "2.0", id: 99, method: "tools/call",
+                params: { name: name, arguments: arguments } }.to_json
+    assert_response :success
+    JSON.parse(JSON.parse(response.body).dig("result", "content", 0, "text"))
+  end
+
+  setup do
+    Rails.cache.delete("mcp_write_count:#{Date.today.iso8601}")
+  end
+
+  # ----- auth -----
+
+  test "POST /api/mcp/write without X-Api-Key returns 403" do
+    post "/api/mcp/write", headers: MCP_HEADERS,
+      params: { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }.to_json
+    assert_response :forbidden
+  end
+
+  test "POST /api/mcp/write with wrong key returns 403" do
+    post "/api/mcp/write", headers: MCP_HEADERS.merge("X-Api-Key" => "nope"),
+      params: { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }.to_json
+    assert_response :forbidden
+  end
+
+  # ----- surface isolation (the read-only invariant, pinned) -----
+
+  test "write surface exposes exactly the five write tools" do
+    assert_equal WRITE_TOOLS, tools_list("/api/mcp/write").sort
+  end
+
+  test "read surface exposes NONE of the write tools" do
+    read_tools = tools_list("/api/mcp")
+    assert_empty read_tools & WRITE_TOOLS,
+      "read-only /api/mcp must never expose write tools; found: #{read_tools & WRITE_TOOLS}"
+  end
+
+  # ----- tool behavior -----
+
+  test "create_assignment validates, applies, and returns segments" do
+    segments = [{ "id" => 5001, "personId" => 10, "startDate" => "2026-07-14", "endDate" => "2026-09-30" }]
+    Stacks::Runn.any_instance.expects(:create_assignment).once.returns(segments)
+
+    payload = call_tool("create_assignment", { person_id: 10, project_id: 100, role_id: 7,
+      start_date: "2026-07-14", end_date: "2026-09-30", minutes_per_day: 480 })
+
+    assert_equal segments, payload["after"]
+    assert_nil payload["before"]
+  end
+
+  test "create_assignment rejects out-of-range minutes without calling the provider" do
+    Stacks::Runn.any_instance.expects(:create_assignment).never
+    payload = call_tool("create_assignment", { person_id: 10, project_id: 100, role_id: 7,
+      start_date: "2026-07-14", end_date: "2026-09-30", minutes_per_day: 2000 })
+    assert_match(/minutes_per_day/, payload["error"])
+  end
+
+  test "create_assignment rejects inverted date ranges" do
+    Stacks::Runn.any_instance.expects(:create_assignment).never
+    payload = call_tool("create_assignment", { person_id: 10, project_id: 100, role_id: 7,
+      start_date: "2026-09-30", end_date: "2026-07-14", minutes_per_day: 480 })
+    assert_match(/start_date must be on or before end_date/, payload["error"])
+  end
+
+  test "delete_assignment deletes by id and echoes it" do
+    Stacks::Runn.any_instance.expects(:delete_assignment).once.with(5001).returns({})
+    payload = call_tool("delete_assignment", { assignment_id: 5001 })
+    assert_equal 5001, payload["deleted_assignment_id"]
+  end
+
+  test "archive_project refuses a confirmed project without allow_confirmed" do
+    RunnProject.create!(runn_id: 88_200, name: "Real Engagement", is_confirmed: true, data: {})
+    Stacks::Runn.any_instance.expects(:update_project).never
+
+    payload = call_tool("archive_project", { project_id: 88_200, is_archived: true })
+    assert_match(/confirmed/, payload["error"])
+  end
+
+  test "archive_project archives a tentative shell and returns before/after" do
+    RunnProject.create!(runn_id: 88_300, name: "Dead Deal [lead:abc]", is_confirmed: false, data: {})
+    Stacks::Runn.any_instance.expects(:update_project).once.with(88_300, is_archived: true)
+      .returns({ "id" => 88_300, "isArchived" => true })
+
+    payload = call_tool("archive_project", { project_id: 88_300, is_archived: true })
+    assert_equal false, payload.dig("before", "is_confirmed")
+    assert_equal true, payload.dig("after", "isArchived")
+  end
+
+  test "create_tentative_project always creates unconfirmed" do
+    Stacks::Runn.any_instance.expects(:create_project).once
+      .with("Globex Redesign [lead:abc123]", 5, pricing_model: "tm", is_confirmed: false)
+      .returns({ "id" => 99_100, "isConfirmed" => false })
+
+    payload = call_tool("create_tentative_project", { name: "Globex Redesign [lead:abc123]", client_id: 5 })
+    assert_equal false, payload.dig("after", "isConfirmed")
+  end
+
+  test "create_placeholder passes the role through" do
+    Stacks::Runn.any_instance.expects(:create_placeholder).once.with(role_id: 7).returns({ "id" => 999_001 })
+    payload = call_tool("create_placeholder", { role_id: 7 })
+    assert_equal 999_001, payload.dig("after", "id")
+  end
+
+  # ----- circuit breaker -----
+
+  test "daily cap refuses further mutations" do
+    # the test env cache is a :null_store — use a real store so the counter counts
+    store = ActiveSupport::Cache::MemoryStore.new
+    Rails.stubs(:cache).returns(store)
+    store.write("mcp_write_count:#{Date.today.iso8601}", Mcp::WriteGuard::DAILY_CAP)
+    Stacks::Runn.any_instance.expects(:delete_assignment).never
+
+    payload = call_tool("delete_assignment", { assignment_id: 1 })
+    assert_match(/daily write cap/, payload["error"])
+  end
+
+  test "writes below the cap increment the counter" do
+    store = ActiveSupport::Cache::MemoryStore.new
+    Rails.stubs(:cache).returns(store)
+    Stacks::Runn.any_instance.expects(:delete_assignment).once.returns({})
+
+    call_tool("delete_assignment", { assignment_id: 1 })
+    assert_equal 1, store.read("mcp_write_count:#{Date.today.iso8601}").to_i
+  end
+end

--- a/test/integration/mcp_write_endpoint_test.rb
+++ b/test/integration/mcp_write_endpoint_test.rb
@@ -28,7 +28,7 @@ class McpWriteEndpointTest < ActionDispatch::IntegrationTest
   end
 
   setup do
-    Rails.cache.delete("mcp_write_count:#{Date.today.iso8601}")
+    Rails.cache.delete("mcp_write_count:#{Time.zone.today.iso8601}")
   end
 
   # ----- auth -----
@@ -98,6 +98,21 @@ class McpWriteEndpointTest < ActionDispatch::IntegrationTest
     assert_match(/confirmed/, payload["error"])
   end
 
+  test "archive_project fails CLOSED when the project is absent from the mirror" do
+    Stacks::Runn.any_instance.expects(:update_project).never
+    payload = call_tool("archive_project", { project_id: 77_777, is_archived: true })
+    assert_match(/not in the nightly mirror/, payload["error"])
+  end
+
+  test "fractional ids are rejected by the schema, never truncated into a neighbor" do
+    Stacks::Runn.any_instance.expects(:delete_assignment).never
+    post "/api/mcp/write", headers: api_key_headers,
+      params: { jsonrpc: "2.0", id: 99, method: "tools/call",
+                params: { name: "delete_assignment", arguments: { assignment_id: 5001.9 } } }.to_json
+    body = response.body
+    refute_match(/deleted_assignment_id/, body, "a fractional id must not delete anything")
+  end
+
   test "archive_project archives a tentative shell and returns before/after" do
     RunnProject.create!(runn_id: 88_300, name: "Dead Deal [lead:abc]", is_confirmed: false, data: {})
     Stacks::Runn.any_instance.expects(:update_project).once.with(88_300, is_archived: true)
@@ -129,7 +144,7 @@ class McpWriteEndpointTest < ActionDispatch::IntegrationTest
     # the test env cache is a :null_store — use a real store so the counter counts
     store = ActiveSupport::Cache::MemoryStore.new
     Rails.stubs(:cache).returns(store)
-    store.write("mcp_write_count:#{Date.today.iso8601}", Mcp::WriteGuard::DAILY_CAP)
+    store.write("mcp_write_count:#{Time.zone.today.iso8601}", Mcp::WriteGuard::DAILY_CAP)
     Stacks::Runn.any_instance.expects(:delete_assignment).never
 
     payload = call_tool("delete_assignment", { assignment_id: 1 })
@@ -142,6 +157,6 @@ class McpWriteEndpointTest < ActionDispatch::IntegrationTest
     Stacks::Runn.any_instance.expects(:delete_assignment).once.returns({})
 
     call_tool("delete_assignment", { assignment_id: 1 })
-    assert_equal 1, store.read("mcp_write_count:#{Date.today.iso8601}").to_i
+    assert_equal 1, store.read("mcp_write_count:#{Time.zone.today.iso8601}").to_i
   end
 end

--- a/test/lib/stacks/runn_test.rb
+++ b/test/lib/stacks/runn_test.rb
@@ -95,6 +95,81 @@ class Stacks::RunnTest < ActiveSupport::TestCase
   end
 
   # --------------------------------------------------------------------------
+  # projection-plane writes (assignment CRUD, project patch, placeholder)
+  # --------------------------------------------------------------------------
+
+  test "create_assignment POSTs the camelCase body and returns parsed segments" do
+    parsed = [{ "id" => 5001, "personId" => 10 }]
+    response = mock("response")
+    response.stubs(:success?).returns(true)
+    response.stubs(:parsed_response).returns(parsed)
+    posted = nil
+    Stacks::Runn.expects(:post).once.with do |path, opts|
+      posted = JSON.parse(opts[:body])
+      path == "/assignments"
+    end.returns(response)
+
+    result = @runn.create_assignment(person_id: 10, project_id: 100, role_id: 7,
+      start_date: "2026-07-14", end_date: "2026-09-30", minutes_per_day: 480, note: "x")
+
+    assert_equal({ "personId" => 10, "projectId" => 100, "roleId" => 7,
+      "startDate" => "2026-07-14", "endDate" => "2026-09-30", "minutesPerDay" => 480,
+      "note" => "x" }, posted)
+    assert_equal parsed, result
+  end
+
+  test "create_assignment omits nil optionals and coerces ids" do
+    response = mock("response")
+    response.stubs(:success?).returns(true)
+    response.stubs(:parsed_response).returns([])
+    posted = nil
+    Stacks::Runn.expects(:post).once.with { |_p, opts| posted = JSON.parse(opts[:body]); true }.returns(response)
+
+    @runn.create_assignment(person_id: "10", project_id: 100, role_id: 7,
+      start_date: "2026-07-14", end_date: "2026-09-30", minutes_per_day: 480)
+
+    assert_equal 10, posted["personId"], "string ids must be coerced"
+    refute posted.key?("note"), "nil optionals must be omitted"
+  end
+
+  test "delete_assignment DELETEs by coerced integer id" do
+    response = mock("response")
+    response.stubs(:success?).returns(true)
+    response.stubs(:parsed_response).returns({})
+    Stacks::Runn.expects(:delete).once.with { |path, _| path == "/assignments/5001" }.returns(response)
+    @runn.delete_assignment("5001")
+  end
+
+  test "update_project PATCHes only the provided flags" do
+    response = mock("response")
+    response.stubs(:success?).returns(true)
+    response.stubs(:parsed_response).returns({ "id" => 200, "isArchived" => true })
+    body = nil
+    Stacks::Runn.expects(:patch).once.with do |path, opts|
+      body = JSON.parse(opts[:body])
+      path == "/projects/200"
+    end.returns(response)
+
+    @runn.update_project(200, is_archived: true)
+    assert_equal({ "isArchived" => true }, body)
+  end
+
+  test "create_placeholder POSTs roleId and returns the placeholder person" do
+    parsed = { "id" => 999_001, "roleId" => 7, "firstName" => "Placeholder" }
+    response = mock("response")
+    response.stubs(:success?).returns(true)
+    response.stubs(:parsed_response).returns(parsed)
+    body = nil
+    Stacks::Runn.expects(:post).once.with do |path, opts|
+      body = JSON.parse(opts[:body])
+      path == "/placeholders"
+    end.returns(response)
+
+    assert_equal parsed, @runn.create_placeholder(role_id: 7)
+    assert_equal({ "roleId" => 7 }, body)
+  end
+
+  # --------------------------------------------------------------------------
   # get_assignments / get_leave_for_person (projection-plane reads)
   # --------------------------------------------------------------------------
 


### PR DESCRIPTION
R3 of the resourcing loop (spec: stacksbot `docs/superpowers/specs/2026-07-13-resourcing-write-path-design.md`): Stacksbot takes ownership of the empty projection plane, writing through a dedicated surface.

## The write surface
`POST /api/mcp/write` — a second MCP server, zero registration shared with read-only `/api/mcp` (isolation pinned by test on both endpoints' live `tools/list`). Same `X-Api-Key` (dated relaxation; P7 can slot a scoped token onto just this route). Exactly five tools: `create_assignment`, `delete_assignment`, `create_tentative_project` (unconfirmed-only by construction), `archive_project` (fails CLOSED on anything not explicitly tentative in the nightly mirror), `create_placeholder`. Actuals, rates, and money have no tools here. 500/day circuit breaker; strict validation before cap consumption; generic error responses.

## Read-side: `recent_actuals`
`get_resourcing_projections` now joins, per tracker-mapped project, who actually worked it in the trailing 21 days (local Forecast mirror, zero provider calls): observed avg minutes/day (per-day summing across overlapping assignments; nil allocation = full-time per Forecast's own semantics), last-active date, and last-known role from historical assignments. Extrapolation fuel for the `unprojected-work` detector. Emails matched internally, never emitted.

## Adversarial review (combined correctness+security lens)
Blocker found & fixed: the confirmed-project archive guard originally failed OPEN for projects absent from the mirror. Also fixed from review: fractional-id truncation (integer schemas + non-integral rejection), overlap-diluted averages, nil-allocation invisibility, Rails 6.1 cache-increment semantics, constant-time key compare, empty-PATCH refusal, length/range caps. Sharp edges pinned by test.

Full suite: **730 runs, 0 failures, 0 errors** (2 pre-existing skips).

Companion stacksbot PR (sweep write stage + recipes) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)