### PR TITLE
fix(trueups): year-aware founder trueup range; revert ledger to Sanctuary

### DIFF
--- a/lib/stacks/system.rb
+++ b/lib/stacks/system.rb
@@ -60,11 +60,22 @@ class Stacks::System
       assignments.map{|a| a.forecast_project.forecast_client}.compact.uniq
     end
 
-    def sync_founder_trueups!
+    # Every completed month from the New Deal start up to (but not
+    # including) the current, still-in-progress month.
+    def founder_trueup_months
+      months = []
       working_date = NEW_DEAL_START_AT.clone
       loop do
-        break if working_date.month == Date.today.month
+        break if working_date >= Date.today.beginning_of_month
 
+        months << working_date
+        working_date = working_date.advance(months: 1)
+      end
+      months
+    end
+
+    def sync_founder_trueups!
+      founder_trueup_months.each do |working_date|
         invoice_pass = InvoicePass.includes(invoice_trackers: :contributor_payouts).where(start_of_month: working_date).first
         raise "No invoice pass found for #{working_date}" unless invoice_pass.present?
 
@@ -80,9 +91,7 @@ class Stacks::System
         highest_contributor, highest_contributor_data = contributor_payouts_by_contributor.max_by{|k, v| v[:amount]}
 
         hugh = ForecastPerson.find_by(email: "hugh@sanctuary.computer").contributor
-        # Trueups land on the garden3d ledger now — they're a g3d-level
-        # founder-balance correction, not a Sanctuary obligation.
-        hugh_ledger = Ledger.find_or_create_for(enterprise: Enterprise.garden3d, contributor: hugh)
+        hugh_ledger = Ledger.find_or_create_for(enterprise: Enterprise.sanctuary, contributor: hugh)
         trueup = Trueup.find_or_initialize_by(invoice_pass: invoice_pass, ledger: hugh_ledger)
         founder_trueup_amount = highest_contributor_data[:amount] - contributor_payouts_by_contributor[hugh][:amount]
 
@@ -95,8 +104,6 @@ class Stacks::System
           - **Trueup Amount:** #{ActionController::Base.helpers.number_to_currency(founder_trueup_amount)}
           HEREDOC
         )
-
-        working_date = working_date.advance(months: 1)
       end
     end
   end

--- a/test/lib/stacks/system_test.rb
+++ b/test/lib/stacks/system_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class Stacks::SystemTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::TimeHelpers
+
+  # Regression for the founder-trueup sync silently going no-op once the
+  # calendar reached a month whose number repeats one inside the New Deal
+  # range (June 2025 onward). The old `break if working_date.month ==
+  # Date.today.month` compared month-of-year only, ignoring the year.
+  test "founder_trueup_months covers every completed month since the New Deal, year-aware" do
+    travel_to Date.new(2026, 7, 13) do
+      months = Stacks::System.founder_trueup_months
+
+      assert_equal Date.new(2025, 6, 1), months.first
+      assert_equal Date.new(2026, 6, 1), months.last
+      assert_includes months, Date.new(2026, 5, 1), "May 2026 must be synced"
+      assert_includes months, Date.new(2026, 6, 1), "June 2026 must be synced"
+    end
+  end
+
+  test "founder_trueup_months excludes the current, in-progress month" do
+    travel_to Date.new(2026, 7, 13) do
+      refute_includes Stacks::System.founder_trueup_months, Date.new(2026, 7, 1)
+    end
+  end
+
+  # The month-number collision first bites in June 2026, where the buggy
+  # loop broke on the very first iteration and processed nothing.
+  test "founder_trueup_months does not truncate on a same-month-number collision" do
+    travel_to Date.new(2026, 6, 13) do
+      months = Stacks::System.founder_trueup_months
+      assert_equal Date.new(2025, 6, 1), months.first
+      assert_equal Date.new(2026, 5, 1), months.last
+    end
+  end
+end


### PR DESCRIPTION
## What's going on

Hugh's founder true-ups stopped posting for **May and June 2026** (Paul flagged the gap). Two bugs, both fixed here.

### 1. Year-blind loop (the actual outage)

`Stacks::System.sync_founder_trueups!` walks month-by-month from the New Deal start (June 2025) and stopped on:

```ruby
break if working_date.month == Date.today.month   # month-of-year only, ignores the year
```

It worked for the first year, then broke the instant the calendar reached a month whose *number* repeats one inside the range:

| Run month | Old behaviour |
|---|---|
| Dec 2025 | Jun–Nov 2025 ✅ |
| **Jun 2026** (month 6) | **nothing** — breaks on iteration 1 (Jun 2025 is also month 6) |
| **Jul 2026** (month 7) | **only Jun 2025** — breaks at Jul 2025 |

So since June 2026 the daily task has been a silent no-op for recent months. The scheduled task itself runs fine (daily `SystemTask` rows, zero errors) — it just produced nothing.

**Fix:** extract the month selection into a pure `founder_trueup_months` and terminate on `working_date >= Date.today.beginning_of_month` (year-aware).

### 2. Ledger reroute → reverted to Sanctuary

Commit a9a2fc4 (Jun 2) rerouted founder true-ups onto the **garden3d** ledger, but left the 11 historical true-ups + their QBO bills on **Sanctuary**. Combined with the idempotency key `(invoice_pass, ledger)`, fixing the loop would have created a *fresh garden3d copy of every month* with no `qbo_bill_id` — and the QBO bill sync would have cut **duplicate bills** (~$90k of historical months double-billed).

Per decision, reverted the routing back to Sanctuary so history and backfill live on one ledger and existing bills are preserved. `Enterprise.garden3d` / `GARDEN3D_NAME` are kept — `app/services/qbo/bill_router.rb` depends on the constant.

## Tests

`test/lib/stacks/system_test.rb` freezes time to July/June 2026 and asserts the range spans the New Deal start through the previous month (fails on `main`, passes here).

```
bin/rails test test/lib/stacks/system_test.rb
3 runs, 10 assertions, 0 failures, 0 errors, 0 skips
```

## End-to-end verification (against a prod copy, rolled back)

After removing the stray garden3d dup and running the fixed sync:

- Sanctuary: 11 → **13** true-ups (Jun 2025 → **Jun 2026**)
- **May 2026 created: $9,737.76** · **June 2026 created: $22,718.09**
- 11 existing true-ups + QBO bill IDs **untouched** — no duplicate bills
- garden3d ledger cleared (0)

## Production runbook (post-merge — not yet run)

1. Deploy.
2. `Trueup.find(199).really_destroy!` — remove the stray $0 garden3d dup (no QBO bill attached).
3. `rake stacks:sync_founder_trueups` (or let the daily task fire) → backfills May & June 2026 on Sanctuary.
4. `rake stacks:sync_contributor_qbo_bills` → cuts QBO bills for the 2 new true-ups. Confirm exactly 2 new bills; historical months are skipped (they already carry `qbo_bill_id`s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)