### PR TITLE
fix(runn-sync): auto-confirm tentative projects on actuals + never sync future-dated actuals

### DIFF
--- a/app/models/project_tracker_forecast_to_runn_sync_task.rb
+++ b/app/models/project_tracker_forecast_to_runn_sync_task.rb
@@ -34,6 +34,7 @@ class ProjectTrackerForecastToRunnSyncTask < ApplicationRecord
   def sync!(runn_instance)
     runn(runn_instance)
     raise_if_skip_required!
+    confirm_runn_project_if_needed!
 
     runn_actuals_did_change = false
     forecast_assignments = project_tracker.forecast_assignments.includes(:forecast_person, :forecast_project)
@@ -178,6 +179,20 @@ class ProjectTrackerForecastToRunnSyncTask < ApplicationRecord
     )
   end
 
+  # Runn refuses actuals on tentative projects ("Actuals cannot be on a
+  # tentative project."), and nothing else ever flips the flag — the admin
+  # "Create Runn project" button deliberately creates is_confirmed:false and
+  # nobody finalizes state inside Runn. Real hours flowing IS the
+  # confirmation signal: when we are about to sync actuals for a tentative
+  # project, confirm it first (in Runn and in the local mirror).
+  def confirm_runn_project_if_needed!
+    rp = project_tracker.runn_project
+    return if rp.nil? || rp.is_confirmed != false
+    puts "~~~> Runn project #{rp.runn_id} is tentative but actuals are flowing — confirming it"
+    runn.update_project(rp.runn_id, is_confirmed: true)
+    rp.update(is_confirmed: true)
+  end
+
   # Raises Stacks::Errors::Skipped when the linked Runn project is in a state
   # where syncing actuals can't possibly succeed — archived, non-billable, or
   # missing from our local mirror. The raise flows through run!'s rescue and
@@ -207,10 +222,16 @@ class ProjectTrackerForecastToRunnSyncTask < ApplicationRecord
   # ensures the write to Runn matches the total Stacks lifetime_value.
   def build_forecast_actuals(forecast_assignments)
     forecast_assignments.reduce([]) do |acc, fa|
+      # Runn refuses future-dated actuals ("Cannot create actual for future
+      # date…"): an open assignment stretching past today only syncs the days
+      # that have already happened — the rest sync on future nights.
+      last_syncable_date = [fa.end_date, Date.today].min
+      next acc if fa.start_date > last_syncable_date
+
       runn_role = find_or_create_runn_role_for_forecast_project(fa.forecast_project)
       runn_person = find_or_create_runn_person_for_forecast_person(fa.forecast_person)
 
-      (fa.start_date..fa.end_date).each do |date|
+      (fa.start_date..last_syncable_date).each do |date|
         allocation_in_minutes = (fa.allocation_during_range_in_seconds(date, date, false) / 60.0)
 
         # Runn rounds to the nearest minute - no seconds are permitted.

--- a/app/models/project_tracker_forecast_to_runn_sync_task.rb
+++ b/app/models/project_tracker_forecast_to_runn_sync_task.rb
@@ -34,13 +34,18 @@ class ProjectTrackerForecastToRunnSyncTask < ApplicationRecord
   def sync!(runn_instance)
     runn(runn_instance)
     raise_if_skip_required!
-    confirm_runn_project_if_needed!
 
     runn_actuals_did_change = false
     forecast_assignments = project_tracker.forecast_assignments.includes(:forecast_person, :forecast_project)
 
     # 1. Expand our multi-day forecast_assignments as single day Runn.io actuals for easy diffing
     forecast_assigments_as_runn_actuals = build_forecast_actuals(forecast_assignments)
+
+    # Real (past/today, billable) hours flowing IS the confirmation signal —
+    # confirm a tentative project only once we have actuals to write, never
+    # for an all-future or empty assignment set (which would strip a still-
+    # pipeline shell out of automated dead-deal cleanup).
+    confirm_runn_project_if_needed! if forecast_assigments_as_runn_actuals.any?
 
     runn_actuals = runn.get_actuals_for_project(project_tracker.runn_project.runn_id)
     project_runn_id = project_tracker.runn_project.runn_id
@@ -50,6 +55,13 @@ class ProjectTrackerForecastToRunnSyncTask < ApplicationRecord
     # instead of one HTTP round-trip per actual. For PT 27 (The Light Phone)
     # this collapses ~thousands of POSTs into ~tens.
     pending_writes = []
+
+    # Guard: never emit a future-dated write in EITHER direction. A stale
+    # future actual already in Runn (pre-fix) has no clamped counterpart and
+    # would otherwise be "zeroed" in step 3 — but Runn rejects future writes,
+    # re-raising. Drop such rows from the Runn-side sweep; they age out once
+    # their date passes.
+    runn_actuals = runn_actuals.reject { |ra| Date.parse(ra["date"]) > Time.zone.today }
 
     # 2. Find Forecast Assignments that don't have a corresponding Runn actual & write them
     forecast_assigments_as_runn_actuals.each do |faara|
@@ -127,19 +139,18 @@ class ProjectTrackerForecastToRunnSyncTask < ApplicationRecord
     end
 
     calculated_runn_revenue = calculate_runn_revenue(runn_actuals)
-    # Reconcile against the SAME hours we just wrote, not against the
-    # snapshot-bounded `project_tracker.lifetime_value`. `lifetime_value`
-    # uses pt.start_date..pt.end_date which are read from
-    # `project_tracker.snapshot["last_forecast_assignment_end_date"]` —
-    # that snapshot key isn't refreshed in lockstep with FA changes, so
-    # when an FA's end_date extends past the snapshotted value, LTV
-    # silently undercounts while Runn (correctly) reflects the new dates.
-    # Summing FA#value_in_usd directly bypasses the snapshot and matches
-    # exactly what build_forecast_actuals expanded into Runn.
-    project_tracker_ltv = forecast_assignments.sum(&:value_in_usd).to_f
-    unless calculated_runn_revenue == project_tracker_ltv
-      puts "~~~> Failure, even after sync, Runn revenue is different to total ForecastAssignment value"
-      raise Stacks::Errors::Base.new("Failed Runn sync for Project Tracker (#{project_tracker.name} ID: #{project_tracker.id}), Runn Revenue: #{calculated_runn_revenue}, Project Tracker LTV: #{project_tracker_ltv}")
+    # Reconcile against the SAME hours we just wrote — i.e. the clamped
+    # `forecast_assigments_as_runn_actuals` list, NOT `FA#value_in_usd`.
+    # value_in_usd spans the full unclamped start..end range, so for an
+    # assignment extending past today it counts future days Runn never
+    # received (we never write future-dated actuals), which would make this
+    # equality fail every night for exactly the open/ongoing projects this
+    # sync targets. Deriving expected revenue from the built list keeps the
+    # two sides on identical hours.
+    expected_revenue = calculate_runn_revenue(forecast_assigments_as_runn_actuals)
+    unless calculated_runn_revenue == expected_revenue
+      puts "~~~> Failure, even after sync, Runn revenue is different to the actuals we wrote"
+      raise Stacks::Errors::Base.new("Failed Runn sync for Project Tracker (#{project_tracker.name} ID: #{project_tracker.id}), Runn Revenue: #{calculated_runn_revenue}, Expected (written) Revenue: #{expected_revenue}")
     end
 
     puts "~~~> Worked! Stacks lifetime_value and runn_actuals revenue are in sync!"
@@ -224,8 +235,9 @@ class ProjectTrackerForecastToRunnSyncTask < ApplicationRecord
     forecast_assignments.reduce([]) do |acc, fa|
       # Runn refuses future-dated actuals ("Cannot create actual for future
       # date…"): an open assignment stretching past today only syncs the days
-      # that have already happened — the rest sync on future nights.
-      last_syncable_date = [fa.end_date, Date.today].min
+      # that have already happened — the rest sync on future nights. Bind to
+      # the org calendar (Time.zone.today), not the process UTC date.
+      last_syncable_date = [fa.end_date, Time.zone.today].min
       next acc if fa.start_date > last_syncable_date
 
       runn_role = find_or_create_runn_role_for_forecast_project(fa.forecast_project)

--- a/test/models/project_tracker_forecast_to_runn_sync_task_test.rb
+++ b/test/models/project_tracker_forecast_to_runn_sync_task_test.rb
@@ -1,8 +1,14 @@
 require "test_helper"
 
 class ProjectTrackerForecastToRunnSyncTaskTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::TimeHelpers
+
   setup do
     Thread.current[:sanctuary_enterprise] = nil
+    # Fixture dates live in 2030; freeze "today" just past them so the
+    # future-date clamp (Runn refuses future actuals) is inert for the
+    # existing cases and testable for the new ones.
+    travel_to Time.zone.local(2030, 5, 2, 12)
 
     @date = Date.new(2030, 4, 29)
     @runn_role = { "id" => 999_999, "name" => "$195.00 p/h", "standardRate" => 195.0 }
@@ -245,5 +251,67 @@ class ProjectTrackerForecastToRunnSyncTaskTest < ActiveSupport::TestCase
 
     assert_nothing_raised { @task.send(:raise_skipped_if_runn_project_state_error!, RuntimeError.new("connection refused")) }
     assert_nothing_raised { @task.send(:raise_skipped_if_runn_project_state_error!, RuntimeError.new('{"statusCode":500}')) }
+  end
+
+  # --------------------------------------------------------------------------
+  # future-date clamp + tentative auto-confirm (nightly failures of 2026-07)
+  # --------------------------------------------------------------------------
+
+  test "build_forecast_actuals never emits future-dated actuals" do
+    # frozen today = 2030-05-02; FA runs 05-01 → 05-04
+    fa = ForecastAssignment.create!(
+      forecast_id: rand(1..2_000_000_000),
+      person_id: @forecast_person.forecast_id,
+      project_id: @fp_maintenance.forecast_id,
+      start_date: Date.new(2030, 5, 1), end_date: Date.new(2030, 5, 4),
+      allocation: 2 * 60 * 60,
+    )
+
+    result = @task.send(:build_forecast_actuals, [fa])
+
+    assert_equal ["2030-05-01", "2030-05-02"], result.map { |r| r["date"] }.sort,
+      "days after today must not sync (Runn: 'Cannot create actual for future date')"
+  end
+
+  test "build_forecast_actuals skips assignments that are entirely in the future" do
+    fa = ForecastAssignment.create!(
+      forecast_id: rand(1..2_000_000_000),
+      person_id: @forecast_person.forecast_id,
+      project_id: @fp_maintenance.forecast_id,
+      start_date: Date.new(2030, 5, 3), end_date: Date.new(2030, 5, 6),
+      allocation: 2 * 60 * 60,
+    )
+
+    assert_equal [], @task.send(:build_forecast_actuals, [fa])
+  end
+
+  test "confirm_runn_project_if_needed! flips a tentative project before actuals flow" do
+    runn_project = RunnProject.create!(runn_id: 77_100, name: "Storm King Test", is_confirmed: false, data: {})
+    tracker = ProjectTracker.new(name: "Storm King Test Tracker", runn_project_id: 77_100)
+    assert tracker.save(validate: false)
+    task = ProjectTrackerForecastToRunnSyncTask.new(project_tracker_id: tracker.id)
+    task.stubs(:project_tracker).returns(tracker)
+
+    runn = mock("runn")
+    runn.expects(:update_project).once.with(77_100, is_confirmed: true).returns({ "id" => 77_100, "isConfirmed" => true })
+    task.send(:runn, runn)
+
+    task.send(:confirm_runn_project_if_needed!)
+
+    assert_equal true, runn_project.reload.is_confirmed, "local mirror must flip too"
+  end
+
+  test "confirm_runn_project_if_needed! is a no-op for confirmed projects" do
+    runn_project = RunnProject.create!(runn_id: 77_200, name: "Confirmed Test", is_confirmed: true, data: {})
+    tracker = ProjectTracker.new(name: "Confirmed Test Tracker", runn_project_id: 77_200)
+    assert tracker.save(validate: false)
+    task = ProjectTrackerForecastToRunnSyncTask.new(project_tracker_id: tracker.id)
+    task.stubs(:project_tracker).returns(tracker)
+
+    runn = mock("runn")
+    runn.expects(:update_project).never
+    task.send(:runn, runn)
+
+    task.send(:confirm_runn_project_if_needed!)
   end
 end

--- a/test/models/project_tracker_forecast_to_runn_sync_task_test.rb
+++ b/test/models/project_tracker_forecast_to_runn_sync_task_test.rb
@@ -314,4 +314,56 @@ class ProjectTrackerForecastToRunnSyncTaskTest < ActiveSupport::TestCase
 
     task.send(:confirm_runn_project_if_needed!)
   end
+  # --------------------------------------------------------------------------
+  # sync! integration — the wiring + reconciliation the unit tests don't pin
+  # --------------------------------------------------------------------------
+
+  test "sync! confirms a tentative project and reconciles clamped revenue for a future-extending assignment" do
+    runn_project = RunnProject.create!(runn_id: 78_300, name: "Integ Tentative", is_confirmed: false, data: {})
+    tracker = ProjectTracker.new(name: "Integ Tentative Tracker", runn_project_id: 78_300)
+    assert tracker.save(validate: false)
+
+    fp = ForecastProject.create!(forecast_id: rand(1..2_000_000_000), client_id: @fc.forecast_id,
+      name: "Integ #{SecureRandom.hex(2)}", tags: ["195p/h"])
+    # link the forecast project so tracker.forecast_assignments reaches the FA
+    ProjectTrackerForecastProject.create!(project_tracker: tracker, forecast_project: fp)
+    # 05-01 → 05-05 while today is frozen at 05-02: 2 syncable days (05-01, 05-02), 3 future
+    ForecastAssignment.create!(forecast_id: rand(1..2_000_000_000),
+      person_id: @forecast_person.forecast_id, project_id: fp.forecast_id,
+      start_date: Date.new(2030, 5, 1), end_date: Date.new(2030, 5, 5),
+      allocation: 60 * 60) # 1h/day
+
+    task = ProjectTrackerForecastToRunnSyncTask.new(project_tracker_id: tracker.id)
+    task.stubs(:project_tracker).returns(tracker)
+    task.stubs(:find_or_create_runn_role_for_forecast_project).returns(@runn_role)
+    task.stubs(:find_or_create_runn_person_for_forecast_person).returns(@runn_person)
+
+    runn = mock("runn")
+    runn.stubs(:get_roles).returns([@runn_role])
+    runn.stubs(:get_people).returns([@runn_person])
+    # empty before the write; after the write the reload reflects the 2 rows
+    # we sent (2 days × 60min × $195/60 = $390), matching expected revenue
+    written_back = [
+      { "date" => "2030-05-01", "billableMinutes" => 60, "roleId" => @runn_role["id"], "personId" => @runn_person["id"] },
+      { "date" => "2030-05-02", "billableMinutes" => 60, "roleId" => @runn_role["id"], "personId" => @runn_person["id"] },
+    ]
+    runn.stubs(:get_actuals_for_project).returns([], written_back)
+    # F3: confirm fires (real actuals exist) BEFORE the actuals write
+    confirm_seq = sequence("confirm-then-write")
+    runn.expects(:update_project).with(78_300, is_confirmed: true).in_sequence(confirm_seq)
+      .returns({ "id" => 78_300, "isConfirmed" => true })
+    # 2 syncable days × 1h × $195 = $390; the write carries exactly those 2 rows
+    written = nil
+    runn.expects(:create_or_update_actuals_bulk).in_sequence(confirm_seq).with do |rows|
+      written = rows; true
+    end
+
+    task.send(:sync!, runn)
+
+    assert_equal true, runn_project.reload.is_confirmed
+    assert_equal ["2030-05-01", "2030-05-02"], written.map { |r| r["date"] }.sort,
+      "only past/today days are written; the 3 future days are held"
+    # F1: reconciliation compares written revenue to itself, not unclamped LTV — no raise
+  end
+
 end


### PR DESCRIPTION
Fixes the nightly Forecast→Runn actuals-sync failures (Storm King Development, 5 straight nights since 2026-07-11), surfaced by Stacksbot's Observations digest.

## Two failure classes
1. **`Actuals cannot be on a tentative project.`** — the admin "Create Runn project" button makes `is_confirmed: false` projects "so admins finalize state in Runn," but nobody operates inside Runn. Nothing ever flips the flag, so once real Forecast hours start flowing the nightly sync fails permanently. **Fix:** real (past/today) hours flowing IS the confirmation signal — `sync!` now confirms a tentative project (Runn + local mirror) once it has actuals to write.
2. **`Cannot create actual for future date …`** — the actuals expansion iterated assignment ranges past today. **Fix:** clamp to `[start, min(end, Time.zone.today)]`; future days sync on future nights.

## Adversarial review (one round, all findings fixed)
The reviewer caught that the clamp alone would have **converted the future-date failure into a nightly revenue-mismatch failure** for the same projects (the LTV reconciliation summed unclamped `FA#value_in_usd` while Runn only received clamped days) — a blocker. Also fixed: confirm gated on real actuals existing (never auto-confirms an all-future/empty tracker, preserving dead-deal-cleanup eligibility for pipeline shells); step-3 zeroing no longer emits future-dated writes; `Time.zone.today` not `Date.today`; and a real `sync!` integration test now pins the confirm-before-write ordering and the reconciliation.

Task tests 18/18. Full suite green except 2 **pre-existing** failures in `projects_at_risk_tool_test` (reproduce identically on origin/main with these files reverted — unrelated flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)