### PR TITLE
fix(runn-sync): reconcile revenue at cent resolution, not exact float ==

### DIFF
--- a/app/models/project_tracker_forecast_to_runn_sync_task.rb
+++ b/app/models/project_tracker_forecast_to_runn_sync_task.rb
@@ -148,7 +148,7 @@ class ProjectTrackerForecastToRunnSyncTask < ApplicationRecord
     # sync targets. Deriving expected revenue from the built list keeps the
     # two sides on identical hours.
     expected_revenue = calculate_runn_revenue(forecast_assigments_as_runn_actuals)
-    unless calculated_runn_revenue == expected_revenue
+    unless runn_revenue_reconciled?(calculated_runn_revenue, expected_revenue)
       puts "~~~> Failure, even after sync, Runn revenue is different to the actuals we wrote"
       raise Stacks::Errors::Base.new("Failed Runn sync for Project Tracker (#{project_tracker.name} ID: #{project_tracker.id}), Runn Revenue: #{calculated_runn_revenue}, Expected (written) Revenue: #{expected_revenue}")
     end
@@ -160,6 +160,29 @@ class ProjectTrackerForecastToRunnSyncTask < ApplicationRecord
     runn_actuals.reduce(0) do |acc, ra|
       acc += (runn_roles.find{|rr| rr["id"] == ra["roleId"]}["standardRate"] * (ra["billableMinutes"] / 60.0))
     end
+  end
+
+  # Reconcile two revenue sums at whole-cent resolution. calculate_runn_revenue
+  # sums `rate * (billableMinutes / 60.0)` in each side's row order; float
+  # addition isn't associative, so identical hours summed in Runn's returned
+  # order vs our built order can differ in the last binary digit. An exact
+  # `==` then fails the reconciliation every night for otherwise-synced
+  # projects. Round the DIFFERENCE to cents and require it to be zero: float
+  # summation noise (well under a tenth of a cent even at tens-of-thousands
+  # of rows) rounds away, while a genuine >=1c discrepancy — the smallest real
+  # mis-sync is one billable minute, >= ~$0.20 — survives rounding and fails.
+  #
+  # Two forms were rejected. A raw `(a - b).abs < 0.01` tolerance is unsafe:
+  # `0.01` has no exact binary representation, so a true one-cent gap (e.g.
+  # 1.13 - 1.12) computes as 0.00999… < 0.01 and wrongly reconciles. Rounding
+  # each side to cents — `(a*100).round == (b*100).round` — fixes that but adds
+  # a half-cent rounding seam: for a `.50`-ending rate whose total lands on an
+  # x.xx5 boundary, reorder noise can push the two sides to adjacent cents and
+  # spuriously raise. Rounding the difference (which is only ever noise, or a
+  # real >=1c gap) has no per-side seam and is rate-domain-independent.
+  # (PayStub, app/models/pay_stub.rb, uses the looser per-side tolerance form.)
+  def runn_revenue_reconciled?(runn_revenue, expected_revenue)
+    (runn_revenue - expected_revenue).abs.round(2) == 0
   end
 
   # If Runn returns a 4xx whose response body signals "this project can't

--- a/test/models/project_tracker_forecast_to_runn_sync_task_test.rb
+++ b/test/models/project_tracker_forecast_to_runn_sync_task_test.rb
@@ -366,4 +366,49 @@ class ProjectTrackerForecastToRunnSyncTaskTest < ActiveSupport::TestCase
     # F1: reconciliation compares written revenue to itself, not unclamped LTV — no raise
   end
 
+  # --------------------------------------------------------------------------
+  # revenue reconciliation float tolerance (2026-07 nightly false-failure)
+  # --------------------------------------------------------------------------
+  # calculate_runn_revenue sums `rate * (billableMinutes / 60.0)` in each
+  # side's row order. Float addition isn't associative, so identical hours
+  # summed in Runn's returned order vs our built order differ in the last
+  # binary digit — an exact `==` then fails reconciliation every night for
+  # otherwise-synced projects. We reconcile at a one-cent tolerance instead.
+  test "runn_revenue_reconciled? treats float-summation-order noise as reconciled" do
+    a = 0.1 + 0.2 + 0.3   # => 0.6000000000000001
+    b = 0.3 + 0.2 + 0.1   # => 0.6
+    refute_equal a, b, "precondition: these must be float-unequal to exercise reconciliation"
+    assert @task.send(:runn_revenue_reconciled?, a, b),
+      "sub-cent float noise must reconcile (not raise)"
+  end
+
+  test "runn_revenue_reconciled? treats a sub-cent difference as reconciled" do
+    assert @task.send(:runn_revenue_reconciled?, 100.00, 100.004)
+  end
+
+  test "runn_revenue_reconciled? flags a genuine one-cent discrepancy (float-safe boundary)" do
+    # The exact-1c cases a raw `.abs < 0.01` tolerance would leak: these
+    # differences compute as 0.00999… < 0.01. Integer-cent comparison catches
+    # them — this is the regression guard for the reviewed boundary bug.
+    refute @task.send(:runn_revenue_reconciled?, 1.12, 1.13),
+      "a real one-cent revenue mismatch must still raise"
+    refute @task.send(:runn_revenue_reconciled?, 100.00, 100.01)
+  end
+
+  test "runn_revenue_reconciled? is true for exactly equal revenues" do
+    assert @task.send(:runn_revenue_reconciled?, 999.99, 999.99)
+  end
+
+  test "runn_revenue_reconciled? reconciles zero revenue on both sides" do
+    assert @task.send(:runn_revenue_reconciled?, 0.0, 0.0)
+  end
+
+  test "runn_revenue_reconciled? reconciles a half-cent-boundary total split only by reorder noise" do
+    # Guards the residual of a per-side integer-cent form: for a total on an
+    # x.xx5 boundary (e.g. from a $87.50-style rate), reorder noise near the
+    # half-cent line would round the two sides to adjacent cents and spuriously
+    # raise. Rounding the DIFFERENCE (only noise here) reconciles correctly.
+    assert @task.send(:runn_revenue_reconciled?, 100.005, 100.005 + 1e-12)
+  end
+
 end


### PR DESCRIPTION
## The bug

The nightly Runn sync (`ProjectTrackerForecastToRunnSyncTask`) reconciles a project's revenue after writing actuals: it sums `standardRate * (billableMinutes / 60.0)` over (a) the actuals reloaded from Runn and (b) the list we built and wrote, and raises if they disagree. It compared the two sums with **exact float `==`**.

Float addition isn't associative, so identical hours summed in **Runn's returned row order** vs **our built order** differ in the last binary digit (e.g. `0.6000000000000001` vs `0.6`). The `==` then fails and the job raises a false *"Runn revenue is different"* every night for otherwise-perfectly-synced projects. This is the revenue float-mismatch in the 2026-07 nightly failures — a separate bug from the tentative-project / future-date fixes in #142.

## The fix

`runn_revenue_reconciled?` rounds the **difference** to cents and requires it to be zero:

```ruby
(runn_revenue - expected_revenue).abs.round(2) == 0
```

Summation noise (< a tenth of a cent even at tens-of-thousands of rows) rounds away; a genuine ≥1c discrepancy (the smallest real mis-sync is one billable minute, ≥ ~$0.20) survives and still raises.

**Why round the difference, not compare with a tolerance or per-side cents** (both considered and rejected, documented inline):
- `(a - b).abs < 0.01` is unsafe: `0.01` isn't binary-exact, so a true one-cent gap like `1.13 - 1.12` computes as `0.00999…` and false-passes.
- `(a*100).round == (b*100).round` fixes that but adds a half-cent rounding seam: a `.50`-ending rate whose total lands on an x.xx5 boundary can be split by reorder noise into adjacent cents and spuriously raise.
- Rounding the difference has no per-side seam and is rate-domain-independent.

## Tests & review

TDD'd (red → green). 6 reconciliation cases: order-noise reconciles, sub-cent reconciles, exact-1c raises (the boundary a raw tolerance leaks), zero, and the half-cent-boundary residual. Full file: **24 runs, 0 failures** (6 new + 18 existing, no regressions).

Ran a two-round adversarial review: round 1 caught the `< 0.01` boundary leak (a real Important defect — 4,796 of ~23,000 one-cent pairs would have false-passed); round 2 verified integer-cents closed it and flagged the half-cent residual, which this final round-the-difference form also closes. Verdict: APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
