### PR TITLE
fix(payouts): stop BigDecimal IC amounts serializing into blueprints as strings

### DIFF
--- a/app/models/contributor_payout.rb
+++ b/app/models/contributor_payout.rb
@@ -344,7 +344,7 @@ class ContributorPayout < ApplicationRecord
 
   def as_individual_contributor
     return 0 unless blueprint["IndividualContributor"].present?
-    blueprint["IndividualContributor"].sum{|l| l["amount"]}
+    blueprint["IndividualContributor"].sum{|l| l["amount"].to_f}
   end
 
   def as_commission

--- a/app/models/invoice_tracker.rb
+++ b/app/models/invoice_tracker.rb
@@ -500,7 +500,13 @@ class InvoiceTracker < ApplicationRecord
             }
           else
             ic_share = 1 - pt.company_treasury_split - (account_lead.present? ? 0.08 : 0) - (project_lead.present? ? 0.05 : 0)
-            amount = (working_amount * ic_share).round(2)
+            # company_treasury_split is a BigDecimal column, so ic_share (and thus
+            # working_amount * ic_share) is a BigDecimal — which serializes into the
+            # jsonb blueprint as a STRING ("0.0"), unlike the AL/PL lines above that
+            # use Float literals. A string amount then blows up numeric sums like
+            # ContributorPayout#as_individual_contributor. Coerce to Float so every
+            # blueprint amount is stored as a number.
+            amount = (working_amount * ic_share).round(2).to_f
             payouts[individual_contributor][:blueprint][:IndividualContributor] << {
               blueprint_metadata: ContributorPayout.slim_metadata(metadata),
               amount: amount,

--- a/test/models/contributor_payout_test.rb
+++ b/test/models/contributor_payout_test.rb
@@ -27,6 +27,35 @@ class ContributorPayoutTest < ActiveSupport::TestCase
     assert_equal 0, cp.as_commission
   end
 
+  test "as_individual_contributor sums IndividualContributor blueprint entries" do
+    cp = ContributorPayout.new(blueprint: {
+      "IndividualContributor" => [
+        { "amount" => 100.0 },
+        { "amount" => 50.5 },
+      ],
+    })
+    assert_in_delta 150.5, cp.as_individual_contributor, 0.001
+  end
+
+  test "as_individual_contributor coerces string amounts (e.g. QBO discount lines stored as strings)" do
+    # A comped/$0 "Discount" invoice line arrives from the QBO mirror with its
+    # numeric fields serialized as strings, so make_contributor_payouts! can
+    # persist a String amount alongside Float amounts. Summing raw would raise
+    # "String can't be coerced into Float" and 500 the payouts index.
+    cp = ContributorPayout.new(blueprint: {
+      "IndividualContributor" => [
+        { "amount" => 15783.3 },
+        { "amount" => "0.0" },
+      ],
+    })
+    assert_in_delta 15783.3, cp.as_individual_contributor, 0.001
+  end
+
+  test "as_individual_contributor returns 0 when no IndividualContributor entries" do
+    cp = ContributorPayout.new(blueprint: { "Commission" => [{ "amount" => 200.0 }] })
+    assert_equal 0, cp.as_individual_contributor
+  end
+
   test "70% cap excludes commission entries from LHS sum and uses post-commission total as basis" do
     invoice_tracker = mock("invoice_tracker")
     forecast_client = mock("forecast_client")


### PR DESCRIPTION
## Problem

Navigating to `/admin/invoice_trackers/:id/contributor_payouts` 500s with:

> **TypeError: String can't be coerced into Float** — `contributor_payout.rb:347`

The admin index renders an `as_ic` column for every payout, calling `ContributorPayout#as_individual_contributor`, which sums `blueprint["IndividualContributor"]` amounts. If one entry's `amount` is a **String** and another is a **Float**, `Float + String` raises and the whole page dies.

## Root cause (write side)

In `InvoiceTracker#make_contributor_payouts!`, the IC amount for a non-override line is:

```ruby
ic_share = 1 - pt.company_treasury_split - (account_lead ? 0.08 : 0) - (project_lead ? 0.05 : 0)
amount   = (working_amount * ic_share).round(2)
```

`pt.company_treasury_split` is a **BigDecimal** column → `ic_share` is BigDecimal → `working_amount * ic_share` is BigDecimal. **BigDecimal serializes into the jsonb blueprint as a string** (`{amount: 0.0}.as_json → {"amount"=>"0.0"}`).

- The **AL/PL lines** right above use Float literals (`0.08`/`0.05`) → Float, unaffected.
- **Client lines** dodge it via per-person hourly overrides (a `working_hours * override` Float path).
- A new **$0 "Discount" project** (no override) was the first line to hit the `ic_share` branch and expose the latent bug — but any non-override contributor would trip it (e.g. `"10937.16"`).

## Fix

- **`InvoiceTracker#make_contributor_payouts!`** — coerce the IC amount to Float (`.round(2).to_f`) so every blueprint amount is persisted as a number. *(root fix)*
- **`ContributorPayout#as_individual_contributor`** — add `.to_f` on the sum, matching its five siblings (`as_account_lead` / `as_project_lead` / `as_commission`) which already coerce. Defensive against string amounts already persisted before this fix. *(read-side guard)*
- Regression tests for string-valued IC amounts.

## Verification

- Dry-run regeneration (QBO teardown neutralized, transaction rolled back) now stores the discount line as `0.0` **Float**; a sweep confirms no string amounts remain on any payout, and the index renders cleanly.
- `contributor_payout_test` 9/9, `invoice_tracker_test` 9/9 — 0 failures.

Note: existing rows written before this fix keep their string amounts in the jsonb blueprint; the read-side `.to_f` guard handles those. Re-running "Calculate Default Payouts" rewrites them numeric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)