### PR TITLE
fix(ghost): resolve newsletter slugs via newsletters endpoint

### DIFF
--- a/lib/stacks/ghost.rb
+++ b/lib/stacks/ghost.rb
@@ -61,6 +61,13 @@ class Stacks::Ghost
     (response.parsed_response["members"] || []).first
   end
 
+  def all_newsletters
+    response = handle_response {
+      self.class.get(url("/newsletters/"), query: { limit: "all" }, headers: headers)
+    }
+    response.parsed_response["newsletters"] || []
+  end
+
   def create_member(attrs)
     response = handle_response {
       self.class.post(url("/members/"), query: { include: "labels,newsletters" },

--- a/lib/stacks/ghost_sync.rb
+++ b/lib/stacks/ghost_sync.rb
@@ -126,7 +126,8 @@ class Stacks::GhostSync
       Contact.where("LOWER(email) = ?", email).first ||
       Contact.create_or_find_by!(email: email)
 
-    slugs = (member["newsletters"] || []).map { |n| n["slug"] }.compact.sort
+    slugs = (member["newsletters"] || [])
+      .map { |n| n["slug"] || newsletter_slug_map[n["id"]] }.compact.sort
     ghost_sources = slugs.any? ? slugs.map { |s| "#{SOURCE_PREFIX}:#{s}" } : [SOURCE_PREFIX]
     new_sources = ghost_sources - contact.sources
 
@@ -150,6 +151,16 @@ class Stacks::GhostSync
   end
 
   private
+
+  # Member browse payloads embed newsletters WITHOUT their slug (only
+  # id/name/status — verified against Ghost(Pro) v6 in production), so resolve
+  # slugs via the newsletters endpoint: fetched lazily only when a payload
+  # actually lacks a slug, memoized per sync instance.
+  def newsletter_slug_map
+    @newsletter_slug_map ||= @ghost.all_newsletters.each_with_object({}) do |n, map|
+      map[n["id"]] = n["slug"]
+    end
+  end
 
   # Severs a Ghost member link: clears ghost_id and stamps snapshot.deleted_at
   # while preserving other snapshot keys. Called by the sweep's deletion

--- a/test/lib/stacks/ghost_sync_test.rb
+++ b/test/lib/stacks/ghost_sync_test.rb
@@ -17,6 +17,36 @@ class Stacks::GhostSyncTest < ActiveSupport::TestCase
     System.first_or_create!(settings: {}).update!(ghost_synced_sources: sources)
   end
 
+  test "upsert resolves newsletter slugs via the newsletters endpoint when the member payload lacks them" do
+    ghost = mock("ghost")
+    # .once also proves the map is memoized across upserts on the same sync
+    ghost.expects(:all_newsletters).once.returns([
+      { "id" => "nl-1", "name" => "garden3d", "slug" => "garden3d" },
+    ])
+    sync = sync_with(ghost)
+    slugless = { "newsletters" => [{ "id" => "nl-1", "name" => "garden3d", "status" => "active" }] }
+
+    contact = sync.upsert_contact_from_member(
+      member(id: "m40", email: "slugless@example.com", extra: slugless)
+    ).reload
+    assert_equal ["g3d:ghost:garden3d"], contact.sources
+
+    contact2 = sync.upsert_contact_from_member(
+      member(id: "m41", email: "slugless2@example.com", extra: slugless)
+    ).reload
+    assert_equal ["g3d:ghost:garden3d"], contact2.sources
+  end
+
+  test "upsert does not call the newsletters endpoint when payload slugs are present" do
+    ghost = mock("ghost")
+    ghost.expects(:all_newsletters).never
+    sync = sync_with(ghost)
+    contact = sync.upsert_contact_from_member(
+      member(id: "m42", email: "hasslug@example.com", newsletters: %w[weekly])
+    ).reload
+    assert_equal ["g3d:ghost:weekly"], contact.sources
+  end
+
   test "creates a member with source-name labels for an eligible contact and links ghost_id" do
     enable_sources("newsletter")
     contact = Contact.create!(email: "new@example.com", sources: ["newsletter"], display_name: "New Person")

--- a/test/lib/stacks/ghost_test.rb
+++ b/test/lib/stacks/ghost_test.rb
@@ -57,6 +57,13 @@ class Stacks::GhostTest < ActiveSupport::TestCase
     assert_nil client.find_member_by_email("nope@x.com")
   end
 
+  test "all_newsletters fetches the newsletters collection" do
+    client = build_client
+    resp = fake_response(code: 200, body: { newsletters: [{ id: "nl-1", slug: "garden3d" }] })
+    Stacks::Ghost.expects(:get).with { |url, _opts| url.include?("/newsletters/") }.returns(resp)
+    assert_equal "garden3d", client.all_newsletters.first["slug"]
+  end
+
   test "non-success raises RequestError with code; 422 is not retryable" do
     client = build_client
     Stacks::Ghost.stubs(:post).returns(


### PR DESCRIPTION
Found while verifying the production sync: Ghost's member browse payload embeds newsletters **without** their `slug` field (only id/name/status), so inbound funnel sources degraded to bare `g3d:ghost` instead of the intended `g3d:ghost:<newsletter-slug>`. Fix: lazily fetch `GET /newsletters/` once per sweep (memoized, only when a payload actually lacks a slug) as an id→slug fallback map. TDD'd; ghost suite 244 runs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)