### PR TITLE
feat(ghost): run ghost sync as a daily_enterprise_tasks step

### DIFF
--- a/app/admin/ghost_sync.rb
+++ b/app/admin/ghost_sync.rb
@@ -38,7 +38,9 @@ ActiveAdmin.register_page "Ghost Sync" do
     end
 
     panel "Sync" do
-      para "Runs every 10 minutes via Heroku Scheduler (rake ghost:sync)."
+      para "Runs once a day as part of stacks:daily_enterprise_tasks " \
+           "(also available standalone as rake ghost:sync). Use Sync Now " \
+           "for an immediate pass."
       form action: admin_ghost_sync_sync_now_path, method: :post do
         input type: :hidden, name: :authenticity_token, value: form_authenticity_token
         input type: :submit, value: "Sync Now"

--- a/docs/superpowers/specs/2026-07-20-ghost-contact-sync-design.md
+++ b/docs/superpowers/specs/2026-07-20-ghost-contact-sync-design.md
@@ -12,7 +12,7 @@ Keep stacks contacts in sync with Ghost (garden3d.ghost.io, Ghost(Pro) Publisher
 
 ## Architecture: full-state reconciliation (Approach A)
 
-A scheduled sweep (`rake ghost:sync`, Heroku Scheduler every 10 min, plus an admin "Sync now" button) pulls **all** Ghost members and all sync-eligible contacts, computes desired state per person, and applies the diff in both directions. **The sweep is the only transport** — no webhooks. (Ghost webhooks were originally in scope as a latency optimization, but their 2s delivery timeout and lack of retries meant the sweep had to be fully correct on its own anyway; per Hugh 2026-07-21 they were removed entirely. Signup latency is at most one sweep interval, ~10 minutes.) Any Ghost-side change is picked up by the next sweep.
+A scheduled sweep (a step in `stacks:daily_enterprise_tasks`, once daily — also standalone as `rake ghost:sync` — plus an admin "Sync now" button) pulls **all** Ghost members and all sync-eligible contacts, computes desired state per person, and applies the diff in both directions. **The sweep is the only transport** — no webhooks. (Ghost webhooks were originally in scope as a latency optimization, but their 2s delivery timeout and lack of retries meant the sweep had to be fully correct on its own anyway; per Hugh 2026-07-21 they were removed entirely. Signup latency is at most one sweep interval — daily, per Hugh 2026-07-22; use "Sync now" when sooner matters.) Any Ghost-side change is picked up by the next sweep.
 
 Scale assumption: newsletter-sized lists (thousands, not millions). A paginated full sweep is seconds of work. If that ever changes, `filter=updated_at:>cursor` delta-sync can be layered on without changing semantics.
 
@@ -75,7 +75,7 @@ One upsert path, `Stacks::GhostSync#upsert_contact_from_member(member)`, driven 
 - Match contact by `ghost_id`, else by lowercased email; else `Contact.create_or_find_by!(email:)`.
 - Sources to ensure: `g3d:ghost:<newsletter-slug>` for each **active** newsletter the member subscribes to; plain `g3d:ghost` if they have none (signed up but unsubscribed). Add only missing sources; record a `source_events` entry **only for newly added sources** (so repeat sweeps don't inflate funnel counts) — reusing the atomic `jsonb_set` pattern from `Api::ContactsController`.
 - Set `ghost_id` if unset; refresh `ghost_data.snapshot` (newsletter slugs, `suppressed`, `email_disabled`, `email_in_ghost` when it differs from `contact.email`). Fill blank `display_name` from member name.
-- The upsert is **idempotent** — it only writes when something actually changed — so sweeping the same member every 10 minutes is free, and since the inbound path never writes to Ghost, no loop is possible.
+- The upsert is **idempotent** — it only writes when something actually changed — so repeat sweeps are free, and since the inbound path never writes to Ghost, no loop is possible.
 - Member deletion (detected via §3.1a reconciliation): keep the contact; clear `ghost_id`, stamp `ghost_data.snapshot.deleted_at`.
 
 ## 5. Admin UI (ActiveAdmin)
@@ -86,7 +86,7 @@ One upsert path, `Stacks::GhostSync#upsert_contact_from_member(member)`, driven 
 
 ## 6. Scheduling & concurrency
 
-- `lib/tasks/ghost.rake` → `ghost:sync` invoking `Stacks::GhostSync.new.sync_all!`; Heroku Scheduler every 10 minutes.
+- The sweep runs as an isolated step in `stacks:daily_enterprise_tasks` (once daily, existing Heroku Scheduler job); `lib/tasks/ghost.rake` → `ghost:sync` remains for manual/backfill runs.
 - Postgres advisory lock (`pg_try_advisory_lock` on a fixed key) wraps the sweep so an overlapping Scheduler run / admin button click exits cleanly instead of double-writing.
 
 ## 7. Error handling summary

--- a/lib/tasks/stacks.rake
+++ b/lib/tasks/stacks.rake
@@ -120,6 +120,24 @@ namespace :stacks do
         Rails.logger.error("[stacks:daily_enterprise_tasks] Enterprise##{e.id} (#{e.name}) daily_tasks failed: #{err.class}: #{err.message}")
         Sentry.capture_exception(err) if defined?(Sentry)
       end
+
+      # Ghost two-way contact sync (members, source-name labels, funnel
+      # sources). Per-contact errors are already isolated inside the sweep;
+      # a total failure (e.g. Ghost API unreachable) is isolated here so it
+      # doesn't fail the rest of the daily pass. Advisory lock makes an
+      # overlap with a manual "Sync Now" a clean no-op (returns nil).
+      begin
+        ghost_sync = Stacks::GhostSync.sync_all_with_lock!
+        if ghost_sync
+          Rails.logger.info("[stacks:daily_enterprise_tasks] Ghost sync: #{ghost_sync.summary.to_h.inspect}")
+          ghost_sync.errors.each { |err| Rails.logger.error("[stacks:daily_enterprise_tasks] Ghost sync error: #{err}") }
+        else
+          Rails.logger.info("[stacks:daily_enterprise_tasks] Ghost sync skipped: another run holds the advisory lock")
+        end
+      rescue => e
+        Rails.logger.error("[stacks:daily_enterprise_tasks] Ghost sync failed: #{e.class}: #{e.message}")
+        Sentry.capture_exception(e) if defined?(Sentry)
+      end
     rescue => e
       system_task.mark_as_error(e)
     else


### PR DESCRIPTION
Per Hugh: once daily is enough. Adds an isolated step at the end of `stacks:daily_enterprise_tasks` (same rescue+log+Sentry idiom as the other steps; advisory lock makes overlap with a manual Sync Now a clean no-op), updates the admin-page copy and spec. `rake ghost:sync` stays for manual/backfill runs. **No separate Heroku Scheduler job needed** — if a 10-minute `rake ghost:sync` job was added to Scheduler, remove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)