### PR TITLE
fix(project-tracker): cast batch-cached edge assignment dates to Date

### DIFF
--- a/app/models/project_tracker.rb
+++ b/app/models/project_tracker.rb
@@ -147,8 +147,13 @@ class ProjectTracker < ApplicationRecord
                 ORDER BY end_date DESC LIMIT 1) AS max_end
       FROM unnest(ARRAY[#{int_ids_csv}]::int[]) AS pt(pid)
     SQL
+    # exec_query bypasses model attribute casting, so date columns come back as
+    # ISO strings ("2021-06-23"), not Dates. Cast them here — downstream callers
+    # (first_recorded_assignment_start_date, period_started_at) compare these
+    # against Date.today and a String would raise "comparison of String with Date".
+    cast_date = ->(v) { v.blank? ? nil : (v.is_a?(Date) ? v : Date.iso8601(v.to_s)) }
     edges_by_project_id = rows.each_with_object({}) do |row, h|
-      h[row["pid"].to_i] = [row["min_start"], row["max_end"]]
+      h[row["pid"].to_i] = [cast_date.call(row["min_start"]), cast_date.call(row["max_end"])]
     end
 
     list.each do |pt|

--- a/test/models/project_tracker_test.rb
+++ b/test/models/project_tracker_test.rb
@@ -80,6 +80,32 @@ class ProjectTrackerTest < ActiveSupport::TestCase
     assert_equal Date.new(2024, 6, 30), pt.last_recorded_assignment_end_date
   end
 
+  test "batch-cached edge assignments expose Date bounds, not raw SQL strings" do
+    pt = ProjectTracker.new(name: "Edge assignment bounds")
+    pt.save!(validate: false)
+    pt.update_column(:snapshot, {}) # no snapshot bounds -> forces the edge-assignment fallback
+
+    fp = ForecastProject.new(forecast_id: 987_654, name: "FP", client_id: 123_456)
+    fp.save!(validate: false)
+    ProjectTrackerForecastProject.create!(project_tracker: pt, forecast_project: fp)
+    fa = ForecastAssignment.new(
+      project_id: fp.forecast_id,
+      start_date: Date.new(2021, 6, 23),
+      end_date: Date.new(2022, 3, 31),
+    )
+    fa.save!(validate: false)
+
+    # preload_for_render runs batch_cache_edge_recorded_assignments!, the path the
+    # admin index uses (and the only path that populates @_first_recorded_assignment
+    # from raw SQL).
+    ProjectTracker.preload_for_render([pt])
+
+    assert_instance_of Date, pt.first_recorded_assignment_start_date
+    assert_equal Date.new(2021, 6, 23), pt.first_recorded_assignment_start_date
+    assert_instance_of Date, pt.last_recorded_assignment_end_date
+    assert_equal Date.new(2022, 3, 31), pt.last_recorded_assignment_end_date
+  end
+
   test "lifetime_commissions_paid sums as_commission across all CPs on this tracker's invoices" do
     pt = ProjectTracker.new(name: "Commission Total Test")
     pt.save!(validate: false)


### PR DESCRIPTION
## Problem

`Admin::ProjectTrackersController#index` (and the `ProjectTrackers` / `ForecastProjects` TaskBuilder discoveries) raise:

```
ArgumentError: comparison of String with Date failed
app/models/project_tracker.rb:517:in `<='
```

## Root cause

`ProjectTracker.batch_cache_edge_recorded_assignments!` fetches assignment date bounds with raw SQL via `exec_query`, which **bypasses ActiveRecord attribute casting**. So `date` columns return as ISO strings (`"2021-06-23"`) and were cached into `EdgeAssignment` as strings.

For any tracker whose account-lead period has no `started_at` **and** whose `snapshot` lacks the date key, `period_started_at` falls through to that cached string, and `String <= Date.today` raises.

It only surfaces once Forecast assignment rows exist — e.g. **after restoring production into a dev DB**. An empty dev DB leaves the cache unpopulated and uses live `Date` objects, hiding the bug. (The `snapshot` reader, `date_from_snapshot_key`, already parses correctly and was not the culprit.)

## Fix

Cast the raw `exec_query` rows to `Date` at the source, so every downstream caller sees `Date`s (matching the non-batch `ForecastAssignment` path).

## Verification

- New unit test drives the `preload_for_render` → batch-cache path and asserts `Date` bounds (written test-first; confirmed it fails as `String` before the fix).
- Against a restored-production dev DB, all three previously-failing paths — admin index sort, and both TaskBuilder discoveries — now run cleanly across all trackers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)