### PR TITLE
chore(admin): move Ghost Sync under Contacts, ETL under g3d

### DIFF
--- a/app/admin/document.rb
+++ b/app/admin/document.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Document do
-  menu parent: 'MCP', label: 'ETL: Documents', if: proc { current_admin_user&.can_access_etl_admin? }
+  menu parent: 'Dashboard', label: 'ETL: Documents', if: proc { current_admin_user&.can_access_etl_admin? }
   actions :index, :show
 
   # Only Hugh can reach these pages — blocks direct URL navigation, not just the menu.

--- a/app/admin/ghost_sync.rb
+++ b/app/admin/ghost_sync.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register_page "Ghost Sync" do
-  menu label: "Ghost Sync"
+  menu label: "Ghost Sync", parent: "Contacts"
 
   content title: "Ghost Sync" do
     sources_with_counts_raw = Contact.connection.select_rows(<<~SQL)

--- a/app/admin/meeting.rb
+++ b/app/admin/meeting.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Meeting do
-  menu parent: 'MCP', label: 'ETL: Meetings', if: proc { current_admin_user&.can_access_etl_admin? }
+  menu parent: 'Dashboard', label: 'ETL: Meetings', if: proc { current_admin_user&.can_access_etl_admin? }
   actions :index, :show
 
   # Only Hugh can reach these pages — blocks direct URL navigation, not just the menu.

--- a/app/admin/source_sync.rb
+++ b/app/admin/source_sync.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register SourceSync do
-  menu parent: 'MCP', label: 'ETL: Source syncs', if: proc { current_admin_user&.can_access_etl_admin? }
+  menu parent: 'Dashboard', label: 'ETL: Source syncs', if: proc { current_admin_user&.can_access_etl_admin? }
   actions :index, :show
 
   # Only Hugh can reach these pages — blocks direct URL navigation, not just the menu.


### PR DESCRIPTION
## What

Reorganizes two admin menu groupings:

- **Ghost Sync** → now nested under the **Contacts** menu.
- **ETL: Documents / Meetings / Source syncs** → moved from the **MCP** menu to the **g3d** menu.

## Notes

- The ETL pages target `parent: 'Dashboard'`, not `parent: 'g3d'`. ActiveAdmin matches `parent:` by menu item **id**, and the g3d menu is `register_page "Dashboard"` with `menu label: "g3d"` — so its id is `"Dashboard"` and `"g3d"` is only the display label. This is the same target `periodic_reports.rb` already uses; `parent: 'g3d'` would spawn a phantom duplicate "g3d" menu.
- The **MCP** top-level menu disappears, since the ETL pages were its only children.
- Visibility guards unchanged — the ETL items keep their `can_access_etl_admin?` gate; Ghost Sync stays visible to all admins.

## Verification

Built the admin menu tree in a Rails runner and confirmed: Ghost Sync under Contacts, all three ETL items under g3d, no duplicate "g3d" menu, and MCP gone.

resulting tree:
```
Contacts
  ├─ Contacts Uploader
  └─ Ghost Sync
g3d
  ├─ ETL: Documents
  ├─ ETL: Meetings
  ├─ ETL: Source syncs
  ├─ Quarterly Reports
  └─ Tasks …
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)