### PR TITLE
fix(cost-explorer): attribute payouts by forecast project, not role n…

### DIFF
--- a/app/models/contributor_payout.rb
+++ b/app/models/contributor_payout.rb
@@ -352,6 +352,36 @@ class ContributorPayout < ApplicationRecord
     blueprint["Commission"].sum { |l| l["amount"].to_f }
   end
 
+  def blueprint_entries
+    bp = blueprint
+    return [] unless bp.is_a?(Hash)
+    bp.values.flatten.select { |entry| entry.is_a?(Hash) }
+  end
+
+  # The portion of this payout earned against `forecast_project_ids`.
+  #
+  # Payouts hang off a client-level InvoiceTracker, so every ProjectTracker on
+  # that client sees the same payout. Splitting by each entry's forecast_project
+  # is the only thing stopping a client with separate Design and Development
+  # trackers from booking the full cost against both.
+  #
+  # Attribution keys off the presence of forecast_project metadata rather than a
+  # list of known role names: blueprints have gained roles twice (ProjectLead,
+  # then Commission), and a name-based check silently reverts to charging every
+  # tracker the full amount each time. A blueprint with no attributable entries
+  # at all — the legacy payouts that predate blueprints — still falls back to the
+  # full amount so its cost stays visible somewhere.
+  def amount_attributable_to(forecast_project_ids)
+    entries = blueprint_entries
+    attributable = entries.select { |entry| entry.dig("blueprint_metadata", "forecast_project").present? }
+    return amount.to_f if attributable.empty?
+
+    attributable.reduce(0.0) { |acc, entry|
+      next acc unless forecast_project_ids.include?(entry.dig("blueprint_metadata", "forecast_project"))
+      acc + entry["amount"].to_f
+    }.round(2)
+  end
+
   # SyncsAsQboBill contract
   def bill_txn_date
     invoice_tracker.invoice_pass.start_of_month.end_of_month

--- a/app/models/contributor_payout.rb
+++ b/app/models/contributor_payout.rb
@@ -371,13 +371,21 @@ class ContributorPayout < ApplicationRecord
   # tracker the full amount each time. A blueprint with no attributable entries
   # at all — the legacy payouts that predate blueprints — still falls back to the
   # full amount so its cost stays visible somewhere.
+  # blueprint is editable as raw JSON from the admin, so an entry's metadata is
+  # not guaranteed to be a Hash. Reaching into a malformed one with dig raises
+  # TypeError, and this runs inside the nightly generate_snapshot!, so one bad
+  # paste would take down every project's cost rather than one payout's.
+  def entry_forecast_project(entry)
+    metadata = entry["blueprint_metadata"]
+    metadata.is_a?(Hash) ? metadata["forecast_project"] : nil
+  end
+
   def amount_attributable_to(forecast_project_ids)
-    entries = blueprint_entries
-    attributable = entries.select { |entry| entry.dig("blueprint_metadata", "forecast_project").present? }
+    attributable = blueprint_entries.select { |entry| entry_forecast_project(entry).present? }
     return amount.to_f if attributable.empty?
 
     attributable.reduce(0.0) { |acc, entry|
-      next acc unless forecast_project_ids.include?(entry.dig("blueprint_metadata", "forecast_project"))
+      next acc unless forecast_project_ids.include?(entry_forecast_project(entry))
       acc + entry["amount"].to_f
     }.round(2)
   end

--- a/app/models/project_tracker.rb
+++ b/app/models/project_tracker.rb
@@ -654,28 +654,11 @@ class ProjectTracker < ApplicationRecord
       # Contributor payouts are on the client level, so lets filter out
       # any parts of the payout that are not due to work done against this
       # specific project tracker
-      amount_for_this_tracker = cp.amount
-      bp = cp.blueprint || {}
-      legacy_team_lead_keys = bp.keys.sort == ["AccountLead", "IndividualContributor", "TeamLead"].sort
-      project_lead_keys = bp.keys.sort == ["AccountLead", "IndividualContributor", "ProjectLead"].sort
-      # New blueprint shape may also include AccountLeadSurplus / ProjectLeadSurplus
-      # (in any combination — a CP without surplus shares won't have those keys).
-      role_keys = %w[AccountLead AccountLeadSurplus IndividualContributor ProjectLead ProjectLeadSurplus TeamLead Commission]
-      surplus_aware_keys = bp.keys.any? && (bp.keys - role_keys).empty? &&
-        (bp.key?("AccountLeadSurplus") || bp.key?("ProjectLeadSurplus"))
-      if bp.is_a?(Hash) && (legacy_team_lead_keys || project_lead_keys || surplus_aware_keys)
-        amount_for_this_tracker = 0
-        amount_for_this_tracker = bp.values.flatten.reduce(0) do |acc, v|
-          if fpids.include?(v.try(:dig, "blueprint_metadata", "forecast_project"))
-            acc += v.try(:dig, "amount").to_f
-          end
-          acc
-        end
-      end
+      amount_for_this_tracker = cp.amount_attributable_to(fpids)
 
       next acc unless amount_for_this_tracker > 0
       acc[cp.accrual_date][cp.contributor.forecast_person] = {
-        amount: amount_for_this_tracker.round(2),
+        amount: amount_for_this_tracker,
         type: :contributor_payout,
       }
       acc

--- a/test/models/contributor_payout_test.rb
+++ b/test/models/contributor_payout_test.rb
@@ -214,4 +214,34 @@ class ContributorPayoutTest < ActiveSupport::TestCase
     assert_in_delta 100.0, cp.amount_attributable_to([1]), 0.001
     assert_in_delta 200.0, cp.amount_attributable_to([2]), 0.001
   end
+
+  # blueprint is editable as raw JSON from the admin, so a malformed entry has to
+  # skip that entry rather than raise — monthly_cosr runs inside the nightly
+  # generate_snapshot!, where a TypeError would take down every project's cost.
+  test "amount_attributable_to skips an entry whose blueprint_metadata is not a hash" do
+    cp = ContributorPayout.new(
+      amount: 500.0,
+      blueprint: {
+        "IndividualContributor" => [
+          { "amount" => 300.0, "blueprint_metadata" => { "forecast_project" => 1 } },
+          { "amount" => 200.0, "blueprint_metadata" => "corrupted" },
+        ],
+      },
+    )
+
+    assert_in_delta 300.0, cp.amount_attributable_to([1]), 0.001
+  end
+
+  test "amount_attributable_to falls back to the full amount when every entry's metadata is malformed" do
+    cp = ContributorPayout.new(
+      amount: 500.0,
+      blueprint: {
+        "IndividualContributor" => [
+          { "amount" => 500.0, "blueprint_metadata" => "corrupted" },
+        ],
+      },
+    )
+
+    assert_in_delta 500.0, cp.amount_attributable_to([1]), 0.001
+  end
 end

--- a/test/models/contributor_payout_test.rb
+++ b/test/models/contributor_payout_test.rb
@@ -128,4 +128,90 @@ class ContributorPayoutTest < ActiveSupport::TestCase
     assert_in_delta 84.50, chunk[:surplus], 0.05
     assert_in_delta 0.57 * 850, chunk[:maximum], 0.01
   end
+
+  # A client-level payout is shared by every ProjectTracker on that client, so
+  # attribution has to come from each entry's forecast_project. Blueprints grew a
+  # Commission key in May 2026; the exact-key-set matching this replaced stopped
+  # recognising them and handed the full amount to both trackers.
+  test "amount_attributable_to splits a commission-bearing blueprint by forecast project" do
+    cp = ContributorPayout.new(
+      amount: 3310.50,
+      blueprint: {
+        "AccountLead" => [
+          { "amount" => 228.0, "blueprint_metadata" => { "forecast_project" => 4869136 } },
+          { "amount" => 336.0, "blueprint_metadata" => { "forecast_project" => 4869137 } },
+        ],
+        "ProjectLead" => [
+          { "amount" => 142.5, "blueprint_metadata" => { "forecast_project" => 4869136 } },
+          { "amount" => 210.0, "blueprint_metadata" => { "forecast_project" => 4869137 } },
+        ],
+        "IndividualContributor" => [
+          { "amount" => 2394.0, "blueprint_metadata" => { "forecast_project" => 4869137 } },
+        ],
+        "Commission" => [],
+      },
+    )
+
+    assert_in_delta 2940.0, cp.amount_attributable_to([4869137]), 0.001
+    assert_in_delta 370.5, cp.amount_attributable_to([4869136]), 0.001
+  end
+
+  test "amount_attributable_to returns 0 when no entry belongs to the given forecast projects" do
+    cp = ContributorPayout.new(
+      amount: 1624.50,
+      blueprint: {
+        "AccountLead" => [],
+        "ProjectLead" => [],
+        "Commission" => [],
+        "IndividualContributor" => [
+          { "amount" => 1624.5, "blueprint_metadata" => { "forecast_project" => 4869136 } },
+        ],
+      },
+    )
+
+    assert_equal 0, cp.amount_attributable_to([4869137])
+  end
+
+  test "amount_attributable_to coerces string amounts" do
+    cp = ContributorPayout.new(
+      amount: 100.0,
+      blueprint: {
+        "IndividualContributor" => [
+          { "amount" => "100.0", "blueprint_metadata" => { "forecast_project" => 7 } },
+        ],
+      },
+    )
+
+    assert_in_delta 100.0, cp.amount_attributable_to([7]), 0.001
+  end
+
+  # 15 legacy payouts carry no blueprint at all, so there is nothing to attribute
+  # by. Falling back to the full amount keeps their cost visible rather than
+  # silently dropping it from every tracker.
+  test "amount_attributable_to falls back to the full amount when the blueprint is empty" do
+    cp = ContributorPayout.new(amount: 4125.0, blueprint: {})
+
+    assert_in_delta 4125.0, cp.amount_attributable_to([4869137]), 0.001
+  end
+
+  # Adding the Commission role in May 2026 is what broke attribution the first
+  # time, because the old check matched on an exact set of role names. Attribution
+  # keys off each entry's forecast_project instead, so the next new role splits
+  # correctly without anyone remembering to update a list.
+  test "amount_attributable_to splits correctly across a role it has never seen before" do
+    cp = ContributorPayout.new(
+      amount: 300.0,
+      blueprint: {
+        "IndividualContributor" => [
+          { "amount" => 100.0, "blueprint_metadata" => { "forecast_project" => 1 } },
+        ],
+        "SomeFutureRole" => [
+          { "amount" => 200.0, "blueprint_metadata" => { "forecast_project" => 2 } },
+        ],
+      },
+    )
+
+    assert_in_delta 100.0, cp.amount_attributable_to([1]), 0.001
+    assert_in_delta 200.0, cp.amount_attributable_to([2]), 0.001
+  end
 end

--- a/test/models/project_tracker_test.rb
+++ b/test/models/project_tracker_test.rb
@@ -120,4 +120,73 @@ class ProjectTrackerTest < ActiveSupport::TestCase
 
     assert_in_delta 80.0, pt.lifetime_commissions_paid, 0.001
   end
+
+  # A client with separate Design and Development trackers shares one
+  # client-level InvoiceTracker, so both trackers see the same payouts.
+  # monthly_cosr has to split them by each blueprint entry's forecast_project,
+  # or both projects book the full cost and both margins crater.
+  test "monthly_cosr attributes a shared client payout to each tracker by forecast project" do
+    enterprise = Enterprise.find_by!(name: Enterprise::SANCTUARY_NAME)
+    forecast_client = ForecastClient.create!(forecast_id: 90_100_001, name: "Split Client")
+    invoice_pass = InvoicePass.find_or_create_by!(start_of_month: Date.new(2026, 6, 1))
+    qbo_account = enterprise.qbo_account || QboAccount.create!(
+      enterprise: enterprise,
+      client_id: "test_client",
+      client_secret: "test_secret",
+      realm_id: "test_realm_#{SecureRandom.hex(4)}",
+    )
+    invoice_tracker = InvoiceTracker.create!(
+      forecast_client: forecast_client,
+      invoice_pass: invoice_pass,
+      qbo_account: qbo_account,
+    )
+
+    design_fp = ForecastProject.create!(forecast_id: 90_200_001, name: "Design", code: "SPL-1", client_id: forecast_client.forecast_id)
+    dev_fp = ForecastProject.create!(forecast_id: 90_200_002, name: "Development", code: "SPL-2", client_id: forecast_client.forecast_id)
+
+    design = ProjectTracker.new(name: "Split Design")
+    design.save!(validate: false)
+    ProjectTrackerForecastProject.create!(project_tracker: design, forecast_project_id: design_fp.forecast_id)
+
+    dev = ProjectTracker.new(name: "Split Development")
+    dev.save!(validate: false)
+    ProjectTrackerForecastProject.create!(project_tracker: dev, forecast_project_id: dev_fp.forecast_id)
+
+    person = ForecastPerson.create!(forecast_id: 90_300_001, first_name: "Lead", last_name: "Person", email: "lead-#{SecureRandom.hex(3)}@example.com")
+    contributor = Contributor.create!(forecast_person_id: person.forecast_id)
+    ledger = Ledger.find_by!(contributor: contributor, enterprise: enterprise)
+
+    payout = ContributorPayout.new(
+      invoice_tracker: invoice_tracker,
+      ledger: ledger,
+      created_by: AdminUser.first || AdminUser.create!(email: "admin-#{SecureRandom.hex(3)}@example.com", password: SecureRandom.hex(8)),
+      amount: 3310.50,
+      blueprint: {
+        "AccountLead" => [
+          { "amount" => 228.0, "blueprint_metadata" => { "forecast_project" => dev_fp.forecast_id } },
+          { "amount" => 336.0, "blueprint_metadata" => { "forecast_project" => design_fp.forecast_id } },
+        ],
+        "ProjectLead" => [
+          { "amount" => 142.5, "blueprint_metadata" => { "forecast_project" => dev_fp.forecast_id } },
+          { "amount" => 210.0, "blueprint_metadata" => { "forecast_project" => design_fp.forecast_id } },
+        ],
+        "IndividualContributor" => [
+          { "amount" => 2394.0, "blueprint_metadata" => { "forecast_project" => design_fp.forecast_id } },
+        ],
+        "Commission" => [],
+      },
+    )
+    payout.save!(validate: false)
+
+    design.stubs(:invoice_trackers).returns([invoice_tracker])
+    dev.stubs(:invoice_trackers).returns([invoice_tracker])
+
+    accrual = invoice_pass.start_of_month.end_of_month
+    design_cost = design.monthly_cosr[accrual].values.sum { |c| c[:amount] }
+    dev_cost = dev.monthly_cosr[accrual].values.sum { |c| c[:amount] }
+
+    assert_in_delta 2940.0, design_cost, 0.001
+    assert_in_delta 370.5, dev_cost, 0.001
+    assert_in_delta payout.amount, design_cost + dev_cost, 0.001
+  end
 end


### PR DESCRIPTION
…ames

Contributor payouts hang off a client-level InvoiceTracker, so every ProjectTracker on that client sees the same payout. Splitting them by each blueprint entry's forecast_project is what keeps a client with separate Design and Development trackers from booking the full cost against both.

monthly_cosr decided whether a payout was splittable by comparing its blueprint's key set against three hardcoded shapes. Adding the Commission role in May 2026 broke all three matches, so the guard fell through to its default of attributing the entire payout to whichever tracker was being rendered — charging both trackers the full amount and inflating each one's cost. Big Thief Development read 23.26% and Big Thief Design 27.00%, marking both unsuccessful against the 30% threshold.

Attribution now keys off the presence of forecast_project metadata rather than a list of known role names. Blueprints have gained roles twice (ProjectLead, then Commission) and a name-based check silently reverts to charging every tracker the full amount each time. Payouts with no attributable entries at all — the legacy rows predating blueprints — still fall back to the full amount so their cost stays visible.

Verified against a production copy: six project trackers change, every other tracker is byte-identical, and no cost is orphaned (each dollar lands on exactly one tracker). Big Thief Development moves to 30.64% and Design to 34.13%. Snapshots regenerate nightly via stacks:daily_tasks, so no backfill is needed.