### PR TITLE
feat(okrs): client LTV, tenure, revenue concentration & pipeline KPIs

### DIFF
--- a/app/admin/okr_explorer.rb
+++ b/app/admin/okr_explorer.rb
@@ -5,7 +5,7 @@ ActiveAdmin.register_page "OKR Explorer" do
     all_gradations = ["month", "quarter", "year", "trailing_3_months", "trailing_4_months", "trailing_6_months", "trailing_12_months"]
     default_gradation = "month"
 
-    all_okrs = ["average_hourly_rate", "successful_projects", "successful_proposals"]
+    all_okrs = ["average_hourly_rate", "successful_projects", "successful_proposals", "average_client_lifetime_value", "average_client_tenure", "client_revenue_concentration", "forecasted_sales_revenue"]
     default_okr = "average_hourly_rate"
 
     studio = Studio.find(params[:studio_id])

--- a/app/models/okr.rb
+++ b/app/models/okr.rb
@@ -44,6 +44,10 @@ class Okr < ApplicationRecord
     story_points_per_billable_week: 24,
     cost_per_story_point: 25,
     project_satisfaction: 26,
+    average_client_lifetime_value: 27,
+    average_client_tenure: 28,
+    client_revenue_concentration: 29,
+    forecasted_sales_revenue: 30,
   }
 
   def self.make_annual_growth_progress_data(target, tolerance, last_year_value, current_value, base_unit_type)

--- a/app/models/stacks_task.rb
+++ b/app/models/stacks_task.rb
@@ -36,6 +36,7 @@ class StacksTask
     no_received_at_timestamp_set: "Notion lead needs received-at timestamp",
     needs_settling: "Notion lead needs settling",
     no_studios_set: "Notion lead needs studios assigned",
+    needs_budget_estimate: "Notion lead needs an estimated budget",
 
     # Survey issues
     survey: "Studio survey response required",

--- a/app/models/studio.rb
+++ b/app/models/studio.rb
@@ -648,8 +648,14 @@ class Studio < ApplicationRecord
     data
   end
 
+  # Deliberately NOT memoized: an argument-ignoring memo (||=) would let the
+  # first caller's preloaded_studios win forever, silently ignoring later
+  # callers' arguments. It is also a thread-safety foot-gun when called inside
+  # Parallel.map (the snapshot path). Construction is cheap (~0.05-0.13s);
+  # callers that need a shared instance (generate_snapshot!) pass one in via the
+  # preloaded_client_revenue default argument instead of relying on the memo.
   def client_revenue(preloaded_studios = Studio.all)
-    @_client_revenue ||= Stacks::ClientRevenue.new(self, preloaded_studios)
+    Stacks::ClientRevenue.new(self, preloaded_studios)
   end
 
   def utilization_for_period(period)

--- a/app/models/studio.rb
+++ b/app/models/studio.rb
@@ -107,7 +107,8 @@ class Studio < ApplicationRecord
     g3d_utilization_by_period,
     preloaded_studios,
     preloaded_new_biz_leads,
-    all_okrs
+    all_okrs,
+    preloaded_client_revenue = client_revenue(preloaded_studios)
   )
     d = {
       label: period.label,
@@ -128,6 +129,7 @@ class Studio < ApplicationRecord
       utilization_by_period[prev_period],
       g3d_utilization_by_period[period],
       g3d_utilization_by_period[prev_period],
+      preloaded_client_revenue
     )
 
     d[:cash][:okrs] = self.okrs_for_period(period, d[:cash][:datapoints], all_okrs)
@@ -141,6 +143,7 @@ class Studio < ApplicationRecord
       utilization_by_period[prev_period],
       g3d_utilization_by_period[period],
       g3d_utilization_by_period[prev_period],
+      preloaded_client_revenue
     )
     d[:accrual][:okrs] = self.okrs_for_period(period, d[:accrual][:datapoints], all_okrs)
     d
@@ -148,7 +151,8 @@ class Studio < ApplicationRecord
 
   def generate_snapshot!(
     preloaded_studios = Studio.all,
-    preloaded_new_biz_leads = new_biz_leads
+    preloaded_new_biz_leads = new_biz_leads,
+    preloaded_client_revenue = client_revenue(preloaded_studios)
   )
     all_okrs = Okr.includes({ okr_periods: { okr_period_studios: :studio }}).all
     g3d = preloaded_studios.find(&:is_garden3d?)
@@ -179,7 +183,8 @@ class Studio < ApplicationRecord
               g3d_utilization_by_period,
               preloaded_studios,
               preloaded_new_biz_leads,
-              all_okrs
+              all_okrs,
+              preloaded_client_revenue
             )
           end
         end
@@ -266,6 +271,14 @@ class Studio < ApplicationRecord
       "#{ActionController::Base.helpers.number_to_currency(datapoints[:income][:value])} income recieved"
     when "lead_growth"
       "#{datapoints[:lead_count][:value]} leads recieved"
+    when "average_client_lifetime_value"
+      "across #{datapoints[:average_client_lifetime_value][:extras][:client_count]} clients invoiced since June 2021"
+    when "average_client_tenure"
+      "across #{datapoints[:average_client_tenure][:extras][:client_count]} clients invoiced since June 2021"
+    when "client_revenue_concentration"
+      "#{datapoints[:client_revenue_concentration][:extras][:top_client_name] || "no top client"}: #{ActionController::Base.helpers.number_to_currency(datapoints[:client_revenue_concentration][:extras][:top_client_amount])} of #{ActionController::Base.helpers.number_to_currency(datapoints[:client_revenue_concentration][:extras][:total_revenue])}"
+    when "forecasted_sales_revenue"
+      "#{datapoints[:forecasted_sales_revenue][:extras][:budgeted_lead_count]} of #{datapoints[:forecasted_sales_revenue][:extras][:open_lead_count]} open leads budgeted"
     else
       ""
     end

--- a/app/models/studio.rb
+++ b/app/models/studio.rb
@@ -447,7 +447,8 @@ class Studio < ApplicationRecord
     utilization_for_period = utilization_for_period(period, preloaded_studios),
     utilization_for_prev_period = utilization_for_period(prev_period, preloaded_studios),
     g3d_utilization_for_period = preloaded_studios.find(&:is_garden3d?).utilization_for_period(period, preloaded_studios),
-    g3d_utilization_for_prev_period = preloaded_studios.find(&:is_garden3d?).utilization_for_period(prev_period, preloaded_studios)
+    g3d_utilization_for_prev_period = preloaded_studios.find(&:is_garden3d?).utilization_for_period(prev_period, preloaded_studios),
+    preloaded_client_revenue = client_revenue(preloaded_studios)
   )
     # TODO: Fix me - right now I return nil if this period predates utilization data OR
     # there's just no one there
@@ -625,7 +626,17 @@ class Studio < ApplicationRecord
       data[:actual_cost_per_hour_sold][:value] = total_billable > 0 ? (cost_of_doing_business / total_billable) : 0
     end
 
+    data.merge!(Stacks::ClientKpiDatapoints.call(
+      period: period,
+      leads: preloaded_new_biz_leads,
+      client_revenue: preloaded_client_revenue
+    ))
+
     data
+  end
+
+  def client_revenue(preloaded_studios = Studio.all)
+    @_client_revenue ||= Stacks::ClientRevenue.new(self, preloaded_studios)
   end
 
   def utilization_for_period(period)

--- a/app/views/admin/okr_explorer/_okr_explorer.html.erb
+++ b/app/views/admin/okr_explorer/_okr_explorer.html.erb
@@ -46,6 +46,41 @@ function update(a, b) {
   </div>
 <% end %>
 
+<%
+  generic_okrs = ["average_client_lifetime_value", "average_client_tenure", "client_revenue_concentration", "forecasted_sales_revenue"]
+  dedicated_okrs = ["successful_projects", "successful_proposals", "average_hourly_rate"]
+%>
+<% if generic_okrs.include?(current_okr) %>
+  <% snapshot[current_gradation].reverse.each do |period| %>
+    <%
+      dp = period.dig(accounting_method, "datapoints", current_okr)
+      raw_value = dp&.dig("value")
+      unit      = dp&.dig("unit")
+      formatted = if raw_value.nil?
+        "—"
+      elsif unit == "usd"
+        number_to_currency(raw_value)
+      elsif unit == "percentage"
+        "#{raw_value.round(1)}%"
+      else
+        raw_value.round(1).to_s
+      end
+    %>
+    <div class="title_bar" id="title_bar" style="padding: 80px 0px 20px 0px;">
+      <div id="titlebar_left">
+        <h2 id="page_title">
+          <%= period["label"] %>
+        </h2>
+      </div>
+      <div id="titlebar_right">
+        <h2 id="page_title">
+          <%= formatted %>
+        </h2>
+      </div>
+    </div>
+  <% end %>
+<% end %>
+
 <% if current_okr == "time_to_merge_pr" %>
 <% end %>
 

--- a/docs/superpowers/plans/2026-07-29-studio-okr-client-kpis.md
+++ b/docs/superpowers/plans/2026-07-29-studio-okr-client-kpis.md
@@ -945,3 +945,5 @@ git commit -m "feat(okrs): wire client & pipeline KPIs into snapshots, hints, ex
 ## Post-implementation (manual, not code)
 
 Creating the Okr records is an admin-UI step, done after deploy via ActiveAdmin ("Okey Dokeys"): one Okr per KPI with a name, description, operator (`greater_than` for LTV/tenure/forecast, `less_than` for concentration), the matching datapoint, and OkrPeriods (target, tolerance, date range, studios). Recommended names: "Average Client Lifetime Value", "Average Client Tenure", "Client Revenue Concentration", "Forecasted Sales Revenue".
+
+Note: the four new datapoints appear in dashboards and the OKR Explorer only after the next nightly snapshot run (or a manual `studio.generate_snapshot!` call) — old snapshots lack the new keys and the explorer will show "—" for those periods.

--- a/docs/superpowers/plans/2026-07-29-studio-okr-client-kpis.md
+++ b/docs/superpowers/plans/2026-07-29-studio-okr-client-kpis.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add four new Studio-level OKR datapoints — `average_client_lifetime_value`, `average_client_tenure`, `client_revenue_concentration`, `forecasted_sales_revenue` — plus a `needs_budget_estimate` data-hygiene task, per the approved spec at `docs/superpowers/specs/2026-07-29-studio-okr-client-kpis-design.md`.
 
-**Architecture:** A new PORO `Stacks::ClientRevenue` turns InvoiceTracker history into per-client revenue rows (studio-attributed via blueprint lines) and answers LTV/tenure/concentration queries. `Studio#key_datapoints_for_period` merges four new datapoint hash entries, so the existing OKR machinery (targets, health, nightly snapshots, OKR Explorer, MCP tool) picks them up with no further plumbing. `Stacks::Notion::Lead` gains status/budget readers shared by the pipeline KPI and a new TaskBuilder discovery rule.
+**Architecture:** Service objects carry the logic, keeping the already-large `Studio` model thin. `Stacks::ClientRevenue` turns InvoiceTracker history into per-client revenue rows (studio-attributed via blueprint lines) and answers LTV/tenure/concentration queries; `Stacks::ClientKpiDatapoints` builds the four datapoint hash entries from it. `Studio#key_datapoints_for_period` merely merges that service's result, so the existing OKR machinery (targets, health, nightly snapshots, OKR Explorer, MCP tool) picks the KPIs up with no further plumbing. `Stacks::Notion::Lead` gains status/budget readers shared by the pipeline KPI and a new TaskBuilder discovery rule.
 
 **Tech Stack:** Rails, PostgreSQL (jsonb), Minitest + mocha (NOT RSpec — the spec doc says RSpec but this repo uses Minitest; follow this plan), ActiveAdmin.
 
@@ -477,12 +477,13 @@ git commit -m "feat: add Stacks::ClientRevenue for per-client studio revenue"
 
 ---
 
-### Task 3: Okr enum entries + the four datapoints on Studio
+### Task 3: Okr enum entries + `Stacks::ClientKpiDatapoints` service
 
 **Files:**
+- Create: `lib/stacks/client_kpi_datapoints.rb`
 - Modify: `app/models/okr.rb:46` (end of `datapoint` enum)
-- Modify: `app/models/studio.rb` (`key_datapoints_for_period`, ends ~line 629; add two new methods after it)
-- Test: `test/models/studio_test.rb` (append tests)
+- Modify: `app/models/studio.rb` (`key_datapoints_for_period`, ends ~line 629; add one small memoized helper after it)
+- Test: `test/lib/stacks/client_kpi_datapoints_test.rb` (create)
 
 **Interfaces:**
 - Consumes:
@@ -492,14 +493,17 @@ git commit -m "feat: add Stacks::ClientRevenue for per-client studio revenue"
 - Produces (used by Task 5):
   - `Okr.datapoints` gains `average_client_lifetime_value: 27, average_client_tenure: 28, client_revenue_concentration: 29, forecasted_sales_revenue: 30`
   - `Studio#client_revenue(preloaded_studios = Studio.all)` → memoized `Stacks::ClientRevenue`
-  - `Studio#client_and_pipeline_datapoints(period, preloaded_new_biz_leads, client_revenue)` → Hash with the four datapoint keys, each `{value:, unit:, extras:}` shaped like existing datapoints
-  - `Studio#key_datapoints_for_period` gains a final positional param `preloaded_client_revenue = client_revenue(preloaded_studios)` and merges the four keys into its return value
+  - `Stacks::ClientKpiDatapoints.call(period:, leads:, client_revenue:)` → Hash with the four datapoint keys, each `{value:, unit:, extras:}` shaped like existing datapoints
+  - `Studio#key_datapoints_for_period` gains a final positional param `preloaded_client_revenue = client_revenue(preloaded_studios)` and merges the service's four keys into its return value
 
 - [ ] **Step 1: Write the failing test**
 
-Append to `test/models/studio_test.rb` (inside `class StudioTest`):
+Create `test/lib/stacks/client_kpi_datapoints_test.rb`:
 
 ```ruby
+require 'test_helper'
+
+class StacksClientKpiDatapointsTest < ActiveSupport::TestCase
   test "datapoint enum includes the four client & pipeline KPIs at 27-30" do
     assert_equal 27, Okr.datapoints["average_client_lifetime_value"]
     assert_equal 28, Okr.datapoints["average_client_tenure"]
@@ -507,7 +511,7 @@ Append to `test/models/studio_test.rb` (inside `class StudioTest`):
     assert_equal 30, Okr.datapoints["forecasted_sales_revenue"]
   end
 
-  test "#client_and_pipeline_datapoints returns the four KPI entries" do
+  test ".call returns the four KPI entries" do
     studio = Studio.new(name: "garden3d", mini_name: "g3d")
     acme = ForecastClient.new(name: "Acme")
 
@@ -536,7 +540,11 @@ Append to `test/models/studio_test.rb` (inside `class StudioTest`):
     } }).as_lead
 
     period = Stacks::Period.new("Feb 2025", Date.new(2025, 2, 1), Date.new(2025, 2, 28))
-    data = studio.client_and_pipeline_datapoints(period, [open_budgeted, open_unbudgeted, lost], client_revenue)
+    data = Stacks::ClientKpiDatapoints.call(
+      period: period,
+      leads: [open_budgeted, open_unbudgeted, lost],
+      client_revenue: client_revenue
+    )
 
     assert_equal 10_000.0, data[:average_client_lifetime_value][:value]
     assert_equal :usd, data[:average_client_lifetime_value][:unit]
@@ -554,12 +562,13 @@ Append to `test/models/studio_test.rb` (inside `class StudioTest`):
     assert_equal 2, data[:forecasted_sales_revenue][:extras][:open_lead_count]
     assert_equal 1, data[:forecasted_sales_revenue][:extras][:budgeted_lead_count]
   end
+end
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `bin/rails test test/models/studio_test.rb`
-Expected: the two new tests FAIL (`Okr.datapoints["average_client_lifetime_value"]` is nil; `NoMethodError: undefined method 'client_and_pipeline_datapoints'`). Pre-existing tests in this file must PASS — if any fail before your change, stop and report.
+Run: `bin/rails test test/lib/stacks/client_kpi_datapoints_test.rb`
+Expected: FAIL — `Okr.datapoints["average_client_lifetime_value"]` is nil, and `NameError: uninitialized constant Stacks::ClientKpiDatapoints`.
 
 - [ ] **Step 3: Write the implementation**
 
@@ -595,33 +604,50 @@ In `app/models/studio.rb`:
 (b) At the end of `key_datapoints_for_period`, immediately before the final `data` return (currently line 628), add:
 
 ```ruby
-    data.merge!(client_and_pipeline_datapoints(period, preloaded_new_biz_leads, preloaded_client_revenue))
+    data.merge!(Stacks::ClientKpiDatapoints.call(
+      period: period,
+      leads: preloaded_new_biz_leads,
+      client_revenue: preloaded_client_revenue
+    ))
 
     data
   end
 ```
 
-(c) After `key_datapoints_for_period` ends, add the two new methods:
+(c) After `key_datapoints_for_period` ends, add one small memoized helper:
 
 ```ruby
   def client_revenue(preloaded_studios = Studio.all)
     @_client_revenue ||= Stacks::ClientRevenue.new(self, preloaded_studios)
   end
+```
 
-  def client_and_pipeline_datapoints(period, preloaded_new_biz_leads, client_revenue)
-    open_leads = preloaded_new_biz_leads.select(&:open?)
-    budgets = open_leads.filter_map(&:estimated_budget)
-    concentration = client_revenue.concentration_for_range(period.starts_at, period.ends_at)
-    client_count = client_revenue.client_count_asof(period.ends_at)
+(d) Create the service at `lib/stacks/client_kpi_datapoints.rb`:
 
+```ruby
+# Builds the four client & pipeline OKR datapoint entries that
+# Studio#key_datapoints_for_period merges into its result. Each entry is
+# shaped like the existing datapoints: { value:, unit:, extras: }.
+class Stacks::ClientKpiDatapoints
+  def self.call(period:, leads:, client_revenue:)
+    new(period: period, leads: leads, client_revenue: client_revenue).call
+  end
+
+  def initialize(period:, leads:, client_revenue:)
+    @period = period
+    @leads = leads
+    @client_revenue = client_revenue
+  end
+
+  def call
     {
       average_client_lifetime_value: {
-        value: client_revenue.average_lifetime_value_asof(period.ends_at),
+        value: @client_revenue.average_lifetime_value_asof(@period.ends_at),
         unit: :usd,
         extras: { client_count: client_count }
       },
       average_client_tenure: {
-        value: client_revenue.average_tenure_months_asof(period.ends_at),
+        value: @client_revenue.average_tenure_months_asof(@period.ends_at),
         unit: :count,
         extras: { client_count: client_count }
       },
@@ -644,17 +670,39 @@ In `app/models/studio.rb`:
       }
     }
   end
+
+  private
+
+  def open_leads
+    @_open_leads ||= @leads.select(&:open?)
+  end
+
+  def budgets
+    @_budgets ||= open_leads.filter_map(&:estimated_budget)
+  end
+
+  def concentration
+    @_concentration ||= @client_revenue.concentration_for_range(@period.starts_at, @period.ends_at)
+  end
+
+  def client_count
+    @_client_count ||= @client_revenue.client_count_asof(@period.ends_at)
+  end
+end
 ```
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `bin/rails test test/models/studio_test.rb`
-Expected: PASS (including the pre-existing tests)
+Run: `bin/rails test test/lib/stacks/client_kpi_datapoints_test.rb`
+Expected: PASS (2 tests)
+
+Also run: `bin/rails test test/models/studio_test.rb`
+Expected: PASS — the `key_datapoints_for_period` signature change must not break pre-existing tests.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add app/models/okr.rb app/models/studio.rb test/models/studio_test.rb
+git add app/models/okr.rb app/models/studio.rb lib/stacks/client_kpi_datapoints.rb test/lib/stacks/client_kpi_datapoints_test.rb
 git commit -m "feat(okrs): add client LTV, tenure, concentration & pipeline datapoints"
 ```
 
@@ -879,7 +927,7 @@ puts "LTV:      #{cr.average_lifetime_value_asof(today).round(0)} across #{cr.cl
 puts "Tenure:   #{cr.average_tenure_months_asof(today).round(1)} months"
 puts "Conc YTD: #{cr.concentration_for_range(today.beginning_of_year, today).inspect}"
 period = Stacks::Period.new("YTD", today.beginning_of_year, today)
-puts "Pipeline: #{g3d.client_and_pipeline_datapoints(period, g3d.new_biz_leads, cr)[:forecasted_sales_revenue].inspect}"
+puts "Pipeline: #{Stacks::ClientKpiDatapoints.call(period: period, leads: g3d.new_biz_leads, client_revenue: cr)[:forecasted_sales_revenue].inspect}"
 '
 ```
 

--- a/docs/superpowers/plans/2026-07-29-studio-okr-client-kpis.md
+++ b/docs/superpowers/plans/2026-07-29-studio-okr-client-kpis.md
@@ -1,0 +1,899 @@
+# Studio OKR: Client & Pipeline KPIs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add four new Studio-level OKR datapoints — `average_client_lifetime_value`, `average_client_tenure`, `client_revenue_concentration`, `forecasted_sales_revenue` — plus a `needs_budget_estimate` data-hygiene task, per the approved spec at `docs/superpowers/specs/2026-07-29-studio-okr-client-kpis-design.md`.
+
+**Architecture:** A new PORO `Stacks::ClientRevenue` turns InvoiceTracker history into per-client revenue rows (studio-attributed via blueprint lines) and answers LTV/tenure/concentration queries. `Studio#key_datapoints_for_period` merges four new datapoint hash entries, so the existing OKR machinery (targets, health, nightly snapshots, OKR Explorer, MCP tool) picks them up with no further plumbing. `Stacks::Notion::Lead` gains status/budget readers shared by the pipeline KPI and a new TaskBuilder discovery rule.
+
+**Tech Stack:** Rails, PostgreSQL (jsonb), Minitest + mocha (NOT RSpec — the spec doc says RSpec but this repo uses Minitest; follow this plan), ActiveAdmin.
+
+## Global Constraints
+
+- New `Okr#datapoint` enum values are APPEND-ONLY: use exactly `27, 28, 29, 30`. Never renumber existing entries.
+- Test framework is Minitest with mocha (`require 'test_helper'`, `ActiveSupport::TestCase`, `.stubs`/`.expects`). Run with `bin/rails test <path>`.
+- No new gems.
+- Lead property names are exact Notion strings: `"Lead Status"`, `"Est. Budget Low"`, `"Est. Budget High"`. Open statuses are exactly: `"Active"`, `"Not started"`, `"On hold (re-engage)"`.
+- Countable revenue = InvoiceTracker with a linked, non-voided QboInvoice on an external (`!is_internal?`) ForecastClient. Dollar value = `qbo_invoice.total`, dated by `invoice_pass.start_of_month`.
+- `lib/` is autoloaded (existing `Stacks::*` classes live there); no `require` statements needed for new `Stacks::` classes.
+- Commit after every task.
+
+---
+
+### Task 1: Lead status & budget readers on `Stacks::Notion::Lead`
+
+**Files:**
+- Modify: `lib/stacks/notion/lead.rb`
+- Test: `test/lib/stacks/notion/lead_test.rb` (create)
+
+**Interfaces:**
+- Consumes: `Stacks::Notion::Base#get_prop_value(key)` — returns the property's inner value: a Hash like `{"name" => "Active"}` for status props, a Numeric (or nil) for number props, `{}` when the property key doesn't exist.
+- Produces (used by Tasks 3 and 4):
+  - `Lead::OPEN_STATUSES` — frozen Array of the three open status strings
+  - `#lead_status` → String or nil
+  - `#open?` → Boolean
+  - `#estimated_budget` → Float, Integer, or nil (midpoint of Low/High; single value if only one filled; nil if neither)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/lib/stacks/notion/lead_test.rb`:
+
+```ruby
+require 'test_helper'
+
+class StacksNotionLeadTest < ActiveSupport::TestCase
+  def lead_with_props(props)
+    NotionPage.new(data: { "properties" => props }).as_lead
+  end
+
+  def status_prop(name)
+    { "type" => "status", "status" => { "name" => name } }
+  end
+
+  def number_prop(value)
+    { "type" => "number", "number" => value }
+  end
+
+  test "#lead_status returns the Lead Status name" do
+    lead = lead_with_props("Lead Status" => status_prop("Active"))
+    assert_equal "Active", lead.lead_status
+  end
+
+  test "#lead_status returns nil when the property is missing or empty" do
+    assert_nil lead_with_props({}).lead_status
+    assert_nil lead_with_props("Lead Status" => { "type" => "status", "status" => nil }).lead_status
+  end
+
+  test "#open? is true for Active, Not started, and On hold (re-engage)" do
+    ["Active", "Not started", "On hold (re-engage)"].each do |status|
+      assert lead_with_props("Lead Status" => status_prop(status)).open?, "expected #{status} to be open"
+    end
+  end
+
+  test "#open? is false for terminal statuses and missing status" do
+    ["Won", "Lost", "Passed", "Cold", "Settled", "Project Paused"].each do |status|
+      refute lead_with_props("Lead Status" => status_prop(status)).open?, "expected #{status} to not be open"
+    end
+    refute lead_with_props({}).open?
+  end
+
+  test "#estimated_budget returns the midpoint when both Low and High are set" do
+    lead = lead_with_props(
+      "Est. Budget Low" => number_prop(40_000),
+      "Est. Budget High" => number_prop(60_000)
+    )
+    assert_equal 50_000, lead.estimated_budget
+  end
+
+  test "#estimated_budget returns the single value when only one is set" do
+    assert_equal 75_000, lead_with_props("Est. Budget High" => number_prop(75_000)).estimated_budget
+    assert_equal 30_000, lead_with_props("Est. Budget Low" => number_prop(30_000)).estimated_budget
+  end
+
+  test "#estimated_budget returns nil when neither is set" do
+    assert_nil lead_with_props({}).estimated_budget
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bin/rails test test/lib/stacks/notion/lead_test.rb`
+Expected: FAIL — `NoMethodError: undefined method 'lead_status'` (and similar for `open?` / `estimated_budget`)
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `lib/stacks/notion/lead.rb`, add inside the class (after the `won_at` / `considered_successful?` methods around line 44):
+
+```ruby
+  # Current-status is the source of truth for "open pipeline". The terminal
+  # date stamps (✨ Status: Won/Lost/Ghosted) are missing on most dead leads,
+  # so they must not be used to decide openness.
+  OPEN_STATUSES = ["Active", "Not started", "On hold (re-engage)"].freeze
+
+  def lead_status
+    (get_prop_value("Lead Status") || {}).dig("name")
+  end
+
+  def open?
+    OPEN_STATUSES.include?(lead_status)
+  end
+
+  # Midpoint of the Est. Budget Low/High Notion number props; a single value
+  # if only one is filled; nil when unbudgeted (callers treat nil as $0 and
+  # file a needs_budget_estimate task).
+  def estimated_budget
+    values = [
+      get_prop_value("Est. Budget Low"),
+      get_prop_value("Est. Budget High")
+    ].select { |v| v.is_a?(Numeric) }
+    return nil if values.empty?
+    values.sum / values.length.to_f
+  end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bin/rails test test/lib/stacks/notion/lead_test.rb`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/stacks/notion/lead.rb test/lib/stacks/notion/lead_test.rb
+git commit -m "feat(leads): add lead_status, open?, and estimated_budget readers"
+```
+
+---
+
+### Task 2: `Stacks::ClientRevenue` PORO
+
+**Files:**
+- Create: `lib/stacks/client_revenue.rb`
+- Test: `test/lib/stacks/client_revenue_test.rb` (create)
+
+**Interfaces:**
+- Consumes:
+  - `InvoiceTracker#qbo_invoice` (`QboInvoice` or nil), `#forecast_client` (`ForecastClient`), `#invoice_pass` (`InvoicePass`, has `start_of_month` Date), `#blueprint` (jsonb Hash: `{"lines" => {"<description>" => {"forecast_person" => <id>, "quantity" => <num>, "unit_price" => <num>, ...}}}`)
+  - `QboInvoice#status` (`:voided` among others), `#total` (Float)
+  - `ForecastClient#is_internal?`, `#name`
+  - `InvoiceTracker.forecast_person_id_from_description(description)` — extracts the `[FP-<id>]` tag from legacy line descriptions, or nil
+  - `ForecastPerson#studio(all_studios)` — the person's Studio, matched by Forecast roles
+  - `Studio#is_garden3d?`
+- Produces (used by Task 3):
+  - `Stacks::ClientRevenue.new(studio, preloaded_studios = Studio.all, trackers = nil)` — `trackers: nil` loads all InvoiceTrackers with includes; tests inject in-memory trackers
+  - `#average_lifetime_value_asof(date)` → Float (0 when no clients)
+  - `#average_tenure_months_asof(date)` → Float (whole-month diff between first and last invoice month per client, averaged; 0 when no clients)
+  - `#client_count_asof(date)` → Integer
+  - `#concentration_for_range(starts_at, ends_at)` → `{ value: Float (0-100), top_client_name: String|nil, top_client_amount: Float, total_revenue: Float }`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/lib/stacks/client_revenue_test.rb`:
+
+```ruby
+require 'test_helper'
+
+class StacksClientRevenueTest < ActiveSupport::TestCase
+  def setup
+    @g3d = Studio.new(name: "garden3d", mini_name: "g3d")
+    @sanctu = Studio.new(name: "Sanctuary Computer", mini_name: "sanctu")
+    @studios = [@g3d, @sanctu]
+    @acme = ForecastClient.new(name: "Acme")
+    @globex = ForecastClient.new(name: "Globex")
+  end
+
+  def make_tracker(client:, month:, total:, blueprint: nil, voided: false, no_invoice: false, internal: false)
+    tracker = InvoiceTracker.new
+    if no_invoice
+      tracker.stubs(:qbo_invoice).returns(nil)
+    else
+      invoice = QboInvoice.new
+      invoice.stubs(:status).returns(voided ? :voided : :paid)
+      invoice.stubs(:total).returns(total.to_f)
+      tracker.stubs(:qbo_invoice).returns(invoice)
+    end
+    client.stubs(:is_internal?).returns(true) if internal
+    tracker.stubs(:forecast_client).returns(client)
+    tracker.stubs(:invoice_pass).returns(InvoicePass.new(start_of_month: month))
+    tracker.stubs(:blueprint).returns(blueprint)
+    tracker
+  end
+
+  test "garden3d counts full invoice totals grouped by client" do
+    trackers = [
+      make_tracker(client: @acme, month: Date.new(2025, 1, 1), total: 10_000),
+      make_tracker(client: @acme, month: Date.new(2025, 3, 1), total: 20_000),
+      make_tracker(client: @globex, month: Date.new(2025, 2, 1), total: 30_000)
+    ]
+    cr = Stacks::ClientRevenue.new(@g3d, @studios, trackers)
+
+    assert_equal 2, cr.client_count_asof(Date.new(2025, 12, 31))
+    assert_equal 30_000.0, cr.average_lifetime_value_asof(Date.new(2025, 12, 31))
+  end
+
+  test "excludes voided, unlinked, and internal-client trackers" do
+    trackers = [
+      make_tracker(client: @acme, month: Date.new(2025, 1, 1), total: 10_000),
+      make_tracker(client: @acme, month: Date.new(2025, 2, 1), total: 99_999, voided: true),
+      make_tracker(client: @acme, month: Date.new(2025, 3, 1), total: 99_999, no_invoice: true),
+      make_tracker(client: @globex, month: Date.new(2025, 1, 1), total: 99_999, internal: true)
+    ]
+    cr = Stacks::ClientRevenue.new(@g3d, @studios, trackers)
+
+    assert_equal 1, cr.client_count_asof(Date.new(2025, 12, 31))
+    assert_equal 10_000.0, cr.average_lifetime_value_asof(Date.new(2025, 12, 31))
+  end
+
+  test "asof date excludes later invoices" do
+    trackers = [
+      make_tracker(client: @acme, month: Date.new(2025, 1, 1), total: 10_000),
+      make_tracker(client: @acme, month: Date.new(2025, 6, 1), total: 50_000)
+    ]
+    cr = Stacks::ClientRevenue.new(@g3d, @studios, trackers)
+
+    assert_equal 10_000.0, cr.average_lifetime_value_asof(Date.new(2025, 3, 31))
+  end
+
+  test "average tenure is whole months between first and last invoice month per client" do
+    trackers = [
+      make_tracker(client: @acme, month: Date.new(2025, 1, 1), total: 1),
+      make_tracker(client: @acme, month: Date.new(2025, 7, 1), total: 1),   # 6 months
+      make_tracker(client: @globex, month: Date.new(2025, 3, 1), total: 1)  # 0 months
+    ]
+    cr = Stacks::ClientRevenue.new(@g3d, @studios, trackers)
+
+    assert_equal 3.0, cr.average_tenure_months_asof(Date.new(2025, 12, 31))
+  end
+
+  test "concentration is the largest client's share of in-range revenue" do
+    trackers = [
+      make_tracker(client: @acme, month: Date.new(2025, 4, 1), total: 75_000),
+      make_tracker(client: @globex, month: Date.new(2025, 5, 1), total: 25_000),
+      make_tracker(client: @globex, month: Date.new(2024, 1, 1), total: 900_000) # out of range
+    ]
+    cr = Stacks::ClientRevenue.new(@g3d, @studios, trackers)
+    result = cr.concentration_for_range(Date.new(2025, 4, 1), Date.new(2025, 6, 30))
+
+    assert_equal 75.0, result[:value]
+    assert_equal "Acme", result[:top_client_name]
+    assert_equal 75_000.0, result[:top_client_amount]
+    assert_equal 100_000.0, result[:total_revenue]
+  end
+
+  test "concentration with no in-range revenue returns zeros" do
+    cr = Stacks::ClientRevenue.new(@g3d, @studios, [])
+    result = cr.concentration_for_range(Date.new(2025, 1, 1), Date.new(2025, 1, 31))
+
+    assert_equal 0, result[:value]
+    assert_nil result[:top_client_name]
+  end
+
+  test "empty rows return 0 for averages" do
+    cr = Stacks::ClientRevenue.new(@g3d, @studios, [])
+    assert_equal 0, cr.average_lifetime_value_asof(Date.today)
+    assert_equal 0, cr.average_tenure_months_asof(Date.today)
+  end
+
+  test "sub-studio takes a pro-rata share of the invoice via blueprint person lines" do
+    person_in_sanctu = ForecastPerson.create!(
+      id: 111, first_name: "Sanctu", last_name: "Person", email: "sanctu@sanctuary.computer",
+      archived: false, roles: ["Sanctuary Computer"], updated_at: Date.today
+    )
+    person_elsewhere = ForecastPerson.create!(
+      id: 222, first_name: "Other", last_name: "Person", email: "other@sanctuary.computer",
+      archived: false, roles: ["XXIX"], updated_at: Date.today
+    )
+
+    blueprint = {
+      "lines" => {
+        "ACME-1 Acme (July 2025) Sanctu Person [FP-111]" => {
+          "forecast_person" => person_in_sanctu.forecast_id, "quantity" => 10, "unit_price" => 100
+        },
+        "ACME-1 Acme (July 2025) Other Person [FP-222]" => {
+          "forecast_person" => person_elsewhere.forecast_id, "quantity" => 30, "unit_price" => 100
+        }
+      }
+    }
+    # blueprint sums to $4,000; sanctu's share is 1,000/4,000 = 25% of the $8,000 invoice
+    trackers = [make_tracker(client: @acme, month: Date.new(2025, 7, 1), total: 8_000, blueprint: blueprint)]
+    cr = Stacks::ClientRevenue.new(@sanctu, @studios, trackers)
+
+    assert_equal 2_000.0, cr.average_lifetime_value_asof(Date.new(2025, 12, 31))
+  end
+
+  test "sub-studio resolves legacy lines via the [FP-id] description tag" do
+    person_in_sanctu = ForecastPerson.create!(
+      id: 111, first_name: "Sanctu", last_name: "Person", email: "sanctu@sanctuary.computer",
+      archived: false, roles: ["Sanctuary Computer"], updated_at: Date.today
+    )
+
+    blueprint = {
+      "lines" => {
+        "ACME-1 Acme (July 2025) Sanctu Person [FP-111]" => { "quantity" => 10, "unit_price" => 100 }
+      }
+    }
+    trackers = [make_tracker(client: @acme, month: Date.new(2025, 7, 1), total: 1_000, blueprint: blueprint)]
+    cr = Stacks::ClientRevenue.new(@sanctu, @studios, trackers)
+
+    assert_equal 1_000.0, cr.average_lifetime_value_asof(Date.new(2025, 12, 31))
+  end
+
+  test "sub-studio skips malformed blueprint lines and trackers with no usable lines" do
+    blueprint = {
+      "lines" => {
+        "bad line" => { "quantity" => "ten", "unit_price" => 100 }
+      }
+    }
+    trackers = [make_tracker(client: @acme, month: Date.new(2025, 7, 1), total: 1_000, blueprint: blueprint)]
+    cr = Stacks::ClientRevenue.new(@sanctu, @studios, trackers)
+
+    assert_equal 0, cr.client_count_asof(Date.new(2025, 12, 31))
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bin/rails test test/lib/stacks/client_revenue_test.rb`
+Expected: FAIL — `NameError: uninitialized constant Stacks::ClientRevenue`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `lib/stacks/client_revenue.rb`:
+
+```ruby
+# Per-client invoiced revenue for a studio, derived from InvoiceTracker
+# history (June 2021 onward). Countable revenue = trackers with a linked,
+# non-voided QBO invoice on an external client. garden3d counts full invoice
+# totals; sub-studios take a pro-rata share via blueprint person lines
+# (person -> studio by Forecast roles), the same attribution the cost
+# explorer uses. Feeds the average_client_lifetime_value,
+# average_client_tenure, and client_revenue_concentration OKR datapoints.
+class Stacks::ClientRevenue
+  Row = Struct.new(:client, :month, :amount, keyword_init: true)
+
+  def initialize(studio, preloaded_studios = Studio.all, trackers = nil)
+    @studio = studio
+    @preloaded_studios = preloaded_studios
+    @trackers = trackers || self.class.all_trackers
+    @rows = build_rows
+  end
+
+  def self.all_trackers
+    InvoiceTracker
+      .includes(:invoice_pass, :qbo_invoice, forecast_client: :enterprise_forecast_client)
+      .to_a
+  end
+
+  def average_lifetime_value_asof(date)
+    totals = totals_by_client_asof(date)
+    return 0 if totals.empty?
+    totals.values.sum / totals.length
+  end
+
+  def average_tenure_months_asof(date)
+    rows = @rows.select { |r| r.month <= date }
+    return 0 if rows.empty?
+    tenures = rows.group_by(&:client).values.map do |client_rows|
+      first, last = client_rows.map(&:month).minmax
+      (last.year * 12 + last.month) - (first.year * 12 + first.month)
+    end
+    tenures.sum.to_f / tenures.length
+  end
+
+  def client_count_asof(date)
+    totals_by_client_asof(date).length
+  end
+
+  def concentration_for_range(starts_at, ends_at)
+    in_range = @rows.select { |r| r.month >= starts_at.beginning_of_month && r.month <= ends_at }
+    total = in_range.sum(&:amount)
+    return { value: 0, top_client_name: nil, top_client_amount: 0, total_revenue: 0 } if total.zero?
+
+    top_client, top_amount = in_range
+      .group_by(&:client)
+      .transform_values { |rs| rs.sum(&:amount) }
+      .max_by { |_, amount| amount }
+
+    {
+      value: (top_amount / total) * 100,
+      top_client_name: top_client.name,
+      top_client_amount: top_amount,
+      total_revenue: total
+    }
+  end
+
+  private
+
+  def totals_by_client_asof(date)
+    @rows
+      .select { |r| r.month <= date }
+      .group_by(&:client)
+      .transform_values { |rs| rs.sum(&:amount) }
+  end
+
+  def build_rows
+    @trackers.filter_map do |tracker|
+      invoice = tracker.qbo_invoice
+      client = tracker.forecast_client
+      next if invoice.nil? || invoice.status == :voided
+      next if client.nil? || client.is_internal?
+
+      amount = @studio.is_garden3d? ? invoice.total : studio_share(tracker, invoice.total)
+      next if amount.nil? || amount.zero?
+
+      Row.new(client: client, month: tracker.invoice_pass.start_of_month, amount: amount)
+    end
+  end
+
+  # Pro-rata share of the invoice total from blueprint lines whose person
+  # belongs to this studio. Legacy lines without a forecast_person key fall
+  # back to the [FP-<id>] description tag. Malformed lines are skipped and
+  # logged; a tracker with no usable lines is omitted from sub-studio numbers
+  # (it still counts for garden3d).
+  def studio_share(tracker, invoice_total)
+    lines = (tracker.blueprint || {})["lines"] || {}
+    studio_sum = 0.0
+    all_sum = 0.0
+
+    lines.each do |description, line|
+      unless line.is_a?(Hash) && line["quantity"].is_a?(Numeric) && line["unit_price"].is_a?(Numeric)
+        Rails.logger.warn("[ClientRevenue] invoice_tracker=#{tracker.id} skipping malformed blueprint line #{description.inspect}")
+        next
+      end
+      line_value = line["quantity"] * line["unit_price"]
+      all_sum += line_value
+
+      person_id = line["forecast_person"] || InvoiceTracker.forecast_person_id_from_description(description)
+      next if person_id.nil?
+      person = forecast_people_by_id[person_id]
+      studio_sum += line_value if person&.studio(@preloaded_studios) == @studio
+    end
+
+    return nil if all_sum.zero?
+    (studio_sum / all_sum) * invoice_total
+  end
+
+  def forecast_people_by_id
+    @_forecast_people_by_id ||= ForecastPerson.all.index_by(&:forecast_id)
+  end
+end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bin/rails test test/lib/stacks/client_revenue_test.rb`
+Expected: PASS (10 tests)
+
+Note: the two `ForecastPerson.create!` tests hit the DB (an `after_create` creates a Contributor); that's normal for this suite.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/stacks/client_revenue.rb test/lib/stacks/client_revenue_test.rb
+git commit -m "feat: add Stacks::ClientRevenue for per-client studio revenue"
+```
+
+---
+
+### Task 3: Okr enum entries + the four datapoints on Studio
+
+**Files:**
+- Modify: `app/models/okr.rb:46` (end of `datapoint` enum)
+- Modify: `app/models/studio.rb` (`key_datapoints_for_period`, ends ~line 629; add two new methods after it)
+- Test: `test/models/studio_test.rb` (append tests)
+
+**Interfaces:**
+- Consumes:
+  - `Stacks::ClientRevenue` public interface from Task 2 (exact signatures listed there)
+  - `Stacks::Notion::Lead#open?` / `#estimated_budget` from Task 1
+  - `Stacks::Period.new(label, starts_at, ends_at)` with `#starts_at` / `#ends_at`
+- Produces (used by Task 5):
+  - `Okr.datapoints` gains `average_client_lifetime_value: 27, average_client_tenure: 28, client_revenue_concentration: 29, forecasted_sales_revenue: 30`
+  - `Studio#client_revenue(preloaded_studios = Studio.all)` → memoized `Stacks::ClientRevenue`
+  - `Studio#client_and_pipeline_datapoints(period, preloaded_new_biz_leads, client_revenue)` → Hash with the four datapoint keys, each `{value:, unit:, extras:}` shaped like existing datapoints
+  - `Studio#key_datapoints_for_period` gains a final positional param `preloaded_client_revenue = client_revenue(preloaded_studios)` and merges the four keys into its return value
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/models/studio_test.rb` (inside `class StudioTest`):
+
+```ruby
+  test "datapoint enum includes the four client & pipeline KPIs at 27-30" do
+    assert_equal 27, Okr.datapoints["average_client_lifetime_value"]
+    assert_equal 28, Okr.datapoints["average_client_tenure"]
+    assert_equal 29, Okr.datapoints["client_revenue_concentration"]
+    assert_equal 30, Okr.datapoints["forecasted_sales_revenue"]
+  end
+
+  test "#client_and_pipeline_datapoints returns the four KPI entries" do
+    studio = Studio.new(name: "garden3d", mini_name: "g3d")
+    acme = ForecastClient.new(name: "Acme")
+
+    invoice = QboInvoice.new
+    invoice.stubs(:status).returns(:paid)
+    invoice.stubs(:total).returns(10_000.0)
+    tracker = InvoiceTracker.new
+    tracker.stubs(:qbo_invoice).returns(invoice)
+    tracker.stubs(:forecast_client).returns(acme)
+    tracker.stubs(:invoice_pass).returns(InvoicePass.new(start_of_month: Date.new(2025, 2, 1)))
+    tracker.stubs(:blueprint).returns(nil)
+
+    client_revenue = Stacks::ClientRevenue.new(studio, [studio], [tracker])
+
+    open_budgeted = NotionPage.new(data: { "properties" => {
+      "Lead Status" => { "type" => "status", "status" => { "name" => "Active" } },
+      "Est. Budget Low" => { "type" => "number", "number" => 40_000 },
+      "Est. Budget High" => { "type" => "number", "number" => 60_000 }
+    } }).as_lead
+    open_unbudgeted = NotionPage.new(data: { "properties" => {
+      "Lead Status" => { "type" => "status", "status" => { "name" => "Not started" } }
+    } }).as_lead
+    lost = NotionPage.new(data: { "properties" => {
+      "Lead Status" => { "type" => "status", "status" => { "name" => "Lost" } },
+      "Est. Budget High" => { "type" => "number", "number" => 999_999 }
+    } }).as_lead
+
+    period = Stacks::Period.new("Feb 2025", Date.new(2025, 2, 1), Date.new(2025, 2, 28))
+    data = studio.client_and_pipeline_datapoints(period, [open_budgeted, open_unbudgeted, lost], client_revenue)
+
+    assert_equal 10_000.0, data[:average_client_lifetime_value][:value]
+    assert_equal :usd, data[:average_client_lifetime_value][:unit]
+    assert_equal 1, data[:average_client_lifetime_value][:extras][:client_count]
+
+    assert_equal 0.0, data[:average_client_tenure][:value]
+    assert_equal :count, data[:average_client_tenure][:unit]
+
+    assert_equal 100.0, data[:client_revenue_concentration][:value]
+    assert_equal :percentage, data[:client_revenue_concentration][:unit]
+    assert_equal "Acme", data[:client_revenue_concentration][:extras][:top_client_name]
+
+    assert_equal 50_000.0, data[:forecasted_sales_revenue][:value]
+    assert_equal :usd, data[:forecasted_sales_revenue][:unit]
+    assert_equal 2, data[:forecasted_sales_revenue][:extras][:open_lead_count]
+    assert_equal 1, data[:forecasted_sales_revenue][:extras][:budgeted_lead_count]
+  end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bin/rails test test/models/studio_test.rb`
+Expected: the two new tests FAIL (`Okr.datapoints["average_client_lifetime_value"]` is nil; `NoMethodError: undefined method 'client_and_pipeline_datapoints'`). Pre-existing tests in this file must PASS — if any fail before your change, stop and report.
+
+- [ ] **Step 3: Write the implementation**
+
+In `app/models/okr.rb`, add to the end of the `datapoint` enum (after `project_satisfaction: 26,` on line 46):
+
+```ruby
+    project_satisfaction: 26,
+    average_client_lifetime_value: 27,
+    average_client_tenure: 28,
+    client_revenue_concentration: 29,
+    forecasted_sales_revenue: 30,
+```
+
+In `app/models/studio.rb`:
+
+(a) Add a final positional parameter to `key_datapoints_for_period` (line 441-451):
+
+```ruby
+  def key_datapoints_for_period(
+    period,
+    prev_period,
+    accounting_method,
+    preloaded_studios = Studio.all,
+    preloaded_new_biz_leads = new_biz_leads,
+    utilization_for_period = utilization_for_period(period, preloaded_studios),
+    utilization_for_prev_period = utilization_for_period(prev_period, preloaded_studios),
+    g3d_utilization_for_period = preloaded_studios.find(&:is_garden3d?).utilization_for_period(period, preloaded_studios),
+    g3d_utilization_for_prev_period = preloaded_studios.find(&:is_garden3d?).utilization_for_period(prev_period, preloaded_studios),
+    preloaded_client_revenue = client_revenue(preloaded_studios)
+  )
+```
+
+(b) At the end of `key_datapoints_for_period`, immediately before the final `data` return (currently line 628), add:
+
+```ruby
+    data.merge!(client_and_pipeline_datapoints(period, preloaded_new_biz_leads, preloaded_client_revenue))
+
+    data
+  end
+```
+
+(c) After `key_datapoints_for_period` ends, add the two new methods:
+
+```ruby
+  def client_revenue(preloaded_studios = Studio.all)
+    @_client_revenue ||= Stacks::ClientRevenue.new(self, preloaded_studios)
+  end
+
+  def client_and_pipeline_datapoints(period, preloaded_new_biz_leads, client_revenue)
+    open_leads = preloaded_new_biz_leads.select(&:open?)
+    budgets = open_leads.filter_map(&:estimated_budget)
+    concentration = client_revenue.concentration_for_range(period.starts_at, period.ends_at)
+    client_count = client_revenue.client_count_asof(period.ends_at)
+
+    {
+      average_client_lifetime_value: {
+        value: client_revenue.average_lifetime_value_asof(period.ends_at),
+        unit: :usd,
+        extras: { client_count: client_count }
+      },
+      average_client_tenure: {
+        value: client_revenue.average_tenure_months_asof(period.ends_at),
+        unit: :count,
+        extras: { client_count: client_count }
+      },
+      client_revenue_concentration: {
+        value: concentration[:value],
+        unit: :percentage,
+        extras: {
+          top_client_name: concentration[:top_client_name],
+          top_client_amount: concentration[:top_client_amount],
+          total_revenue: concentration[:total_revenue]
+        }
+      },
+      forecasted_sales_revenue: {
+        value: budgets.sum,
+        unit: :usd,
+        extras: {
+          open_lead_count: open_leads.count,
+          budgeted_lead_count: budgets.count
+        }
+      }
+    }
+  end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bin/rails test test/models/studio_test.rb`
+Expected: PASS (including the pre-existing tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/models/okr.rb app/models/studio.rb test/models/studio_test.rb
+git commit -m "feat(okrs): add client LTV, tenure, concentration & pipeline datapoints"
+```
+
+---
+
+### Task 4: `needs_budget_estimate` TaskBuilder discovery
+
+**Files:**
+- Modify: `lib/stacks/task_builder/discoveries/notion_leads.rb:42` (in `issues_for`)
+- Modify: `app/models/stacks_task.rb:38` (HUMANIZED_TYPES, Notion lead section)
+- Test: `test/lib/stacks/task_builder/discoveries/notion_leads_test.rb` (create)
+
+**Interfaces:**
+- Consumes: `Stacks::Notion::Lead#open?` / `#estimated_budget` (Task 1); `Discoveries::Base#task(subject:, type:, owners:)` which falls back to `admin_fallback` owners; `StacksTask` (`#type`, `#owners`)
+- Produces: leads that are open and unbudgeted yield a `StacksTask` with `type == :needs_budget_estimate`, routed to the lead's Account Lead admin users (or the admin fallback)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/lib/stacks/task_builder/discoveries/notion_leads_test.rb`:
+
+```ruby
+require 'test_helper'
+
+class StacksTaskBuilderDiscoveriesNotionLeadsTest < ActiveSupport::TestCase
+  def setup
+    @admin = AdminUser.create!(email: "admin@sanctuary.computer", password: "passw0rd")
+  end
+
+  def lead_page(props)
+    NotionPage.new(data: { "properties" => props })
+  end
+
+  def discover(pages)
+    NotionPage.stubs(:lead).returns(pages)
+    Stacks::TaskBuilder::Discoveries::NotionLeads.new(admin_fallback: [@admin]).tasks
+  end
+
+  test "an open lead with no budget yields a needs_budget_estimate task owned by the fallback" do
+    tasks = discover([lead_page(
+      "Lead Status" => { "type" => "status", "status" => { "name" => "Active" } },
+      "✨ Lead Received" => { "type" => "date", "date" => { "start" => Date.today.iso8601 } }
+    )])
+
+    task = tasks.find { |t| t.type == :needs_budget_estimate }
+    assert task, "expected a needs_budget_estimate task"
+    assert_equal [@admin], task.owners
+  end
+
+  test "an open lead with a budget yields no needs_budget_estimate task" do
+    tasks = discover([lead_page(
+      "Lead Status" => { "type" => "status", "status" => { "name" => "Active" } },
+      "✨ Lead Received" => { "type" => "date", "date" => { "start" => Date.today.iso8601 } },
+      "Est. Budget High" => { "type" => "number", "number" => 50_000 }
+    )])
+
+    refute tasks.any? { |t| t.type == :needs_budget_estimate }
+  end
+
+  test "a closed lead with no budget yields no needs_budget_estimate task" do
+    tasks = discover([lead_page(
+      "Lead Status" => { "type" => "status", "status" => { "name" => "Lost" } },
+      "✨ Lead Received" => { "type" => "date", "date" => { "start" => Date.today.iso8601 } }
+    )])
+
+    refute tasks.any? { |t| t.type == :needs_budget_estimate }
+  end
+
+  test "needs_budget_estimate has an explicit humanized label" do
+    assert_equal "Notion lead needs an estimated budget",
+      StacksTask::HUMANIZED_TYPES[:needs_budget_estimate]
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bin/rails test test/lib/stacks/task_builder/discoveries/notion_leads_test.rb`
+Expected: FAIL — first and last tests fail (no `:needs_budget_estimate` task produced; no HUMANIZED_TYPES entry). The two `refute` tests pass trivially.
+
+- [ ] **Step 3: Write the implementation**
+
+In `lib/stacks/task_builder/discoveries/notion_leads.rb`, inside `issues_for(lead)` add after the `no_studios_set` check (line 40):
+
+```ruby
+          out << :needs_budget_estimate if lead.open? && lead.estimated_budget.nil?
+```
+
+In `app/models/stacks_task.rb`, in the `# Notion lead issues` section of `HUMANIZED_TYPES` (after `no_studios_set:` on line 38):
+
+```ruby
+    no_studios_set: "Notion lead needs studios assigned",
+    needs_budget_estimate: "Notion lead needs an estimated budget",
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bin/rails test test/lib/stacks/task_builder/discoveries/notion_leads_test.rb`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/stacks/task_builder/discoveries/notion_leads.rb app/models/stacks_task.rb test/lib/stacks/task_builder/discoveries/notion_leads_test.rb
+git commit -m "feat(tasks): file needs_budget_estimate for open unbudgeted leads"
+```
+
+---
+
+### Task 5: Snapshot wiring, OKR hints, and OKR Explorer
+
+**Files:**
+- Modify: `app/models/studio.rb` — `snapshot_data_for_period` (lines 103-147), `generate_snapshot!` (lines 149-191), `hint_for_okr` (lines 251-272)
+- Modify: `app/admin/okr_explorer.rb:8`
+
+**Interfaces:**
+- Consumes: `Studio#client_revenue` and the new datapoint `extras` keys from Task 3 (`client_count`, `top_client_name`, `top_client_amount`, `total_revenue`, `open_lead_count`, `budgeted_lead_count`)
+- Produces: nightly snapshots include the four datapoints for every gradation/period; OKR chips show hints; OKR Explorer can chart the four datapoints
+
+Why the wiring matters: `generate_snapshot!` runs `snapshot_data_for_period` inside `Parallel.map(in_threads: 5)`. Without eager construction, five threads would race to memoize `@_client_revenue`. Building it once in the method signature (single-threaded, same trick as `preloaded_new_biz_leads`) avoids that.
+
+- [ ] **Step 1: Thread the preloaded ClientRevenue through the snapshot pipeline**
+
+In `app/models/studio.rb`, change `generate_snapshot!`'s signature (line 149-152) to:
+
+```ruby
+  def generate_snapshot!(
+    preloaded_studios = Studio.all,
+    preloaded_new_biz_leads = new_biz_leads,
+    preloaded_client_revenue = client_revenue(preloaded_studios)
+  )
+```
+
+and pass it to `snapshot_data_for_period` (the call at lines 175-183):
+
+```ruby
+            snapshot_data_for_period(
+              period,
+              prev_period,
+              utilization_by_period,
+              g3d_utilization_by_period,
+              preloaded_studios,
+              preloaded_new_biz_leads,
+              all_okrs,
+              preloaded_client_revenue
+            )
+```
+
+Change `snapshot_data_for_period`'s signature (lines 103-111) to accept it:
+
+```ruby
+  def snapshot_data_for_period(
+    period,
+    prev_period,
+    utilization_by_period,
+    g3d_utilization_by_period,
+    preloaded_studios,
+    preloaded_new_biz_leads,
+    all_okrs,
+    preloaded_client_revenue = client_revenue(preloaded_studios)
+  )
+```
+
+and append `preloaded_client_revenue` as the final argument to BOTH `key_datapoints_for_period` calls inside it (the `cash` call at lines 121-131 and the `accrual` call at lines 134-144), e.g. for cash:
+
+```ruby
+    d[:cash][:datapoints] = self.key_datapoints_for_period(
+      period,
+      prev_period,
+      "cash",
+      preloaded_studios,
+      preloaded_new_biz_leads,
+      utilization_by_period[period],
+      utilization_by_period[prev_period],
+      g3d_utilization_by_period[period],
+      g3d_utilization_by_period[prev_period],
+      preloaded_client_revenue
+    )
+```
+
+(repeat identically for the `accrual` call, keeping `"accrual"` as the third argument).
+
+- [ ] **Step 2: Add hints for the four OKRs**
+
+In `app/models/studio.rb`, in `hint_for_okr`'s `case okr.datapoint` (add before the `else` on line 269):
+
+```ruby
+    when "average_client_lifetime_value"
+      "across #{datapoints[:average_client_lifetime_value][:extras][:client_count]} clients invoiced since June 2021"
+    when "average_client_tenure"
+      "across #{datapoints[:average_client_tenure][:extras][:client_count]} clients invoiced since June 2021"
+    when "client_revenue_concentration"
+      "#{datapoints[:client_revenue_concentration][:extras][:top_client_name] || "no top client"}: #{ActionController::Base.helpers.number_to_currency(datapoints[:client_revenue_concentration][:extras][:top_client_amount])} of #{ActionController::Base.helpers.number_to_currency(datapoints[:client_revenue_concentration][:extras][:total_revenue])}"
+    when "forecasted_sales_revenue"
+      "#{datapoints[:forecasted_sales_revenue][:extras][:budgeted_lead_count]} of #{datapoints[:forecasted_sales_revenue][:extras][:open_lead_count]} open leads budgeted"
+```
+
+- [ ] **Step 3: Add the datapoints to the OKR Explorer list**
+
+In `app/admin/okr_explorer.rb`, change line 8 to:
+
+```ruby
+    all_okrs = ["average_hourly_rate", "successful_projects", "successful_proposals", "average_client_lifetime_value", "average_client_tenure", "client_revenue_concentration", "forecasted_sales_revenue"]
+```
+
+(The explorer partial renders unknown datapoints through its generic value path; no partial changes needed.)
+
+- [ ] **Step 4: Run the full test suite**
+
+Run: `bin/rails test`
+Expected: PASS — no regressions. If pre-existing failures exist on the branch base, note them and confirm your changes add none.
+
+- [ ] **Step 5: Verify against real dev data (read-only)**
+
+Run:
+
+```bash
+bin/rails runner '
+g3d = Studio.garden3d
+cr = g3d.client_revenue
+today = Date.today
+puts "LTV:      #{cr.average_lifetime_value_asof(today).round(0)} across #{cr.client_count_asof(today)} clients"
+puts "Tenure:   #{cr.average_tenure_months_asof(today).round(1)} months"
+puts "Conc YTD: #{cr.concentration_for_range(today.beginning_of_year, today).inspect}"
+period = Stacks::Period.new("YTD", today.beginning_of_year, today)
+puts "Pipeline: #{g3d.client_and_pipeline_datapoints(period, g3d.new_biz_leads, cr)[:forecasted_sales_revenue].inspect}"
+'
+```
+
+Expected: LTV a positive dollar figure with ~100+ clients; tenure a positive number of months; concentration value between 0 and 100 with a real client name; pipeline value ≥ 0 with `open_lead_count` around 120 and `budgeted_lead_count` around 13 (July 2026 dev data). Sanity-check these against the spec's data findings; if wildly off (e.g. concentration > 100, client_count 0), stop and investigate.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/models/studio.rb app/admin/okr_explorer.rb
+git commit -m "feat(okrs): wire client & pipeline KPIs into snapshots, hints, explorer"
+```
+
+---
+
+## Post-implementation (manual, not code)
+
+Creating the Okr records is an admin-UI step, done after deploy via ActiveAdmin ("Okey Dokeys"): one Okr per KPI with a name, description, operator (`greater_than` for LTV/tenure/forecast, `less_than` for concentration), the matching datapoint, and OkrPeriods (target, tolerance, date range, studios). Recommended names: "Average Client Lifetime Value", "Average Client Tenure", "Client Revenue Concentration", "Forecasted Sales Revenue".

--- a/docs/superpowers/specs/2026-07-29-studio-okr-client-kpis-design.md
+++ b/docs/superpowers/specs/2026-07-29-studio-okr-client-kpis-design.md
@@ -1,7 +1,7 @@
 # Studio OKR: Client & Pipeline KPIs — Design
 
 **Date:** 2026-07-29
-**Status:** Approved (brainstorming session with Hugh)
+**Status:** Approved; revised after correctness/simplicity review (see Review Revisions)
 
 ## Goal
 
@@ -18,20 +18,24 @@ computed per studio per period in `Studio#key_datapoints_for_period`
 nightly snapshot generation, the OKR Explorer, dashboard chips, and the
 `get_studio_health` MCP tool with no extra plumbing.
 
+Scope note: invoice-pass history starts June 2021 (~1,100 trackers, 113
+clients). Per Hugh, only the last few years of data matter, so this is the
+metric horizon — no backfilling or pre-2021 adjustment.
+
 ## KPI Definitions
 
 ### 1. `average_client_lifetime_value` — unit `:usd`, typical operator `greater_than`
 
-As of the period's end date: every `ForecastClient` that has ever had an
-`InvoiceTracker`, averaged over each client's total invoiced value up to that
-date. All-time population, lifetime-to-date value — a slow-growing number that
-rises as bigger, longer-lived clients land.
+As of the period's end date: every external `ForecastClient` with countable
+invoiced revenue (see Countable revenue), averaged over each client's total
+invoiced value up to that date. All-known-history population, lifetime-to-date
+value — a slow-growing number that rises as bigger, longer-lived clients land.
 
 ### 2. `average_client_tenure` — unit months (`:count`), typical operator `greater_than`
 
 As of the period's end date: per client, months elapsed between their first
-and most recent invoice pass (up to that date), averaged across all clients
-ever. Single-invoice clients count as 0 months.
+and most recent invoice pass (up to that date), averaged across the same
+client population as LTV. Single-invoice clients count as 0 months.
 
 ### 3. `client_revenue_concentration` — unit `:percentage`, typical operator `less_than`
 
@@ -40,31 +44,42 @@ revenue. `extras` names the top client and its dollar amount.
 
 ### 4. `forecasted_sales_revenue` — unit `:usd`, typical operator `greater_than`
 
-Open pipeline as of the period's end, from Notion leads via the existing
+Current open pipeline, from Notion leads via the existing
 `Studio#new_biz_leads` (already per-studio; garden3d sees all leads).
 
-- **Open lead:** `✨ Lead Received` ≤ period end AND no terminal date
-  (`✨ Status: Won`, `✨ Status: Lost`, `✨ Status: Ghosted`,
-  `✨ Status: We Passed`, or `Settled Date`) on or before period end. This
-  date-based rule captures the Active / Not started / On hold (re-engage)
-  statuses and treats Settled as no longer active (per Hugh).
+- **Open lead:** current `Lead Status` is `Active`, `Not started`, or
+  `On hold (re-engage)`. Status is the source of truth — the terminal date
+  stamps (`✨ Status: Won/Lost/Ghosted`, etc.) are missing on most dead leads
+  (e.g. 198 of 326 Lost leads have no date stamp), so date-based
+  reconstruction is not viable.
 - **Lead value:** midpoint of `Est. Budget Low` / `Est. Budget High`
   (Notion number properties); if only one is filled, use it; if neither,
   the lead contributes $0 and triggers a hygiene task (below).
+- **Point-in-time metric:** this KPI always reflects the pipeline as of the
+  nightly snapshot run, regardless of which period is being viewed. It is a
+  "now" metric for steering against current-period targets; it does not
+  reconstruct what the pipeline looked like in past periods.
 
-### Known caveats (accepted)
+### Known caveat (accepted)
 
-- **History horizon:** invoice passes start June 2021 (~1,100 trackers,
-  113 clients). Pre-2021 clients look younger and smaller than reality in
-  LTV and tenure.
-- **Budget fill rate:** only ~10% of currently-open leads have Est. Budget
-  filled, so forecasted sales revenue starts as an undercount and becomes
-  accurate as hygiene tasks are worked.
-- **No budget versioning:** historical periods' pipeline values use each
-  lead's *current* budget numbers (Notion doesn't version them), so past
-  values can drift on re-snapshot.
+Only ~10% of currently-open leads have Est. Budget filled, so forecasted
+sales revenue starts as an undercount and becomes accurate as hygiene tasks
+are worked.
 
 ## Computation & Studio Attribution
+
+### Countable revenue
+
+An InvoiceTracker counts toward client revenue iff:
+
+- it has a linked, non-voided `QboInvoice` (excludes `:not_made`, `:deleted`,
+  and voided trackers — real invoiced dollars only), and
+- its `ForecastClient` is external (`!is_internal?` — internal clients are
+  mapped to an enterprise via `enterprise_forecast_clients`; 62 trackers are
+  inter-studio billing and would inflate LTV and distort concentration).
+
+Its dollar value is the QBO invoice `total`, dated by its InvoicePass month,
+grouped by `forecast_client_id`.
 
 ### `Stacks::ClientRevenue` (new PORO, `lib/stacks/client_revenue.rb`)
 
@@ -73,30 +88,26 @@ math; the client-revenue logic lives in a new PORO that answers one question:
 **per-client invoiced revenue for a studio within a date range.** The three
 client KPIs become short calls into it.
 
-- **Value:** an InvoiceTracker's dollar value is its existing `total`
-  (manual `value` override, else `blueprint_total`), dated by its
-  InvoicePass month, grouped by `forecast_client_id`.
-- **Studio attribution:**
-  - garden3d: every tracker counts, no splitting.
-  - Sub-studios: split each tracker's value by blueprint lines — each line
-    encodes a forecast person and `quantity × unit_price`; person → studio is
-    the same attribution the cost explorer uses. Malformed blueprint entries
-    are skipped and logged (matching the recent cost-explorer fix).
-  - Fallback (no blueprint): split by the linked ProjectTracker's
-    hours-by-studio for that invoice month
-    (`ProjectTracker#total_hours_during_range_by_studio`).
-  - If neither exists: the value counts for garden3d but is omitted from
-    sub-studio numbers rather than guessed.
-- **Internal clients excluded:** clients marked internal via
-  `enterprise_forecast_clients` don't count — inter-studio billing would
-  inflate LTV and distort concentration.
+**Studio attribution:**
+
+- garden3d: every countable tracker counts, no splitting.
+- Sub-studios: split each tracker's value by its blueprint lines — each line
+  encodes a forecast person and `quantity × unit_price`; person → studio is
+  the same attribution the cost explorer uses. Malformed blueprint entries
+  are skipped and logged (matching the recent cost-explorer fix).
+- No further fallback: 1,092 of 1,093 trackers have blueprint lines, so a
+  secondary attribution path is not worth its complexity. A tracker without
+  lines is simply omitted from sub-studio numbers (it still counts for
+  garden3d).
 
 ### Pipeline computation
 
 Stays a small inline computation in `key_datapoints_for_period`, since
 `Studio#new_biz_leads` already loads and scopes leads. `Stacks::Notion::Lead`
-gains readers for the terminal-status dates and budget fields it doesn't
-expose yet. `extras` reports lead count and budget coverage
+gains two readers: `lead_status` (the Notion status property) and
+`estimated_budget` (the Low/High midpoint logic). The same "open lead"
+definition (status-based) is shared by the KPI and the hygiene task.
+`extras` reports lead count and budget coverage
 (e.g. "31 open leads, 12 budgeted").
 
 ### Performance
@@ -108,17 +119,16 @@ per-period query storms.
 
 ## Budget Hygiene Task
 
-`Stacks::TaskBuilder` gains a `needs_budget_estimate` task type: any lead
-whose *current* `Lead Status` is Active, Not started, or On hold (re-engage)
-with neither `Est. Budget Low` nor `Est. Budget High` filled gets a task
-routed to its Account Lead admin users, falling back to the Stacks admin team
-when unset (same routing as `needs_settling`).
+`Stacks::TaskBuilder` gains a `needs_budget_estimate` task type: any open
+lead (same status-based definition as the KPI) with neither `Est. Budget Low`
+nor `Est. Budget High` filled gets a task routed to its Account Lead admin
+users, falling back to the Stacks admin team when unset (same routing as
+`needs_settling`).
 
 ## Error Handling
 
 - Empty denominators return 0 with explanatory `extras`, not nil — a studio
   with no invoiced revenue in a period reports 0% concentration.
-- Leads with missing/unparseable dates are skipped.
 - Malformed blueprint entries are skipped and logged.
 - Enum integers are appended at the next free values, never renumbered;
   existing datapoints are untouched.
@@ -127,10 +137,11 @@ when unset (same routing as `needs_settling`).
 
 RSpec at three levels:
 
-1. **Unit — `Stacks::ClientRevenue`:** grouping by client, studio splits via
-   blueprint persons, fallback chain (blueprint → project-tracker hours →
-   g3d-only), internal-client exclusion, period-end truncation for LTV/tenure.
-2. **Unit — pipeline:** open-lead date logic (each terminal status), budget
+1. **Unit — `Stacks::ClientRevenue`:** countable-revenue rules (voided /
+   unlinked / internal-client trackers excluded), grouping by client, studio
+   splits via blueprint persons (including malformed-entry skip), period-end
+   truncation for LTV/tenure.
+2. **Unit — pipeline:** status-based open-lead logic, budget
    midpoint/single-value/missing cases, coverage extras.
 3. **Integration — `Studio#key_datapoints_for_period`:** all four keys
    present with correct units and sane values.
@@ -159,5 +170,26 @@ RSpec at three levels:
   fallback values).
 - Pipeline scope: **Active, Not started, On hold (re-engage)**; Settled is
   not active.
-- Revenue basis for client metrics: **InvoiceTracker** (option C), accepting
-  the June 2021 history horizon.
+- Revenue basis for client metrics: **InvoiceTracker** (option C).
+- Data horizon: **last few years is sufficient** (Hugh) — June 2021
+  invoice-pass start is the metric horizon, no caveat needed.
+
+## Review Revisions (2026-07-29 correctness & simplicity pass)
+
+1. **Open-lead rule rewritten (correctness).** Terminal date stamps are
+   unreliable (198/326 Lost, 115/189 Passed, 44/143 Won leads lack them);
+   date-based reconstruction would count hundreds of dead leads as pipeline.
+   Now: current `Lead Status` only, and the pipeline KPI is explicitly
+   point-in-time. This also removed the "unversioned budgets drift on
+   re-snapshot" caveat.
+2. **InvoiceTracker value semantics corrected.** `value` is the linked QBO
+   invoice's total, not a manual override. Countable revenue is now
+   "linked, non-voided QBO invoice only" — real invoiced dollars, and the
+   48 not-made/deleted trackers drop out naturally.
+3. **Attribution fallback chain deleted (simplicity).** 1,092/1,093 trackers
+   have blueprint lines; the ProjectTracker-hours fallback served ~1 record
+   and is gone. One attribution mechanism remains.
+4. **`Settled Date` terminal logic deleted** — obsolete under the
+   status-based rule.
+5. **History-horizon caveat reframed** as an accepted scope decision per
+   Hugh's "last few years" guidance.

--- a/docs/superpowers/specs/2026-07-29-studio-okr-client-kpis-design.md
+++ b/docs/superpowers/specs/2026-07-29-studio-okr-client-kpis-design.md
@@ -60,6 +60,12 @@ Current open pipeline, from Notion leads via the existing
   "now" metric for steering against current-period targets; it does not
   reconstruct what the pipeline looked like in past periods.
 
+### Open-lead count note
+
+Raw DB counts of Notion pages with active statuses include soft-deleted pages
+(acts_as_paranoid default scope is not applied to Notion data); live
+(acts_as_paranoid-scoped) open leads ≈ 25 as of 2026-07-29.
+
 ### Known caveat (accepted)
 
 Only ~10% of currently-open leads have Est. Budget filled, so forecasted

--- a/docs/superpowers/specs/2026-07-29-studio-okr-client-kpis-design.md
+++ b/docs/superpowers/specs/2026-07-29-studio-okr-client-kpis-design.md
@@ -1,0 +1,163 @@
+# Studio OKR: Client & Pipeline KPIs — Design
+
+**Date:** 2026-07-29
+**Status:** Approved (brainstorming session with Hugh)
+
+## Goal
+
+Add four new Studio-level OKR datapoints to the existing OKR system:
+
+1. **Average Client Lifetime Value** (evolved from "average deal size")
+2. **Average Client Tenure** (evolved from "average client retention")
+3. **Client Revenue Concentration** (per-client revenue concentration)
+4. **Forecasted Sales Revenue** (open pipeline value)
+
+All four become new `datapoint` enum entries on `Okr` (`app/models/okr.rb`),
+computed per studio per period in `Studio#key_datapoints_for_period`
+(`app/models/studio.rb`), so they inherit targets, tolerance, health tags,
+nightly snapshot generation, the OKR Explorer, dashboard chips, and the
+`get_studio_health` MCP tool with no extra plumbing.
+
+## KPI Definitions
+
+### 1. `average_client_lifetime_value` — unit `:usd`, typical operator `greater_than`
+
+As of the period's end date: every `ForecastClient` that has ever had an
+`InvoiceTracker`, averaged over each client's total invoiced value up to that
+date. All-time population, lifetime-to-date value — a slow-growing number that
+rises as bigger, longer-lived clients land.
+
+### 2. `average_client_tenure` — unit months (`:count`), typical operator `greater_than`
+
+As of the period's end date: per client, months elapsed between their first
+and most recent invoice pass (up to that date), averaged across all clients
+ever. Single-invoice clients count as 0 months.
+
+### 3. `client_revenue_concentration` — unit `:percentage`, typical operator `less_than`
+
+Within the period itself: the largest client's share of the studio's invoiced
+revenue. `extras` names the top client and its dollar amount.
+
+### 4. `forecasted_sales_revenue` — unit `:usd`, typical operator `greater_than`
+
+Open pipeline as of the period's end, from Notion leads via the existing
+`Studio#new_biz_leads` (already per-studio; garden3d sees all leads).
+
+- **Open lead:** `✨ Lead Received` ≤ period end AND no terminal date
+  (`✨ Status: Won`, `✨ Status: Lost`, `✨ Status: Ghosted`,
+  `✨ Status: We Passed`, or `Settled Date`) on or before period end. This
+  date-based rule captures the Active / Not started / On hold (re-engage)
+  statuses and treats Settled as no longer active (per Hugh).
+- **Lead value:** midpoint of `Est. Budget Low` / `Est. Budget High`
+  (Notion number properties); if only one is filled, use it; if neither,
+  the lead contributes $0 and triggers a hygiene task (below).
+
+### Known caveats (accepted)
+
+- **History horizon:** invoice passes start June 2021 (~1,100 trackers,
+  113 clients). Pre-2021 clients look younger and smaller than reality in
+  LTV and tenure.
+- **Budget fill rate:** only ~10% of currently-open leads have Est. Budget
+  filled, so forecasted sales revenue starts as an undercount and becomes
+  accurate as hygiene tasks are worked.
+- **No budget versioning:** historical periods' pipeline values use each
+  lead's *current* budget numbers (Notion doesn't version them), so past
+  values can drift on re-snapshot.
+
+## Computation & Studio Attribution
+
+### `Stacks::ClientRevenue` (new PORO, `lib/stacks/client_revenue.rb`)
+
+`Studio#key_datapoints_for_period` is already ~190 lines of inline metric
+math; the client-revenue logic lives in a new PORO that answers one question:
+**per-client invoiced revenue for a studio within a date range.** The three
+client KPIs become short calls into it.
+
+- **Value:** an InvoiceTracker's dollar value is its existing `total`
+  (manual `value` override, else `blueprint_total`), dated by its
+  InvoicePass month, grouped by `forecast_client_id`.
+- **Studio attribution:**
+  - garden3d: every tracker counts, no splitting.
+  - Sub-studios: split each tracker's value by blueprint lines — each line
+    encodes a forecast person and `quantity × unit_price`; person → studio is
+    the same attribution the cost explorer uses. Malformed blueprint entries
+    are skipped and logged (matching the recent cost-explorer fix).
+  - Fallback (no blueprint): split by the linked ProjectTracker's
+    hours-by-studio for that invoice month
+    (`ProjectTracker#total_hours_during_range_by_studio`).
+  - If neither exists: the value counts for garden3d but is omitted from
+    sub-studio numbers rather than guessed.
+- **Internal clients excluded:** clients marked internal via
+  `enterprise_forecast_clients` don't count — inter-studio billing would
+  inflate LTV and distort concentration.
+
+### Pipeline computation
+
+Stays a small inline computation in `key_datapoints_for_period`, since
+`Studio#new_biz_leads` already loads and scopes leads. `Stacks::Notion::Lead`
+gains readers for the terminal-status dates and budget fields it doesn't
+expose yet. `extras` reports lead count and budget coverage
+(e.g. "31 open leads, 12 budgeted").
+
+### Performance
+
+All four KPIs compute inside the existing nightly `Studio#generate_snapshot!`
+run. The dataset is small; InvoiceTracker + blueprint data loads once per
+snapshot run and is memoized, following existing preload patterns — no
+per-period query storms.
+
+## Budget Hygiene Task
+
+`Stacks::TaskBuilder` gains a `needs_budget_estimate` task type: any lead
+whose *current* `Lead Status` is Active, Not started, or On hold (re-engage)
+with neither `Est. Budget Low` nor `Est. Budget High` filled gets a task
+routed to its Account Lead admin users, falling back to the Stacks admin team
+when unset (same routing as `needs_settling`).
+
+## Error Handling
+
+- Empty denominators return 0 with explanatory `extras`, not nil — a studio
+  with no invoiced revenue in a period reports 0% concentration.
+- Leads with missing/unparseable dates are skipped.
+- Malformed blueprint entries are skipped and logged.
+- Enum integers are appended at the next free values, never renumbered;
+  existing datapoints are untouched.
+
+## Testing
+
+RSpec at three levels:
+
+1. **Unit — `Stacks::ClientRevenue`:** grouping by client, studio splits via
+   blueprint persons, fallback chain (blueprint → project-tracker hours →
+   g3d-only), internal-client exclusion, period-end truncation for LTV/tenure.
+2. **Unit — pipeline:** open-lead date logic (each terminal status), budget
+   midpoint/single-value/missing cases, coverage extras.
+3. **Integration — `Studio#key_datapoints_for_period`:** all four keys
+   present with correct units and sane values.
+4. **`TaskBuilder`:** `needs_budget_estimate` fires for open unbudgeted
+   leads, routes to Account Lead, falls back to admin team.
+
+## Rollout
+
+1. Ship code (enum entries, `Stacks::ClientRevenue`, computations, lead
+   readers, task type).
+2. Create the four Okr records manually in ActiveAdmin (name, description,
+   operator, OkrPeriods with target/tolerance/date range, studio
+   assignments) — the existing workflow.
+3. Optional: add the four to OKR Explorer's `all_okrs` list
+   (`app/admin/okr_explorer.rb`) so they chart over time.
+
+## Decisions Log (from brainstorming)
+
+- "Average deal size" → reframed as **Average Client Lifetime Value** (Hugh).
+- LTV cohort: **all clients ever, all-time revenue** (not period-billed or
+  new-client cohort).
+- Retention → **average client tenure** (first→last invoice span, months).
+- Concentration → **largest client's % of period revenue** (not top-3 or HHI).
+- Forecasted sales revenue → **pipeline only** (no booked Forecast.app work).
+- Missing budgets → **sum what exists + hygiene tasks** (no synthetic
+  fallback values).
+- Pipeline scope: **Active, Not started, On hold (re-engage)**; Settled is
+  not active.
+- Revenue basis for client metrics: **InvoiceTracker** (option C), accepting
+  the June 2021 history horizon.

--- a/lib/stacks/client_kpi_datapoints.rb
+++ b/lib/stacks/client_kpi_datapoints.rb
@@ -1,0 +1,64 @@
+# Builds the four client & pipeline OKR datapoint entries that
+# Studio#key_datapoints_for_period merges into its result. Each entry is
+# shaped like the existing datapoints: { value:, unit:, extras: }.
+class Stacks::ClientKpiDatapoints
+  def self.call(period:, leads:, client_revenue:)
+    new(period: period, leads: leads, client_revenue: client_revenue).call
+  end
+
+  def initialize(period:, leads:, client_revenue:)
+    @period = period
+    @leads = leads
+    @client_revenue = client_revenue
+  end
+
+  def call
+    {
+      average_client_lifetime_value: {
+        value: @client_revenue.average_lifetime_value_asof(@period.ends_at),
+        unit: :usd,
+        extras: { client_count: client_count }
+      },
+      average_client_tenure: {
+        value: @client_revenue.average_tenure_months_asof(@period.ends_at),
+        unit: :count,
+        extras: { client_count: client_count }
+      },
+      client_revenue_concentration: {
+        value: concentration[:value],
+        unit: :percentage,
+        extras: {
+          top_client_name: concentration[:top_client_name],
+          top_client_amount: concentration[:top_client_amount],
+          total_revenue: concentration[:total_revenue]
+        }
+      },
+      forecasted_sales_revenue: {
+        value: budgets.sum,
+        unit: :usd,
+        extras: {
+          open_lead_count: open_leads.count,
+          budgeted_lead_count: budgets.count
+        }
+      }
+    }
+  end
+
+  private
+
+  def open_leads
+    @_open_leads ||= @leads.select(&:open?)
+  end
+
+  def budgets
+    @_budgets ||= open_leads.filter_map(&:estimated_budget)
+  end
+
+  def concentration
+    @_concentration ||= @client_revenue.concentration_for_range(@period.starts_at, @period.ends_at)
+  end
+
+  def client_count
+    @_client_count ||= @client_revenue.client_count_asof(@period.ends_at)
+  end
+end

--- a/lib/stacks/client_kpi_datapoints.rb
+++ b/lib/stacks/client_kpi_datapoints.rb
@@ -17,7 +17,7 @@ class Stacks::ClientKpiDatapoints
       average_client_lifetime_value: {
         value: @client_revenue.average_lifetime_value_asof(@period.ends_at),
         unit: :usd,
-        extras: { client_count: client_count }
+        extras: { client_count: client_count, skipped_tracker_count: @client_revenue.skipped_tracker_count }
       },
       average_client_tenure: {
         value: @client_revenue.average_tenure_months_asof(@period.ends_at),
@@ -30,7 +30,8 @@ class Stacks::ClientKpiDatapoints
         extras: {
           top_client_name: concentration[:top_client_name],
           top_client_amount: concentration[:top_client_amount],
-          total_revenue: concentration[:total_revenue]
+          total_revenue: concentration[:total_revenue],
+          skipped_tracker_count: @client_revenue.skipped_tracker_count
         }
       },
       forecasted_sales_revenue: {

--- a/lib/stacks/client_kpi_datapoints.rb
+++ b/lib/stacks/client_kpi_datapoints.rb
@@ -22,7 +22,7 @@ class Stacks::ClientKpiDatapoints
       average_client_tenure: {
         value: @client_revenue.average_tenure_months_asof(@period.ends_at),
         unit: :count,
-        extras: { client_count: client_count }
+        extras: { client_count: client_count, skipped_tracker_count: @client_revenue.skipped_tracker_count }
       },
       client_revenue_concentration: {
         value: concentration[:value],

--- a/lib/stacks/client_revenue.rb
+++ b/lib/stacks/client_revenue.rb
@@ -8,10 +8,13 @@
 class Stacks::ClientRevenue
   Row = Struct.new(:client, :month, :amount, keyword_init: true)
 
+  attr_reader :skipped_tracker_count
+
   def initialize(studio, preloaded_studios = Studio.all, trackers = nil)
     @studio = studio
     @preloaded_studios = preloaded_studios
     @trackers = trackers || self.class.all_trackers
+    @skipped_tracker_count = 0
     @rows = build_rows
   end
 
@@ -73,6 +76,16 @@ class Stacks::ClientRevenue
       begin
         invoice = tracker.qbo_invoice
         client = tracker.forecast_client
+
+        # Guard: skip invoices with no stored data to prevent the lazy live-QBO
+        # sync in QboInvoice#data from firing inside the nightly snapshot hot
+        # path. Use read_attribute to bypass the lazy-sync override in #data.
+        # These are data-quality drops, so they count toward skipped_tracker_count.
+        if invoice && invoice.read_attribute(:data).blank?
+          @skipped_tracker_count += 1
+          next
+        end
+
         next if invoice.nil? || invoice.status == :voided
         next if client.nil? || client.is_internal?
 
@@ -82,6 +95,7 @@ class Stacks::ClientRevenue
         Row.new(client: client, month: tracker.invoice_pass.start_of_month, amount: amount)
       rescue => e
         Rails.logger.warn("[ClientRevenue] invoice_tracker=#{tracker.id} skipped: #{e.class}: #{e.message}")
+        @skipped_tracker_count += 1
         nil
       end
     end

--- a/lib/stacks/client_revenue.rb
+++ b/lib/stacks/client_revenue.rb
@@ -70,15 +70,20 @@ class Stacks::ClientRevenue
 
   def build_rows
     @trackers.filter_map do |tracker|
-      invoice = tracker.qbo_invoice
-      client = tracker.forecast_client
-      next if invoice.nil? || invoice.status == :voided
-      next if client.nil? || client.is_internal?
+      begin
+        invoice = tracker.qbo_invoice
+        client = tracker.forecast_client
+        next if invoice.nil? || invoice.status == :voided
+        next if client.nil? || client.is_internal?
 
-      amount = @studio.is_garden3d? ? invoice.total : studio_share(tracker, invoice.total)
-      next if amount.nil? || amount.zero?
+        amount = @studio.is_garden3d? ? invoice.total : studio_share(tracker, invoice.total)
+        next if amount.nil? || amount.zero?
 
-      Row.new(client: client, month: tracker.invoice_pass.start_of_month, amount: amount)
+        Row.new(client: client, month: tracker.invoice_pass.start_of_month, amount: amount)
+      rescue => e
+        Rails.logger.warn("[ClientRevenue] invoice_tracker=#{tracker.id} skipped: #{e.class}: #{e.message}")
+        nil
+      end
     end
   end
 

--- a/lib/stacks/client_revenue.rb
+++ b/lib/stacks/client_revenue.rb
@@ -1,0 +1,116 @@
+# Per-client invoiced revenue for a studio, derived from InvoiceTracker
+# history (June 2021 onward). Countable revenue = trackers with a linked,
+# non-voided QBO invoice on an external client. garden3d counts full invoice
+# totals; sub-studios take a pro-rata share via blueprint person lines
+# (person -> studio by Forecast roles), the same attribution the cost
+# explorer uses. Feeds the average_client_lifetime_value,
+# average_client_tenure, and client_revenue_concentration OKR datapoints.
+class Stacks::ClientRevenue
+  Row = Struct.new(:client, :month, :amount, keyword_init: true)
+
+  def initialize(studio, preloaded_studios = Studio.all, trackers = nil)
+    @studio = studio
+    @preloaded_studios = preloaded_studios
+    @trackers = trackers || self.class.all_trackers
+    @rows = build_rows
+  end
+
+  def self.all_trackers
+    InvoiceTracker
+      .includes(:invoice_pass, :qbo_invoice, forecast_client: :enterprise_forecast_client)
+      .to_a
+  end
+
+  def average_lifetime_value_asof(date)
+    totals = totals_by_client_asof(date)
+    return 0 if totals.empty?
+    totals.values.sum / totals.length
+  end
+
+  def average_tenure_months_asof(date)
+    rows = @rows.select { |r| r.month <= date }
+    return 0 if rows.empty?
+    tenures = rows.group_by(&:client).values.map do |client_rows|
+      first, last = client_rows.map(&:month).minmax
+      (last.year * 12 + last.month) - (first.year * 12 + first.month)
+    end
+    tenures.sum.to_f / tenures.length
+  end
+
+  def client_count_asof(date)
+    totals_by_client_asof(date).length
+  end
+
+  def concentration_for_range(starts_at, ends_at)
+    in_range = @rows.select { |r| r.month >= starts_at.beginning_of_month && r.month <= ends_at }
+    total = in_range.sum(&:amount)
+    return { value: 0, top_client_name: nil, top_client_amount: 0, total_revenue: 0 } if total.zero?
+
+    top_client, top_amount = in_range
+      .group_by(&:client)
+      .transform_values { |rs| rs.sum(&:amount) }
+      .max_by { |_, amount| amount }
+
+    {
+      value: (top_amount / total) * 100,
+      top_client_name: top_client.name,
+      top_client_amount: top_amount,
+      total_revenue: total
+    }
+  end
+
+  private
+
+  def totals_by_client_asof(date)
+    @rows
+      .select { |r| r.month <= date }
+      .group_by(&:client)
+      .transform_values { |rs| rs.sum(&:amount) }
+  end
+
+  def build_rows
+    @trackers.filter_map do |tracker|
+      invoice = tracker.qbo_invoice
+      client = tracker.forecast_client
+      next if invoice.nil? || invoice.status == :voided
+      next if client.nil? || client.is_internal?
+
+      amount = @studio.is_garden3d? ? invoice.total : studio_share(tracker, invoice.total)
+      next if amount.nil? || amount.zero?
+
+      Row.new(client: client, month: tracker.invoice_pass.start_of_month, amount: amount)
+    end
+  end
+
+  # Pro-rata share of the invoice total from blueprint lines whose person
+  # belongs to this studio. Legacy lines without a forecast_person key fall
+  # back to the [FP-<id>] description tag. Malformed lines are skipped and
+  # logged; a tracker with no usable lines is omitted from sub-studio numbers
+  # (it still counts for garden3d).
+  def studio_share(tracker, invoice_total)
+    lines = (tracker.blueprint || {})["lines"] || {}
+    studio_sum = 0.0
+    all_sum = 0.0
+
+    lines.each do |description, line|
+      unless line.is_a?(Hash) && line["quantity"].is_a?(Numeric) && line["unit_price"].is_a?(Numeric)
+        Rails.logger.warn("[ClientRevenue] invoice_tracker=#{tracker.id} skipping malformed blueprint line #{description.inspect}")
+        next
+      end
+      line_value = line["quantity"] * line["unit_price"]
+      all_sum += line_value
+
+      person_id = line["forecast_person"] || InvoiceTracker.forecast_person_id_from_description(description)
+      next if person_id.nil?
+      person = forecast_people_by_id[person_id]
+      studio_sum += line_value if person&.studio(@preloaded_studios) == @studio
+    end
+
+    return nil if all_sum.zero?
+    (studio_sum / all_sum) * invoice_total
+  end
+
+  def forecast_people_by_id
+    @_forecast_people_by_id ||= ForecastPerson.all.index_by(&:forecast_id)
+  end
+end

--- a/lib/stacks/notion/lead.rb
+++ b/lib/stacks/notion/lead.rb
@@ -43,6 +43,31 @@ class Stacks::Notion::Lead < Stacks::Notion::Base
     won_at.present?
   end
 
+  # Current-status is the source of truth for "open pipeline". The terminal
+  # date stamps (✨ Status: Won/Lost/Ghosted) are missing on most dead leads,
+  # so they must not be used to decide openness.
+  OPEN_STATUSES = ["Active", "Not started", "On hold (re-engage)"].freeze
+
+  def lead_status
+    (get_prop_value("Lead Status") || {}).dig("name")
+  end
+
+  def open?
+    OPEN_STATUSES.include?(lead_status)
+  end
+
+  # Midpoint of the Est. Budget Low/High Notion number props; a single value
+  # if only one is filled; nil when unbudgeted (callers treat nil as $0 and
+  # file a needs_budget_estimate task).
+  def estimated_budget
+    values = [
+      get_prop_value("Est. Budget Low"),
+      get_prop_value("Est. Budget High")
+    ].select { |v| v.is_a?(Numeric) }
+    return nil if values.empty?
+    values.sum / values.length.to_f
+  end
+
   # Bulk-preload cache populated by callers iterating many leads. When set,
   # account_lead_admin_users resolves against this in-memory map instead of
   # firing one SQL query per lead.

--- a/lib/stacks/task_builder/discoveries/notion_leads.rb
+++ b/lib/stacks/task_builder/discoveries/notion_leads.rb
@@ -39,6 +39,8 @@ module Stacks
           studios = lead.studios
           out << :no_studios_set if studios.blank?
 
+          out << :needs_budget_estimate if lead.open? && lead.estimated_budget.nil?
+
           out
         end
       end

--- a/test/lib/stacks/client_kpi_datapoints_test.rb
+++ b/test/lib/stacks/client_kpi_datapoints_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+
+class StacksClientKpiDatapointsTest < ActiveSupport::TestCase
+  test "datapoint enum includes the four client & pipeline KPIs at 27-30" do
+    assert_equal 27, Okr.datapoints["average_client_lifetime_value"]
+    assert_equal 28, Okr.datapoints["average_client_tenure"]
+    assert_equal 29, Okr.datapoints["client_revenue_concentration"]
+    assert_equal 30, Okr.datapoints["forecasted_sales_revenue"]
+  end
+
+  test ".call returns the four KPI entries" do
+    studio = Studio.new(name: "garden3d", mini_name: "g3d")
+    acme = ForecastClient.new(name: "Acme")
+
+    invoice = QboInvoice.new
+    invoice.stubs(:status).returns(:paid)
+    invoice.stubs(:total).returns(10_000.0)
+    tracker = InvoiceTracker.new
+    tracker.stubs(:qbo_invoice).returns(invoice)
+    tracker.stubs(:forecast_client).returns(acme)
+    tracker.stubs(:invoice_pass).returns(InvoicePass.new(start_of_month: Date.new(2025, 2, 1)))
+    tracker.stubs(:blueprint).returns(nil)
+
+    client_revenue = Stacks::ClientRevenue.new(studio, [studio], [tracker])
+
+    open_budgeted = NotionPage.new(data: { "properties" => {
+      "Lead Status" => { "type" => "status", "status" => { "name" => "Active" } },
+      "Est. Budget Low" => { "type" => "number", "number" => 40_000 },
+      "Est. Budget High" => { "type" => "number", "number" => 60_000 }
+    } }).as_lead
+    open_unbudgeted = NotionPage.new(data: { "properties" => {
+      "Lead Status" => { "type" => "status", "status" => { "name" => "Not started" } }
+    } }).as_lead
+    lost = NotionPage.new(data: { "properties" => {
+      "Lead Status" => { "type" => "status", "status" => { "name" => "Lost" } },
+      "Est. Budget High" => { "type" => "number", "number" => 999_999 }
+    } }).as_lead
+
+    period = Stacks::Period.new("Feb 2025", Date.new(2025, 2, 1), Date.new(2025, 2, 28))
+    data = Stacks::ClientKpiDatapoints.call(
+      period: period,
+      leads: [open_budgeted, open_unbudgeted, lost],
+      client_revenue: client_revenue
+    )
+
+    assert_equal 10_000.0, data[:average_client_lifetime_value][:value]
+    assert_equal :usd, data[:average_client_lifetime_value][:unit]
+    assert_equal 1, data[:average_client_lifetime_value][:extras][:client_count]
+
+    assert_equal 0.0, data[:average_client_tenure][:value]
+    assert_equal :count, data[:average_client_tenure][:unit]
+
+    assert_equal 100.0, data[:client_revenue_concentration][:value]
+    assert_equal :percentage, data[:client_revenue_concentration][:unit]
+    assert_equal "Acme", data[:client_revenue_concentration][:extras][:top_client_name]
+
+    assert_equal 50_000.0, data[:forecasted_sales_revenue][:value]
+    assert_equal :usd, data[:forecasted_sales_revenue][:unit]
+    assert_equal 2, data[:forecasted_sales_revenue][:extras][:open_lead_count]
+    assert_equal 1, data[:forecasted_sales_revenue][:extras][:budgeted_lead_count]
+  end
+end

--- a/test/lib/stacks/client_kpi_datapoints_test.rb
+++ b/test/lib/stacks/client_kpi_datapoints_test.rb
@@ -50,6 +50,7 @@ class StacksClientKpiDatapointsTest < ActiveSupport::TestCase
 
     assert_equal 0.0, data[:average_client_tenure][:value]
     assert_equal :count, data[:average_client_tenure][:unit]
+    assert_equal 0, data[:average_client_tenure][:extras][:skipped_tracker_count]
 
     assert_equal 100.0, data[:client_revenue_concentration][:value]
     assert_equal :percentage, data[:client_revenue_concentration][:unit]

--- a/test/lib/stacks/client_kpi_datapoints_test.rb
+++ b/test/lib/stacks/client_kpi_datapoints_test.rb
@@ -12,7 +12,7 @@ class StacksClientKpiDatapointsTest < ActiveSupport::TestCase
     studio = Studio.new(name: "garden3d", mini_name: "g3d")
     acme = ForecastClient.new(name: "Acme")
 
-    invoice = QboInvoice.new
+    invoice = QboInvoice.new(data: { "synced" => true })
     invoice.stubs(:status).returns(:paid)
     invoice.stubs(:total).returns(10_000.0)
     tracker = InvoiceTracker.new
@@ -46,6 +46,7 @@ class StacksClientKpiDatapointsTest < ActiveSupport::TestCase
     assert_equal 10_000.0, data[:average_client_lifetime_value][:value]
     assert_equal :usd, data[:average_client_lifetime_value][:unit]
     assert_equal 1, data[:average_client_lifetime_value][:extras][:client_count]
+    assert_equal 0, data[:average_client_lifetime_value][:extras][:skipped_tracker_count]
 
     assert_equal 0.0, data[:average_client_tenure][:value]
     assert_equal :count, data[:average_client_tenure][:unit]
@@ -53,6 +54,7 @@ class StacksClientKpiDatapointsTest < ActiveSupport::TestCase
     assert_equal 100.0, data[:client_revenue_concentration][:value]
     assert_equal :percentage, data[:client_revenue_concentration][:unit]
     assert_equal "Acme", data[:client_revenue_concentration][:extras][:top_client_name]
+    assert_equal 0, data[:client_revenue_concentration][:extras][:skipped_tracker_count]
 
     assert_equal 50_000.0, data[:forecasted_sales_revenue][:value]
     assert_equal :usd, data[:forecasted_sales_revenue][:unit]

--- a/test/lib/stacks/client_revenue_test.rb
+++ b/test/lib/stacks/client_revenue_test.rb
@@ -50,6 +50,7 @@ class StacksClientRevenueTest < ActiveSupport::TestCase
 
     assert_equal 1, cr.client_count_asof(Date.new(2025, 12, 31))
     assert_equal 10_000.0, cr.average_lifetime_value_asof(Date.new(2025, 12, 31))
+    assert_equal 0, cr.skipped_tracker_count
   end
 
   test "asof date excludes later invoices" do

--- a/test/lib/stacks/client_revenue_test.rb
+++ b/test/lib/stacks/client_revenue_test.rb
@@ -156,4 +156,23 @@ class StacksClientRevenueTest < ActiveSupport::TestCase
 
     assert_equal 0, cr.client_count_asof(Date.new(2025, 12, 31))
   end
+
+  test "a tracker whose invoice raises TypeError from #status is skipped while a healthy tracker still counts" do
+    # Simulates QboInvoice#status calling `due_date - Date.today` where due_date is nil
+    bad_invoice = QboInvoice.new
+    bad_invoice.stubs(:status).raises(TypeError, "nil can't be coerced into Integer")
+
+    bad_tracker = InvoiceTracker.new
+    bad_tracker.stubs(:qbo_invoice).returns(bad_invoice)
+    bad_tracker.stubs(:forecast_client).returns(@acme)
+    bad_tracker.stubs(:invoice_pass).returns(InvoicePass.new(start_of_month: Date.new(2025, 1, 1)))
+    bad_tracker.stubs(:blueprint).returns(nil)
+
+    healthy_tracker = make_tracker(client: @globex, month: Date.new(2025, 2, 1), total: 5_000)
+
+    cr = Stacks::ClientRevenue.new(@g3d, @studios, [bad_tracker, healthy_tracker])
+
+    assert_equal 1, cr.client_count_asof(Date.new(2025, 12, 31))
+    assert_equal 5_000.0, cr.average_lifetime_value_asof(Date.new(2025, 12, 31))
+  end
 end

--- a/test/lib/stacks/client_revenue_test.rb
+++ b/test/lib/stacks/client_revenue_test.rb
@@ -1,0 +1,159 @@
+require 'test_helper'
+
+class StacksClientRevenueTest < ActiveSupport::TestCase
+  def setup
+    @g3d = Studio.new(name: "garden3d", mini_name: "g3d")
+    @sanctu = Studio.new(name: "Sanctuary Computer", mini_name: "sanctu")
+    @studios = [@g3d, @sanctu]
+    @acme = ForecastClient.new(name: "Acme")
+    @globex = ForecastClient.new(name: "Globex")
+  end
+
+  def make_tracker(client:, month:, total:, blueprint: nil, voided: false, no_invoice: false, internal: false)
+    tracker = InvoiceTracker.new
+    if no_invoice
+      tracker.stubs(:qbo_invoice).returns(nil)
+    else
+      invoice = QboInvoice.new
+      invoice.stubs(:status).returns(voided ? :voided : :paid)
+      invoice.stubs(:total).returns(total.to_f)
+      tracker.stubs(:qbo_invoice).returns(invoice)
+    end
+    client.stubs(:is_internal?).returns(true) if internal
+    tracker.stubs(:forecast_client).returns(client)
+    tracker.stubs(:invoice_pass).returns(InvoicePass.new(start_of_month: month))
+    tracker.stubs(:blueprint).returns(blueprint)
+    tracker
+  end
+
+  test "garden3d counts full invoice totals grouped by client" do
+    trackers = [
+      make_tracker(client: @acme, month: Date.new(2025, 1, 1), total: 10_000),
+      make_tracker(client: @acme, month: Date.new(2025, 3, 1), total: 20_000),
+      make_tracker(client: @globex, month: Date.new(2025, 2, 1), total: 30_000)
+    ]
+    cr = Stacks::ClientRevenue.new(@g3d, @studios, trackers)
+
+    assert_equal 2, cr.client_count_asof(Date.new(2025, 12, 31))
+    assert_equal 30_000.0, cr.average_lifetime_value_asof(Date.new(2025, 12, 31))
+  end
+
+  test "excludes voided, unlinked, and internal-client trackers" do
+    trackers = [
+      make_tracker(client: @acme, month: Date.new(2025, 1, 1), total: 10_000),
+      make_tracker(client: @acme, month: Date.new(2025, 2, 1), total: 99_999, voided: true),
+      make_tracker(client: @acme, month: Date.new(2025, 3, 1), total: 99_999, no_invoice: true),
+      make_tracker(client: @globex, month: Date.new(2025, 1, 1), total: 99_999, internal: true)
+    ]
+    cr = Stacks::ClientRevenue.new(@g3d, @studios, trackers)
+
+    assert_equal 1, cr.client_count_asof(Date.new(2025, 12, 31))
+    assert_equal 10_000.0, cr.average_lifetime_value_asof(Date.new(2025, 12, 31))
+  end
+
+  test "asof date excludes later invoices" do
+    trackers = [
+      make_tracker(client: @acme, month: Date.new(2025, 1, 1), total: 10_000),
+      make_tracker(client: @acme, month: Date.new(2025, 6, 1), total: 50_000)
+    ]
+    cr = Stacks::ClientRevenue.new(@g3d, @studios, trackers)
+
+    assert_equal 10_000.0, cr.average_lifetime_value_asof(Date.new(2025, 3, 31))
+  end
+
+  test "average tenure is whole months between first and last invoice month per client" do
+    trackers = [
+      make_tracker(client: @acme, month: Date.new(2025, 1, 1), total: 1),
+      make_tracker(client: @acme, month: Date.new(2025, 7, 1), total: 1),   # 6 months
+      make_tracker(client: @globex, month: Date.new(2025, 3, 1), total: 1)  # 0 months
+    ]
+    cr = Stacks::ClientRevenue.new(@g3d, @studios, trackers)
+
+    assert_equal 3.0, cr.average_tenure_months_asof(Date.new(2025, 12, 31))
+  end
+
+  test "concentration is the largest client's share of in-range revenue" do
+    trackers = [
+      make_tracker(client: @acme, month: Date.new(2025, 4, 1), total: 75_000),
+      make_tracker(client: @globex, month: Date.new(2025, 5, 1), total: 25_000),
+      make_tracker(client: @globex, month: Date.new(2024, 1, 1), total: 900_000) # out of range
+    ]
+    cr = Stacks::ClientRevenue.new(@g3d, @studios, trackers)
+    result = cr.concentration_for_range(Date.new(2025, 4, 1), Date.new(2025, 6, 30))
+
+    assert_equal 75.0, result[:value]
+    assert_equal "Acme", result[:top_client_name]
+    assert_equal 75_000.0, result[:top_client_amount]
+    assert_equal 100_000.0, result[:total_revenue]
+  end
+
+  test "concentration with no in-range revenue returns zeros" do
+    cr = Stacks::ClientRevenue.new(@g3d, @studios, [])
+    result = cr.concentration_for_range(Date.new(2025, 1, 1), Date.new(2025, 1, 31))
+
+    assert_equal 0, result[:value]
+    assert_nil result[:top_client_name]
+  end
+
+  test "empty rows return 0 for averages" do
+    cr = Stacks::ClientRevenue.new(@g3d, @studios, [])
+    assert_equal 0, cr.average_lifetime_value_asof(Date.today)
+    assert_equal 0, cr.average_tenure_months_asof(Date.today)
+  end
+
+  test "sub-studio takes a pro-rata share of the invoice via blueprint person lines" do
+    person_in_sanctu = ForecastPerson.create!(
+      id: 111, first_name: "Sanctu", last_name: "Person", email: "sanctu@sanctuary.computer",
+      archived: false, roles: ["Sanctuary Computer"], updated_at: Date.today
+    )
+    person_elsewhere = ForecastPerson.create!(
+      id: 222, first_name: "Other", last_name: "Person", email: "other@sanctuary.computer",
+      archived: false, roles: ["XXIX"], updated_at: Date.today
+    )
+
+    blueprint = {
+      "lines" => {
+        "ACME-1 Acme (July 2025) Sanctu Person [FP-111]" => {
+          "forecast_person" => person_in_sanctu.forecast_id, "quantity" => 10, "unit_price" => 100
+        },
+        "ACME-1 Acme (July 2025) Other Person [FP-222]" => {
+          "forecast_person" => person_elsewhere.forecast_id, "quantity" => 30, "unit_price" => 100
+        }
+      }
+    }
+    # blueprint sums to $4,000; sanctu's share is 1,000/4,000 = 25% of the $8,000 invoice
+    trackers = [make_tracker(client: @acme, month: Date.new(2025, 7, 1), total: 8_000, blueprint: blueprint)]
+    cr = Stacks::ClientRevenue.new(@sanctu, @studios, trackers)
+
+    assert_equal 2_000.0, cr.average_lifetime_value_asof(Date.new(2025, 12, 31))
+  end
+
+  test "sub-studio resolves legacy lines via the [FP-id] description tag" do
+    person_in_sanctu = ForecastPerson.create!(
+      id: 111, first_name: "Sanctu", last_name: "Person", email: "sanctu@sanctuary.computer",
+      archived: false, roles: ["Sanctuary Computer"], updated_at: Date.today
+    )
+
+    blueprint = {
+      "lines" => {
+        "ACME-1 Acme (July 2025) Sanctu Person [FP-111]" => { "quantity" => 10, "unit_price" => 100 }
+      }
+    }
+    trackers = [make_tracker(client: @acme, month: Date.new(2025, 7, 1), total: 1_000, blueprint: blueprint)]
+    cr = Stacks::ClientRevenue.new(@sanctu, @studios, trackers)
+
+    assert_equal 1_000.0, cr.average_lifetime_value_asof(Date.new(2025, 12, 31))
+  end
+
+  test "sub-studio skips malformed blueprint lines and trackers with no usable lines" do
+    blueprint = {
+      "lines" => {
+        "bad line" => { "quantity" => "ten", "unit_price" => 100 }
+      }
+    }
+    trackers = [make_tracker(client: @acme, month: Date.new(2025, 7, 1), total: 1_000, blueprint: blueprint)]
+    cr = Stacks::ClientRevenue.new(@sanctu, @studios, trackers)
+
+    assert_equal 0, cr.client_count_asof(Date.new(2025, 12, 31))
+  end
+end

--- a/test/lib/stacks/client_revenue_test.rb
+++ b/test/lib/stacks/client_revenue_test.rb
@@ -14,7 +14,8 @@ class StacksClientRevenueTest < ActiveSupport::TestCase
     if no_invoice
       tracker.stubs(:qbo_invoice).returns(nil)
     else
-      invoice = QboInvoice.new
+      # Use non-blank data so the blank-data guard in build_rows doesn't skip these trackers.
+      invoice = QboInvoice.new(data: { "synced" => true })
       invoice.stubs(:status).returns(voided ? :voided : :paid)
       invoice.stubs(:total).returns(total.to_f)
       tracker.stubs(:qbo_invoice).returns(invoice)
@@ -159,7 +160,7 @@ class StacksClientRevenueTest < ActiveSupport::TestCase
 
   test "a tracker whose invoice raises TypeError from #status is skipped while a healthy tracker still counts" do
     # Simulates QboInvoice#status calling `due_date - Date.today` where due_date is nil
-    bad_invoice = QboInvoice.new
+    bad_invoice = QboInvoice.new(data: { "synced" => true })
     bad_invoice.stubs(:status).raises(TypeError, "nil can't be coerced into Integer")
 
     bad_tracker = InvoiceTracker.new
@@ -174,5 +175,28 @@ class StacksClientRevenueTest < ActiveSupport::TestCase
 
     assert_equal 1, cr.client_count_asof(Date.new(2025, 12, 31))
     assert_equal 5_000.0, cr.average_lifetime_value_asof(Date.new(2025, 12, 31))
+    assert_equal 1, cr.skipped_tracker_count
+  end
+
+  test "a tracker whose invoice has blank data is skipped without triggering lazy sync; a healthy tracker still counts" do
+    # blank-data invoice: QboInvoice.new with NO data attribute — the new guard must skip it
+    # without ever calling #status or #total (which would trigger the lazy live-QBO sync).
+    blank_invoice = QboInvoice.new  # data column is nil/blank — no data: kwarg
+    blank_invoice.expects(:status).never
+    blank_invoice.expects(:total).never
+
+    blank_tracker = InvoiceTracker.new
+    blank_tracker.stubs(:qbo_invoice).returns(blank_invoice)
+    blank_tracker.stubs(:forecast_client).returns(@acme)
+    blank_tracker.stubs(:invoice_pass).returns(InvoicePass.new(start_of_month: Date.new(2025, 1, 1)))
+    blank_tracker.stubs(:blueprint).returns(nil)
+
+    healthy_tracker = make_tracker(client: @globex, month: Date.new(2025, 2, 1), total: 5_000)
+
+    cr = Stacks::ClientRevenue.new(@g3d, @studios, [blank_tracker, healthy_tracker])
+
+    assert_equal 1, cr.client_count_asof(Date.new(2025, 12, 31))
+    assert_equal 5_000.0, cr.average_lifetime_value_asof(Date.new(2025, 12, 31))
+    assert_equal 1, cr.skipped_tracker_count
   end
 end

--- a/test/lib/stacks/notion/lead_test.rb
+++ b/test/lib/stacks/notion/lead_test.rb
@@ -1,0 +1,55 @@
+require 'test_helper'
+
+class StacksNotionLeadTest < ActiveSupport::TestCase
+  def lead_with_props(props)
+    NotionPage.new(data: { "properties" => props }).as_lead
+  end
+
+  def status_prop(name)
+    { "type" => "status", "status" => { "name" => name } }
+  end
+
+  def number_prop(value)
+    { "type" => "number", "number" => value }
+  end
+
+  test "#lead_status returns the Lead Status name" do
+    lead = lead_with_props("Lead Status" => status_prop("Active"))
+    assert_equal "Active", lead.lead_status
+  end
+
+  test "#lead_status returns nil when the property is missing or empty" do
+    assert_nil lead_with_props({}).lead_status
+    assert_nil lead_with_props("Lead Status" => { "type" => "status", "status" => nil }).lead_status
+  end
+
+  test "#open? is true for Active, Not started, and On hold (re-engage)" do
+    ["Active", "Not started", "On hold (re-engage)"].each do |status|
+      assert lead_with_props("Lead Status" => status_prop(status)).open?, "expected #{status} to be open"
+    end
+  end
+
+  test "#open? is false for terminal statuses and missing status" do
+    ["Won", "Lost", "Passed", "Cold", "Settled", "Project Paused"].each do |status|
+      refute lead_with_props("Lead Status" => status_prop(status)).open?, "expected #{status} to not be open"
+    end
+    refute lead_with_props({}).open?
+  end
+
+  test "#estimated_budget returns the midpoint when both Low and High are set" do
+    lead = lead_with_props(
+      "Est. Budget Low" => number_prop(40_000),
+      "Est. Budget High" => number_prop(60_000)
+    )
+    assert_equal 50_000, lead.estimated_budget
+  end
+
+  test "#estimated_budget returns the single value when only one is set" do
+    assert_equal 75_000, lead_with_props("Est. Budget High" => number_prop(75_000)).estimated_budget
+    assert_equal 30_000, lead_with_props("Est. Budget Low" => number_prop(30_000)).estimated_budget
+  end
+
+  test "#estimated_budget returns nil when neither is set" do
+    assert_nil lead_with_props({}).estimated_budget
+  end
+end

--- a/test/lib/stacks/task_builder/discoveries/notion_leads_test.rb
+++ b/test/lib/stacks/task_builder/discoveries/notion_leads_test.rb
@@ -44,6 +44,19 @@ class StacksTaskBuilderDiscoveriesNotionLeadsTest < ActiveSupport::TestCase
     refute tasks.any? { |t| t.type == :needs_budget_estimate }
   end
 
+  test "an open unbudgeted lead with an Account Lead routes to that admin user" do
+    account_lead = AdminUser.create!(email: "seller@sanctuary.computer", password: "passw0rd")
+    tasks = discover([lead_page(
+      "Lead Status" => { "type" => "status", "status" => { "name" => "Active" } },
+      "✨ Lead Received" => { "type" => "date", "date" => { "start" => Date.today.iso8601 } },
+      "Account Lead" => { "type" => "people", "people" => [{ "person" => { "email" => "seller@sanctuary.computer" } }] }
+    )])
+
+    task = tasks.find { |t| t.type == :needs_budget_estimate }
+    assert task, "expected a needs_budget_estimate task"
+    assert_equal [account_lead], task.owners
+  end
+
   test "needs_budget_estimate has an explicit humanized label" do
     assert_equal "Notion lead needs an estimated budget",
       StacksTask::HUMANIZED_TYPES[:needs_budget_estimate]

--- a/test/lib/stacks/task_builder/discoveries/notion_leads_test.rb
+++ b/test/lib/stacks/task_builder/discoveries/notion_leads_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+class StacksTaskBuilderDiscoveriesNotionLeadsTest < ActiveSupport::TestCase
+  def setup
+    @admin = AdminUser.create!(email: "admin@sanctuary.computer", password: "passw0rd")
+  end
+
+  def lead_page(props)
+    NotionPage.new(data: { "properties" => props })
+  end
+
+  def discover(pages)
+    NotionPage.stubs(:lead).returns(pages)
+    Stacks::TaskBuilder::Discoveries::NotionLeads.new(admin_fallback: [@admin]).tasks
+  end
+
+  test "an open lead with no budget yields a needs_budget_estimate task owned by the fallback" do
+    tasks = discover([lead_page(
+      "Lead Status" => { "type" => "status", "status" => { "name" => "Active" } },
+      "✨ Lead Received" => { "type" => "date", "date" => { "start" => Date.today.iso8601 } }
+    )])
+
+    task = tasks.find { |t| t.type == :needs_budget_estimate }
+    assert task, "expected a needs_budget_estimate task"
+    assert_equal [@admin], task.owners
+  end
+
+  test "an open lead with a budget yields no needs_budget_estimate task" do
+    tasks = discover([lead_page(
+      "Lead Status" => { "type" => "status", "status" => { "name" => "Active" } },
+      "✨ Lead Received" => { "type" => "date", "date" => { "start" => Date.today.iso8601 } },
+      "Est. Budget High" => { "type" => "number", "number" => 50_000 }
+    )])
+
+    refute tasks.any? { |t| t.type == :needs_budget_estimate }
+  end
+
+  test "a closed lead with no budget yields no needs_budget_estimate task" do
+    tasks = discover([lead_page(
+      "Lead Status" => { "type" => "status", "status" => { "name" => "Lost" } },
+      "✨ Lead Received" => { "type" => "date", "date" => { "start" => Date.today.iso8601 } }
+    )])
+
+    refute tasks.any? { |t| t.type == :needs_budget_estimate }
+  end
+
+  test "needs_budget_estimate has an explicit humanized label" do
+    assert_equal "Notion lead needs an estimated budget",
+      StacksTask::HUMANIZED_TYPES[:needs_budget_estimate]
+  end
+end

--- a/test/models/studio_test.rb
+++ b/test/models/studio_test.rb
@@ -173,6 +173,7 @@ class StudioTest < ActiveSupport::TestCase
     assert data[:average_client_lifetime_value][:extras].key?(:client_count)
     assert data[:average_client_lifetime_value][:extras].key?(:skipped_tracker_count)
     assert data[:average_client_tenure][:extras].key?(:client_count)
+    assert data[:average_client_tenure][:extras].key?(:skipped_tracker_count)
     assert data[:client_revenue_concentration][:extras].key?(:top_client_name)
     assert data[:client_revenue_concentration][:extras].key?(:top_client_amount)
     assert data[:client_revenue_concentration][:extras].key?(:total_revenue)

--- a/test/models/studio_test.rb
+++ b/test/models/studio_test.rb
@@ -131,4 +131,51 @@ class StudioTest < ActiveSupport::TestCase
     assert_includes studio.members_active_on(Date.new(2026, 6, 1)), au
     assert_not_includes studio.members_active_on(Date.new(2025, 1, 1)), au # before membership
   end
+
+  test "key_datapoints_for_period includes all four client KPI keys with correct units" do
+    studio = Studio.create!(name: "garden3d", mini_name: "g3d", accounting_prefix: "")
+
+    pnl = { income: 0.0, cost_of_goods_sold: 0.0, expenses: 0.0, net_operating_income: 0.0 }
+    studio.stubs(:profit_and_loss_for_period).returns(pnl)
+
+    period = Stacks::Period.new("Jan 2025", Date.new(2025, 1, 1), Date.new(2025, 1, 31))
+    cr = Stacks::ClientRevenue.new(studio, [studio], [])
+
+    data = studio.key_datapoints_for_period(
+      period,
+      nil,
+      "cash",
+      [studio],
+      [],
+      {},
+      {},
+      {},
+      {},
+      cr
+    )
+
+    # All four new KPI keys must be present
+    assert data.key?(:average_client_lifetime_value), "expected :average_client_lifetime_value"
+    assert data.key?(:average_client_tenure),         "expected :average_client_tenure"
+    assert data.key?(:client_revenue_concentration),  "expected :client_revenue_concentration"
+    assert data.key?(:forecasted_sales_revenue),      "expected :forecasted_sales_revenue"
+
+    # Units
+    assert_equal :usd,        data[:average_client_lifetime_value][:unit]
+    assert_equal :count,      data[:average_client_tenure][:unit]
+    assert_equal :percentage, data[:client_revenue_concentration][:unit]
+    assert_equal :usd,        data[:forecasted_sales_revenue][:unit]
+
+    # With no trackers and no leads, LTV is 0
+    assert_equal 0, data[:average_client_lifetime_value][:value]
+
+    # extras keys present
+    assert data[:average_client_lifetime_value][:extras].key?(:client_count)
+    assert data[:average_client_tenure][:extras].key?(:client_count)
+    assert data[:client_revenue_concentration][:extras].key?(:top_client_name)
+    assert data[:client_revenue_concentration][:extras].key?(:top_client_amount)
+    assert data[:client_revenue_concentration][:extras].key?(:total_revenue)
+    assert data[:forecasted_sales_revenue][:extras].key?(:open_lead_count)
+    assert data[:forecasted_sales_revenue][:extras].key?(:budgeted_lead_count)
+  end
 end

--- a/test/models/studio_test.rb
+++ b/test/models/studio_test.rb
@@ -171,10 +171,12 @@ class StudioTest < ActiveSupport::TestCase
 
     # extras keys present
     assert data[:average_client_lifetime_value][:extras].key?(:client_count)
+    assert data[:average_client_lifetime_value][:extras].key?(:skipped_tracker_count)
     assert data[:average_client_tenure][:extras].key?(:client_count)
     assert data[:client_revenue_concentration][:extras].key?(:top_client_name)
     assert data[:client_revenue_concentration][:extras].key?(:top_client_amount)
     assert data[:client_revenue_concentration][:extras].key?(:total_revenue)
+    assert data[:client_revenue_concentration][:extras].key?(:skipped_tracker_count)
     assert data[:forecasted_sales_revenue][:extras].key?(:open_lead_count)
     assert data[:forecasted_sales_revenue][:extras].key?(:budgeted_lead_count)
   end


### PR DESCRIPTION
## What

Four new Studio-level OKR datapoints, wired through the existing OKR machinery (targets/tolerance/health, nightly snapshots, dashboard chips, OKR Explorer, `get_studio_health` MCP tool):

| Datapoint | Definition | Unit / operator |
|---|---|---|
| `average_client_lifetime_value` | All-time invoiced revenue per external client (as of period end), averaged | `:usd`, greater_than |
| `average_client_tenure` | Months from first → most recent invoice pass per client, averaged | months (`:count`), greater_than |
| `client_revenue_concentration` | Largest client's share of the studio's invoiced revenue in the period (top client named in extras) | `:percentage`, less_than |
| `forecasted_sales_revenue` | Sum of Est. Budget midpoints across open Notion leads (Active / Not started / On hold) — point-in-time, as of snapshot | `:usd`, greater_than |

Plus a `needs_budget_estimate` TaskBuilder hygiene task: open leads missing `Est. Budget Low/High` route a task to their Account Lead (fallback: admin team), so the pipeline number self-corrects as sales fills in budgets (~11 of 25 open leads budgeted today).

## How

Service objects keep `Studio` thin:
- **`Stacks::ClientRevenue`** — turns InvoiceTracker history (June 2021+) into per-client revenue rows. Countable = linked, non-voided QBO invoice on an external client; value = QBO invoice total, dated by invoice-pass month. garden3d counts full totals; sub-studios take a pro-rata share via blueprint person lines (same attribution as the cost explorer), with `[FP-id]` legacy-tag fallback; malformed lines/trackers are skipped and logged so one bad row can't fail the nightly snapshot.
- **`Stacks::ClientKpiDatapoints`** — builds the four `{value, unit, extras}` entries; `Studio#key_datapoints_for_period` just merges the result.
- **`Stacks::Notion::Lead`** — new `lead_status` / `open?` / `estimated_budget` readers (current status is the source of truth; terminal date stamps are missing on most dead leads).
- Snapshot wiring constructs `ClientRevenue` once, single-threaded, before `Parallel.map` (same pattern as `preloaded_new_biz_leads`); OKR Explorer gets a generic per-period section for the four datapoints.

## Verification

- Full suite: 829 runs, 2198 assertions, 0 failures attributable to this branch (1 pre-existing date-sensitive AdminUserTest flake, identical without these changes).
- Dev-data runner (garden3d): LTV $254,285 across 104 clients; tenure 10.5 months; YTD concentration 12.7% (top client named); pipeline $2.26M from 25 open leads (11 budgeted).
- Built via spec → plan → subagent-driven TDD with per-task reviews, a final whole-branch review (3 Important findings found and fixed: explorer blank-page, snapshot fragility to malformed QBO invoices, missing integration test), and re-review. An adversarial review pass on this PR follows as a comment.

## Rollout

1. Merge; nightly snapshot (or a manual regeneration) populates the datapoints — old snapshots show "—" in the explorer until then.
2. Create the four Okr records in ActiveAdmin (operator `greater_than` except concentration `less_than`) with targets/tolerance/periods/studios.
3. Budget hygiene tasks start appearing for Account Leads on the next TaskBuilder run.

Spec: `docs/superpowers/specs/2026-07-29-studio-okr-client-kpis-design.md` · Plan: `docs/superpowers/plans/2026-07-29-studio-okr-client-kpis.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)