### PR TITLE
fix(okrs): align frozen OKR column with scrolling table via JS

### DIFF
--- a/app/views/admin/studios/_show.html.erb
+++ b/app/views/admin/studios/_show.html.erb
@@ -209,8 +209,66 @@ function update(a, b) {
 </div>
 
 <script>
-  var columnWidth = document.querySelector('#main_content > div:nth-child(15) > div > div.module-body > table.index_table.index.info').clientWidth;
-  document.querySelector('#main_content > div:nth-child(15) > div > div.module-body > table.index_table.index.right-scrolling').style.paddingLeft = `${columnWidth}px`;
+  // Keeps the frozen "info" column (OKR names) aligned with the horizontally
+  // scrolling values table. Both tables transpose their rows into visual
+  // columns via `tr.invert`, so alignment depends on every OKR row being the
+  // same height across both tables. A fixed `min-height` used to hold that
+  // invariant, but longer OKR names now wrap and overflow it, causing rows to
+  // drift and overlap. Instead of a hardcoded height, measure the natural
+  // height of each row and lock every cell in that row to the tallest one.
+  (function () {
+    function syncSplitTable(moduleBody) {
+      var infoTable = moduleBody.querySelector('table.info');
+      var scrollTable = moduleBody.querySelector('table.right-scrolling');
+      if (!infoTable || !scrollTable) return;
+
+      // Horizontal: reserve space for the (absolutely positioned) info column.
+      scrollTable.style.paddingLeft = infoTable.clientWidth + 'px';
+
+      var infoRow = infoTable.querySelector('tbody tr.invert');
+      if (!infoRow) return;
+      var infoCells = Array.prototype.slice.call(infoRow.querySelectorAll('td.col'));
+      var periodCols = Array.prototype.slice
+        .call(scrollTable.querySelectorAll('tbody tr.invert'))
+        .map(function (row) {
+          return Array.prototype.slice.call(row.querySelectorAll('td.col'));
+        });
+
+      // Align the header spacer so both bodies start at the same y-offset.
+      var infoHead = infoTable.querySelector('thead th');
+      var scrollHeadRow = scrollTable.querySelector('thead tr');
+      if (infoHead && scrollHeadRow) {
+        infoHead.style.height = '';
+        infoHead.style.height = scrollHeadRow.offsetHeight + 'px';
+      }
+
+      // Clear previously applied heights so we re-measure natural content size.
+      infoCells.forEach(function (cell) { cell.style.height = ''; });
+      periodCols.forEach(function (cols) {
+        cols.forEach(function (cell) { cell.style.height = ''; });
+      });
+
+      // Lock each OKR row (frozen name + every period's value) to its tallest
+      // cell, so the two tables stay in vertical lockstep however long a name is.
+      infoCells.forEach(function (infoCell, i) {
+        var tallest = infoCell.offsetHeight;
+        periodCols.forEach(function (cols) {
+          if (cols[i]) tallest = Math.max(tallest, cols[i].offsetHeight);
+        });
+        infoCell.style.height = tallest + 'px';
+        periodCols.forEach(function (cols) {
+          if (cols[i]) cols[i].style.height = tallest + 'px';
+        });
+      });
+    }
+
+    function syncAll() {
+      document.querySelectorAll('.dashboard-module .module-body').forEach(syncSplitTable);
+    }
+
+    window.addEventListener('load', syncAll);
+    window.addEventListener('resize', syncAll);
+  })();
 </script>
 
 <div class="title_bar" id="title_bar" style="padding: 80px 0px 20px 0px;">


### PR DESCRIPTION
## What

The Studio OKRs dashboard renders a **frozen "info" column** (OKR names) beside a **horizontally scrolling values table**. Both transpose their rows into visual columns via the `tr.invert` CSS trick, so alignment between the two tables depended entirely on **every row being exactly `min-height: 95px`**.

Now that OKR names are longer, they wrap past 95px in the name column while the value cells stay at 95px — so the two columns drift and rows overlap (see the reported "Lead Growth" / "Workplace Satisfaction" overlap).

## Fix

Replaced the old load-time script — which only set the horizontal offset and relied on a brittle `#main_content > div:nth-child(15)` selector — with one that:

- measures each OKR row's **natural height** across the name cell + every period's value cell, and locks all of them to the **tallest**, so rows grow to fit long names and stay in vertical lockstep;
- selects the tables **by class** instead of `nth-child(15)`;
- syncs the header spacer height so both bodies start at the same y-offset;
- re-runs on `resize`.

The CSS `min-height: 95px` now simply acts as the floor for short rows.

## Testing

- Booted the app locally and confirmed it serves.
- Manual/visual verification on a Studio show page (🤝 Studio OKRs module) recommended — this is inline view JS with no automated harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)