### PR TITLE
fix(okrs): render Average Client Tenure as months, not an unlabeled count

### DIFF
--- a/app/views/admin/dashboard/_dashboard.html.erb
+++ b/app/views/admin/dashboard/_dashboard.html.erb
@@ -48,6 +48,8 @@
                 <% end %>
               <% elsif unit == "display" %>
                 <h2 style="margin: 0;" class="<%= health %>"><%= okr_results.dig("value") %></h2>
+              <% elsif unit == "months" %>
+                <h2 style="margin: 0;" class="<%= health %>"><%= value.round(1) %> months</h2> <p>(<%= target.round(1) %> months±<%= tolerance %>)</p>
               <% else %>
                 <h2 style="margin: 0;" class="<%= health %>"><%= value.round(2) %></h2> <p>(<%= target.round(2) %>±<%= tolerance %>)</p>
               <% end %>

--- a/app/views/admin/okr_explorer/_okr_explorer.html.erb
+++ b/app/views/admin/okr_explorer/_okr_explorer.html.erb
@@ -62,6 +62,8 @@ function update(a, b) {
         number_to_currency(raw_value)
       elsif unit == "percentage"
         "#{raw_value.round(1)}%"
+      elsif unit == "months"
+        "#{raw_value.round(1)} months"
       else
         raw_value.round(1).to_s
       end

--- a/app/views/admin/periodic_reports/_okr_chips.html.erb
+++ b/app/views/admin/periodic_reports/_okr_chips.html.erb
@@ -24,6 +24,8 @@
                 <h2 style="margin: 0;" class="<%= health %>"><%= value.round(2) %>%</h2> <p>(<%= target.round(2) %>%±<%= tolerance %>)</p>
               <% elsif unit == "display" %>
                 <h2 style="margin: 0;" class="<%= health %>"><%= okr_results.dig("value") %></h2>
+              <% elsif unit == "months" %>
+                <h2 style="margin: 0;" class="<%= health %>"><%= value.round(1) %> months</h2> <p>(<%= target.round(1) %> months±<%= tolerance %>)</p>
               <% else %>
                 <h2 style="margin: 0;" class="<%= health %>"><%= value.round(2) %></h2> <p>(<%= target.round(2) %>±<%= tolerance %>)</p>
               <% end %>

--- a/app/views/admin/studios/_show.html.erb
+++ b/app/views/admin/studios/_show.html.erb
@@ -189,6 +189,8 @@ function update(a, b) {
                             <strong style="font-size: 15px"><%= okr_results.dig("value") %></strong>
                           <% elsif unit == "days" %>
                             <strong style="font-size: 15px"><%= value.round(2) %> days</strong> (target: <%= target.round(2) %>)
+                          <% elsif unit == "months" %>
+                            <strong style="font-size: 15px"><%= value.round(1) %> months</strong> (target: <%= target.round(1) %> months)
                           <% else %>
                             <strong style="font-size: 15px"><%= value.round(2) %></strong> (target: <%= target.round(2) %>)
                           <% end %>

--- a/lib/stacks/client_kpi_datapoints.rb
+++ b/lib/stacks/client_kpi_datapoints.rb
@@ -21,7 +21,7 @@ class Stacks::ClientKpiDatapoints
       },
       average_client_tenure: {
         value: @client_revenue.average_tenure_months_asof(@period.ends_at),
-        unit: :count,
+        unit: :months,
         extras: { client_count: client_count, skipped_tracker_count: @client_revenue.skipped_tracker_count }
       },
       client_revenue_concentration: {

--- a/test/lib/stacks/client_kpi_datapoints_test.rb
+++ b/test/lib/stacks/client_kpi_datapoints_test.rb
@@ -49,7 +49,7 @@ class StacksClientKpiDatapointsTest < ActiveSupport::TestCase
     assert_equal 0, data[:average_client_lifetime_value][:extras][:skipped_tracker_count]
 
     assert_equal 0.0, data[:average_client_tenure][:value]
-    assert_equal :count, data[:average_client_tenure][:unit]
+    assert_equal :months, data[:average_client_tenure][:unit]
     assert_equal 0, data[:average_client_tenure][:extras][:skipped_tracker_count]
 
     assert_equal 100.0, data[:client_revenue_concentration][:value]

--- a/test/models/studio_test.rb
+++ b/test/models/studio_test.rb
@@ -162,7 +162,7 @@ class StudioTest < ActiveSupport::TestCase
 
     # Units
     assert_equal :usd,        data[:average_client_lifetime_value][:unit]
-    assert_equal :count,      data[:average_client_tenure][:unit]
+    assert_equal :months,     data[:average_client_tenure][:unit]
     assert_equal :percentage, data[:client_revenue_concentration][:unit]
     assert_equal :usd,        data[:forecasted_sales_revenue][:unit]
 


### PR DESCRIPTION
## What

`average_client_tenure` is computed by `average_tenure_months_asof` — the average number of **months** between each client's first and last invoiced month (`lib/stacks/client_revenue.rb`). But the datapoint declared `unit: :count`.

None of the OKR views have a `count` branch, so it fell through to the default renderer and displayed as a **bare number** (e.g. `18.3 (target: 24)`) with no unit label — leaving "months" implicit and easy to misread as a raw count.

## Fix

- Introduce a `:months` unit and set `average_client_tenure` to it (`lib/stacks/client_kpi_datapoints.rb`).
- Add an explicit `months` render branch to **all four** OKR render sites so it shows e.g. `18.3 months (target: 24 months)`:
  - `app/views/admin/studios/_show.html.erb`
  - `app/views/admin/dashboard/_dashboard.html.erb`
  - `app/views/admin/periodic_reports/_okr_chips.html.erb`
  - `app/views/admin/okr_explorer/_okr_explorer.html.erb`
- Update the unit assertions in the two affected tests.

## Testing

```
bundle exec rails test test/lib/stacks/client_kpi_datapoints_test.rb test/models/studio_test.rb
# 7 runs, 46 assertions, 0 failures
```

## Note

Branched off `main` (which already has the client-KPI datapoints), separate from the OKR table-alignment PR (#155).

🤖 Generated with [Claude Code](https://claude.com/claude-code)