### PR TITLE
feat(recurring-assignments): Stacks-owned recurring Forecast assignments

### DIFF
--- a/app/admin/recurring_assignments.rb
+++ b/app/admin/recurring_assignments.rb
@@ -1,7 +1,7 @@
 ActiveAdmin.register RecurringAssignment do
   menu label: "Recurring Assignments", parent: "Team"
   config.filters = false
-  actions :index, :new, :create, :edit, :update, :destroy
+  actions :index, :new, :create, :edit, :update, :destroy, :show
 
   WEEKDAY_CHOICES = [%w[Mon 1], %w[Tue 2], %w[Wed 3], %w[Thu 4], %w[Fri 5], %w[Sat 6], %w[Sun 0]].freeze
 
@@ -57,8 +57,8 @@ ActiveAdmin.register RecurringAssignment do
 
   show do
     attributes_table do
-      row(:person) { |r| r.forecast_person&.email }
-      row(:project) { |r| r.forecast_project&.name }
+      row(:person) { |r| r.forecast_person&.email || "Person ##{r.forecast_person_id}" }
+      row(:project) { |r| r.forecast_project&.name || "Project ##{r.forecast_project_id}" }
       row(:hours_per_day) { |r| r.allocation_in_hours }
       row(:weekdays) { |r| r.weekdays.sort.map { |d| Date::ABBR_DAYNAMES[d] }.join(", ") }
       row :starts_on

--- a/app/admin/recurring_assignments.rb
+++ b/app/admin/recurring_assignments.rb
@@ -1,0 +1,103 @@
+ActiveAdmin.register RecurringAssignment do
+  menu label: "Recurring Assignments", parent: "Team"
+  config.filters = false
+  actions :index, :new, :create, :edit, :update, :destroy
+
+  WEEKDAY_CHOICES = [%w[Mon 1], %w[Tue 2], %w[Wed 3], %w[Thu 4], %w[Fri 5], %w[Sat 6], %w[Sun 0]].freeze
+
+  permit_params :forecast_person_id, :forecast_project_id, :allocation_in_hours,
+    :active_on_days_off, :notes, :starts_on, :ends_on, :paused_at, weekdays: []
+
+  controller do
+    def scoped_collection
+      super.includes(:forecast_person, :forecast_project, :recurring_assignment_occurrences)
+    end
+  end
+
+  action_item :materialize_now, only: :edit do
+    link_to "Materialize Now",
+      materialize_now_admin_recurring_assignment_path(resource),
+      method: :post,
+      data: { confirm: "Create/refresh Forecast assignments for this rule now?" }
+  end
+
+  member_action :materialize_now, method: :post do
+    resource.materialize!
+    redirect_to edit_admin_recurring_assignment_path(resource), notice: "Materialized."
+  rescue => e
+    redirect_to edit_admin_recurring_assignment_path(resource), alert: e.message
+  end
+
+  action_item :toggle_pause, only: :edit do
+    link_to(resource.paused? ? "Resume" : "Pause",
+      toggle_pause_admin_recurring_assignment_path(resource), method: :post)
+  end
+
+  member_action :toggle_pause, method: :post do
+    resource.update!(paused_at: resource.paused? ? nil : Time.current)
+    redirect_to edit_admin_recurring_assignment_path(resource),
+      notice: resource.paused? ? "Paused." : "Resumed."
+  end
+
+  index download_links: false do
+    column(:person) { |r| r.forecast_person&.email || "Person ##{r.forecast_person_id}" }
+    column(:project) { |r| r.forecast_project&.name || "Project ##{r.forecast_project_id}" }
+    column(:hours_per_day) { |r| r.allocation_in_hours }
+    column(:weekdays) { |r| r.weekdays.sort.map { |d| Date::ABBR_DAYNAMES[d] }.join(", ") }
+    column :starts_on
+    column :ends_on
+    column(:occurrences) do |r|
+      m = r.recurring_assignment_occurrences.count { |o| o.status == "materialized" }
+      d = r.recurring_assignment_occurrences.count { |o| o.status == "deleted" }
+      "#{m} live / #{d} deleted"
+    end
+    column(:status) { |r| r.paused? ? status_tag("Paused") : status_tag("Active") }
+    actions
+  end
+
+  show do
+    attributes_table do
+      row(:person) { |r| r.forecast_person&.email }
+      row(:project) { |r| r.forecast_project&.name }
+      row(:hours_per_day) { |r| r.allocation_in_hours }
+      row(:weekdays) { |r| r.weekdays.sort.map { |d| Date::ABBR_DAYNAMES[d] }.join(", ") }
+      row :starts_on
+      row :ends_on
+      row :active_on_days_off
+      row :notes
+      row(:status) { |r| r.paused? ? "Paused" : "Active" }
+    end
+    panel "Occurrences" do
+      table_for resource.recurring_assignment_occurrences.order(occurs_on: :desc) do
+        column :occurs_on
+        column :status
+        column(:forecast_assignment) do |o|
+          if o.forecast_assignment_id
+            link_to o.forecast_assignment_id,
+              "https://forecastapp.com/#{Stacks::Utils.config[:forecast][:account_id]}/schedule/projects/#{o.recurring_assignment.forecast_project_id}/assignments/#{o.forecast_assignment_id}/edit",
+              target: "_blank"
+          end
+        end
+      end
+    end
+  end
+
+  form do |f|
+    f.semantic_errors
+    f.inputs do
+      f.input :forecast_person_id, as: :select,
+        collection: ForecastPerson.active.order(:email).map { |p| [p.email, p.forecast_id] },
+        prompt: "Choose a person…"
+      f.input :forecast_project_id, as: :select,
+        collection: ForecastProject.active.map { |p| [p.name, p.forecast_id] }.sort_by(&:first),
+        prompt: "Choose a project…"
+      f.input :allocation_in_hours, label: "Hours per day", hint: "Stored as seconds/day for Forecast."
+      f.input :weekdays, as: :check_boxes, collection: WEEKDAY_CHOICES
+      f.input :starts_on, as: :datepicker
+      f.input :ends_on, as: :datepicker, hint: "Leave blank for open-ended (materializes 26 weeks ahead, extending each day)."
+      f.input :active_on_days_off
+      f.input :notes
+    end
+    f.actions
+  end
+end

--- a/app/admin/recurring_assignments.rb
+++ b/app/admin/recurring_assignments.rb
@@ -94,7 +94,7 @@ ActiveAdmin.register RecurringAssignment do
       f.input :allocation_in_hours, label: "Hours per day", hint: "Stored as seconds/day for Forecast."
       f.input :weekdays, as: :check_boxes, collection: WEEKDAY_CHOICES
       f.input :starts_on, as: :datepicker
-      f.input :ends_on, as: :datepicker, hint: "Leave blank for open-ended (materializes 26 weeks ahead, extending each day)."
+      f.input :ends_on, as: :datepicker, hint: "Leave blank for open-ended (never ends). Assignments are only ever created up to today — never in advance; each day's occurrence materializes on/after its date."
       f.input :active_on_days_off
       f.input :notes
     end

--- a/app/models/recurring_assignment.rb
+++ b/app/models/recurring_assignment.rb
@@ -5,6 +5,8 @@ class RecurringAssignment < ApplicationRecord
     foreign_key: "forecast_person_id", primary_key: "forecast_id", optional: true
   belongs_to :forecast_project, class_name: "ForecastProject",
     foreign_key: "forecast_project_id", primary_key: "forecast_id", optional: true
+  before_destroy :remove_future_forecast_assignments!
+
   has_many :recurring_assignment_occurrences, dependent: :destroy
 
   validates :forecast_person_id, presence: true
@@ -43,6 +45,16 @@ class RecurringAssignment < ApplicationRecord
     last = [ends_on, Date.today + HORIZON].compact.min
     return [] if starts_on > last
     (starts_on..last).select { |d| weekdays.include?(d.wday) }
+  end
+
+  # Deletes only FUTURE materialized occurrences from Forecast on rule teardown;
+  # past occurrences are left for historical accuracy, tombstoned ones are already gone.
+  def remove_future_forecast_assignments!(forecast_client = Stacks::Forecast.new)
+    recurring_assignment_occurrences
+      .materialized
+      .where.not(forecast_assignment_id: nil)
+      .where("occurs_on >= ?", Date.today)
+      .find_each { |occ| forecast_client.delete_assignment(occ.forecast_assignment_id) }
   end
 
   private

--- a/app/models/recurring_assignment.rb
+++ b/app/models/recurring_assignment.rb
@@ -3,8 +3,11 @@ class RecurringAssignment < ApplicationRecord
     foreign_key: "forecast_person_id", primary_key: "forecast_id", optional: true
   belongs_to :forecast_project, class_name: "ForecastProject",
     foreign_key: "forecast_project_id", primary_key: "forecast_id", optional: true
-  before_destroy :remove_future_forecast_assignments!
 
+  # Destroying a rule stops future materialization and drops its occurrence tracking
+  # rows, but deliberately leaves the already-created Forecast assignments intact —
+  # under retrospect-only materialization every one is a record of allocation that
+  # already happened, so it's historical, not ours to erase.
   has_many :recurring_assignment_occurrences, dependent: :destroy
 
   validates :forecast_person_id, presence: true
@@ -48,16 +51,6 @@ class RecurringAssignment < ApplicationRecord
     last = [ends_on, Date.today].compact.min
     return [] if starts_on.nil? || starts_on > last
     (starts_on..last).select { |d| weekdays.include?(d.wday) }
-  end
-
-  # Deletes only FUTURE materialized occurrences from Forecast on rule teardown;
-  # past occurrences are left for historical accuracy, tombstoned ones are already gone.
-  def remove_future_forecast_assignments!(forecast_client = Stacks::Forecast.new)
-    recurring_assignment_occurrences
-      .materialized
-      .where.not(forecast_assignment_id: nil)
-      .where("occurs_on >= ?", Date.today)
-      .find_each { |occ| forecast_client.delete_assignment(occ.forecast_assignment_id) }
   end
 
   private

--- a/app/models/recurring_assignment.rb
+++ b/app/models/recurring_assignment.rb
@@ -28,6 +28,23 @@ class RecurringAssignment < ApplicationRecord
     self.allocation = (hours.to_f * 3600).round
   end
 
+  # Idempotent. Pass 1 tombstones occurrences deleted in Forecast (absent from the
+  # freshly-synced ForecastAssignment mirror); Pass 2 creates any missing occurrence.
+  # MUST run after Stacks::Forecast#sync_all! so the mirror is authoritative — see the
+  # daily_tasks wiring. Detection runs BEFORE creation so this-run creations are never
+  # mistaken for deletions.
+  def materialize!(forecast_client: nil)
+    return if paused?
+    detect_deletions!
+    create_missing_occurrences!(forecast_client || Stacks::Forecast.new)
+  end
+
+  def expected_occurrence_dates
+    last = [ends_on, Date.today + HORIZON].compact.min
+    return [] if starts_on > last
+    (starts_on..last).select { |d| weekdays.include?(d.wday) }
+  end
+
   private
 
   def weekdays_valid
@@ -41,5 +58,37 @@ class RecurringAssignment < ApplicationRecord
   def ends_on_not_before_starts_on
     return if ends_on.blank? || starts_on.blank?
     errors.add(:ends_on, "cannot be before starts_on") if ends_on < starts_on
+  end
+
+  def detect_deletions!
+    recurring_assignment_occurrences.materialized.where.not(forecast_assignment_id: nil).find_each do |occ|
+      next if ForecastAssignment.exists?(forecast_id: occ.forecast_assignment_id)
+      occ.update!(status: "deleted")
+    end
+  end
+
+  def create_missing_occurrences!(forecast_client)
+    existing = recurring_assignment_occurrences.pluck(:occurs_on).to_set
+    expected_occurrence_dates.each do |date|
+      next if existing.include?(date)
+      begin
+        assignment = forecast_client.create_assignment(
+          project_id: forecast_project_id,
+          person_id: forecast_person_id,
+          start_date: date,
+          end_date: date,
+          allocation: allocation,
+          notes: notes,
+          active_on_days_off: active_on_days_off,
+        )
+        recurring_assignment_occurrences.create!(
+          occurs_on: date,
+          status: "materialized",
+          forecast_assignment_id: assignment["id"],
+        )
+      rescue => e
+        Sentry.capture_exception(e)
+      end
+    end
   end
 end

--- a/app/models/recurring_assignment.rb
+++ b/app/models/recurring_assignment.rb
@@ -73,10 +73,22 @@ class RecurringAssignment < ApplicationRecord
   end
 
   def detect_deletions!
-    recurring_assignment_occurrences.materialized.where.not(forecast_assignment_id: nil).find_each do |occ|
-      next if ForecastAssignment.exists?(forecast_id: occ.forecast_assignment_id)
-      occ.update!(status: "deleted")
-    end
+    # Only occurrences the Forecast sync actually covers are eligible for
+    # deletion-detection. sync_all_assignments! walks month-by-month only up to
+    # the CURRENT month, so future-dated assignments are never in the mirror —
+    # absence there means "not yet synced," NOT "deleted in the UI." Bounding to
+    # end-of-current-month prevents falsely tombstoning every future occurrence on
+    # the next daily run. (Pass 2 never recreates a date that already has an
+    # occurrence row, so a genuinely deleted future assignment is still never
+    # recreated; it just isn't labeled deleted until its month enters the sync window.)
+    recurring_assignment_occurrences
+      .materialized
+      .where.not(forecast_assignment_id: nil)
+      .where("occurs_on <= ?", Date.today.end_of_month)
+      .find_each do |occ|
+        next if ForecastAssignment.exists?(forecast_id: occ.forecast_assignment_id)
+        occ.update!(status: "deleted")
+      end
   end
 
   def create_missing_occurrences!(forecast_client)

--- a/app/models/recurring_assignment.rb
+++ b/app/models/recurring_assignment.rb
@@ -1,0 +1,45 @@
+class RecurringAssignment < ApplicationRecord
+  HORIZON = 26.weeks
+
+  belongs_to :forecast_person, class_name: "ForecastPerson",
+    foreign_key: "forecast_person_id", primary_key: "forecast_id", optional: true
+  belongs_to :forecast_project, class_name: "ForecastProject",
+    foreign_key: "forecast_project_id", primary_key: "forecast_id", optional: true
+  has_many :recurring_assignment_occurrences, dependent: :destroy
+
+  validates :forecast_person_id, presence: true
+  validates :forecast_project_id, presence: true
+  validates :allocation, presence: true, numericality: { greater_than: 0, only_integer: true }
+  validates :starts_on, presence: true
+  validate :weekdays_valid
+  validate :ends_on_not_before_starts_on
+
+  scope :active, -> { where(paused_at: nil) }
+
+  def paused?
+    paused_at.present?
+  end
+
+  def allocation_in_hours
+    allocation && allocation / 3600.0
+  end
+
+  def allocation_in_hours=(hours)
+    self.allocation = (hours.to_f * 3600).round
+  end
+
+  private
+
+  def weekdays_valid
+    if weekdays.blank?
+      errors.add(:weekdays, "must include at least one day")
+    elsif weekdays.any? { |d| !(0..6).cover?(d) }
+      errors.add(:weekdays, "must be integers 0 (Sun) through 6 (Sat)")
+    end
+  end
+
+  def ends_on_not_before_starts_on
+    return if ends_on.blank? || starts_on.blank?
+    errors.add(:ends_on, "cannot be before starts_on") if ends_on < starts_on
+  end
+end

--- a/app/models/recurring_assignment.rb
+++ b/app/models/recurring_assignment.rb
@@ -1,6 +1,4 @@
 class RecurringAssignment < ApplicationRecord
-  HORIZON = 26.weeks
-
   belongs_to :forecast_person, class_name: "ForecastPerson",
     foreign_key: "forecast_person_id", primary_key: "forecast_id", optional: true
   belongs_to :forecast_project, class_name: "ForecastProject",
@@ -41,9 +39,14 @@ class RecurringAssignment < ApplicationRecord
     create_missing_occurrences!(forecast_client || Stacks::Forecast.new)
   end
 
+  # Occurrences are only ever created on/before today — never in advance. A rule with
+  # a blank ends_on "never ends"; it simply materializes each day's occurrence once
+  # that day arrives. Bounding creation to today (rather than a future horizon) also
+  # guarantees every occurrence falls inside the Forecast sync window, which is what
+  # keeps deletion-detection safe (see detect_deletions!).
   def expected_occurrence_dates
-    last = [ends_on, Date.today + HORIZON].compact.min
-    return [] if starts_on > last
+    last = [ends_on, Date.today].compact.min
+    return [] if starts_on.nil? || starts_on > last
     (starts_on..last).select { |d| weekdays.include?(d.wday) }
   end
 
@@ -73,14 +76,17 @@ class RecurringAssignment < ApplicationRecord
   end
 
   def detect_deletions!
-    # Only occurrences the Forecast sync actually covers are eligible for
-    # deletion-detection. sync_all_assignments! walks month-by-month only up to
-    # the CURRENT month, so future-dated assignments are never in the mirror —
-    # absence there means "not yet synced," NOT "deleted in the UI." Bounding to
-    # end-of-current-month prevents falsely tombstoning every future occurrence on
-    # the next daily run. (Pass 2 never recreates a date that already has an
-    # occurrence row, so a genuinely deleted future assignment is still never
-    # recreated; it just isn't labeled deleted until its month enters the sync window.)
+    # Tombstone occurrences whose Forecast assignment vanished from the freshly-synced
+    # mirror (i.e. deleted in the Forecast UI). Two independent guards keep this safe:
+    #   1. materialize! creates occurrences only on/before today (never in advance), and
+    #   2. we only judge occurrences the sync actually covers — sync_all_assignments!
+    #      walks month-by-month up to the CURRENT month, so we bound detection to
+    #      end-of-current-month.
+    # Together these guarantee an in-window occurrence absent from the mirror was
+    # deleted, not merely "not yet synced." Detection runs BEFORE creation so this
+    # run's fresh rows (created after this pass) are never judged before their next
+    # sync. A false tombstone is permanent — Pass 2 never recreates a date that
+    # already has a row — so the bound is deliberately conservative defense-in-depth.
     recurring_assignment_occurrences
       .materialized
       .where.not(forecast_assignment_id: nil)

--- a/app/models/recurring_assignment_occurrence.rb
+++ b/app/models/recurring_assignment_occurrence.rb
@@ -1,0 +1,11 @@
+class RecurringAssignmentOccurrence < ApplicationRecord
+  STATUSES = %w[materialized deleted].freeze
+
+  belongs_to :recurring_assignment
+
+  validates :occurs_on, presence: true
+  validates :status, inclusion: { in: STATUSES }
+
+  scope :materialized, -> { where(status: "materialized") }
+  scope :deleted, -> { where(status: "deleted") }
+end

--- a/db/migrate/20260730000001_create_recurring_assignments.rb
+++ b/db/migrate/20260730000001_create_recurring_assignments.rb
@@ -1,0 +1,19 @@
+class CreateRecurringAssignments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :recurring_assignments do |t|
+      t.bigint :forecast_person_id, null: false
+      t.bigint :forecast_project_id, null: false
+      t.integer :allocation, null: false
+      t.boolean :active_on_days_off, null: false, default: false
+      t.text :notes, null: false, default: ""
+      t.integer :weekdays, array: true, null: false, default: [1, 2, 3, 4, 5]
+      t.date :starts_on, null: false
+      t.date :ends_on
+      t.datetime :paused_at
+      t.timestamps
+    end
+    add_index :recurring_assignments, :forecast_person_id
+    add_index :recurring_assignments, :forecast_project_id
+    add_index :recurring_assignments, :paused_at
+  end
+end

--- a/db/migrate/20260730000002_create_recurring_assignment_occurrences.rb
+++ b/db/migrate/20260730000002_create_recurring_assignment_occurrences.rb
@@ -1,0 +1,18 @@
+class CreateRecurringAssignmentOccurrences < ActiveRecord::Migration[6.1]
+  def change
+    create_table :recurring_assignment_occurrences do |t|
+      t.references :recurring_assignment, null: false, foreign_key: true,
+        index: { name: "idx_recurring_occurrences_on_recurring_assignment_id" }
+      t.date :occurs_on, null: false
+      t.bigint :forecast_assignment_id
+      t.string :status, null: false, default: "materialized"
+      t.timestamps
+    end
+    add_index :recurring_assignment_occurrences,
+      [:recurring_assignment_id, :occurs_on],
+      unique: true,
+      name: "idx_recurring_occurrences_on_rule_and_date"
+    add_index :recurring_assignment_occurrences, :forecast_assignment_id,
+      name: "idx_recurring_occurrences_on_forecast_assignment_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_07_29_000001) do
+ActiveRecord::Schema.define(version: 2026_07_30_000002) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -1114,6 +1114,35 @@ ActiveRecord::Schema.define(version: 2026_07_29_000001) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "recurring_assignment_occurrences", force: :cascade do |t|
+    t.bigint "recurring_assignment_id", null: false
+    t.date "occurs_on", null: false
+    t.bigint "forecast_assignment_id"
+    t.string "status", default: "materialized", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["forecast_assignment_id"], name: "idx_recurring_occurrences_on_forecast_assignment_id"
+    t.index ["recurring_assignment_id", "occurs_on"], name: "idx_recurring_occurrences_on_rule_and_date", unique: true
+    t.index ["recurring_assignment_id"], name: "idx_recurring_occurrences_on_recurring_assignment_id"
+  end
+
+  create_table "recurring_assignments", force: :cascade do |t|
+    t.bigint "forecast_person_id", null: false
+    t.bigint "forecast_project_id", null: false
+    t.integer "allocation", null: false
+    t.boolean "active_on_days_off", default: false, null: false
+    t.text "notes", default: "", null: false
+    t.integer "weekdays", default: [1, 2, 3, 4, 5], null: false, array: true
+    t.date "starts_on", null: false
+    t.date "ends_on"
+    t.datetime "paused_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["forecast_person_id"], name: "index_recurring_assignments_on_forecast_person_id"
+    t.index ["forecast_project_id"], name: "index_recurring_assignments_on_forecast_project_id"
+    t.index ["paused_at"], name: "index_recurring_assignments_on_paused_at"
+  end
+
   create_table "recurring_charges", force: :cascade do |t|
     t.bigint "forecast_client_id", null: false
     t.decimal "quantity", default: "0.0", null: false
@@ -1476,6 +1505,7 @@ ActiveRecord::Schema.define(version: 2026_07_29_000001) do
   add_foreign_key "qbo_profit_and_loss_reports", "qbo_accounts"
   add_foreign_key "qbo_tokens", "qbo_accounts"
   add_foreign_key "qbo_vendors", "qbo_accounts"
+  add_foreign_key "recurring_assignment_occurrences", "recurring_assignments"
   add_foreign_key "recurring_ledger_adjustments", "ledgers"
   add_foreign_key "reimbursements", "admin_users", column: "accepted_by_id"
   add_foreign_key "reimbursements", "ledgers"

--- a/docs/superpowers/plans/2026-07-30-recurring-forecast-assignments.md
+++ b/docs/superpowers/plans/2026-07-30-recurring-forecast-assignments.md
@@ -417,7 +417,6 @@ class RecurringAssignmentMaterializeTest < ActiveSupport::TestCase
   test "creates one Forecast assignment per expected weekday and records occurrences" do
     ra = rule # Mondays 2026-08-03,10,17,24 => 4 occurrences
     client = build_client
-    seq = sequence("ids")
     client.expects(:create_assignment).times(4).returns(
       { "id" => 1 }, { "id" => 2 }, { "id" => 3 }, { "id" => 4 }
     )

--- a/docs/superpowers/plans/2026-07-30-recurring-forecast-assignments.md
+++ b/docs/superpowers/plans/2026-07-30-recurring-forecast-assignments.md
@@ -1,0 +1,831 @@
+# Recurring Forecast Assignments Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let Stacks own a "recurring assignment" rule and materialize each occurrence as a concrete Forecast assignment via the `api.forecastapp.com` write API, respecting manual deletions (never recreate a deleted assignment).
+
+**Architecture:** Two local models — `RecurringAssignment` (the rule) and `RecurringAssignmentOccurrence` (one row per occurrence date, tracking the materialized `forecast_assignment_id` + a `materialized`/`deleted` status). `RecurringAssignment#materialize!` runs two ordered passes (deletion-detection, then creation) and is invoked inline right after `Stacks::Forecast#sync_all!` in the daily cron, so the local `ForecastAssignment` mirror is authoritative and "absent from mirror" unambiguously means "deleted in Forecast." An ActiveAdmin resource provides CRUD + "materialize now".
+
+**Tech Stack:** Rails 6.1, Postgres (jsonb, integer arrays), HTTParty (Forecast client), ActiveAdmin, Minitest + Mocha (HTTP stubbed at the class-method level, no WebMock/VCR).
+
+## Global Constraints
+
+- Rails `~> 6.1`; migrations subclass `ActiveRecord::Migration[6.1]`.
+- Forecast mirror models (`ForecastPerson`, `ForecastProject`, `ForecastAssignment`) use `self.primary_key = "forecast_id"`; new models reference them by `forecast_id` via `belongs_to ... primary_key: "forecast_id"`, `optional: true` (mirror rows can be pruned — don't couple validity to their presence).
+- Allocation is stored in **seconds/day** (Forecast native). Admin enters hours.
+- Forecast writes wrap the body as `{ assignment: { ... } }`, `Content-Type: application/json`.
+- Tests stub Forecast HTTP with `Stacks::Forecast.expects(:post)/:delete` (per `test/lib/stacks/runn_test.rb`); build the client with `Stacks::Forecast.allocate` + `instance_variable_set(:@headers, {...})` to skip config-dependent `initialize` (per `test/lib/stacks/forecast_test.rb`).
+- Commit after every task. End commit messages with the Co-Authored-By trailer.
+
+---
+
+### Task 1: Forecast write methods (`create_assignment`, `delete_assignment`)
+
+**Files:**
+- Modify: `lib/stacks/forecast.rb`
+- Test: `test/lib/stacks/forecast_test.rb`
+
+**Interfaces:**
+- Produces:
+  - `Stacks::Forecast#create_assignment(project_id:, person_id:, start_date:, end_date:, allocation:, notes: "", active_on_days_off: false)` → returns the parsed `"assignment"` Hash (includes `"id"`). Raises on non-2xx.
+  - `Stacks::Forecast#delete_assignment(forecast_id)` → returns `true`; treats HTTP 404 as already-deleted (idempotent). Raises on other non-2xx.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `test/lib/stacks/forecast_test.rb`:
+
+```ruby
+def build_forecast_client
+  fc = Stacks::Forecast.allocate
+  fc.instance_variable_set(:@headers, { "Authorization": "Bearer test" })
+  fc
+end
+
+test "create_assignment POSTs the assignment envelope and returns the assignment hash" do
+  fc = build_forecast_client
+  response = mock("response")
+  response.stubs(:success?).returns(true)
+  response.stubs(:parsed_response).returns({ "assignment" => { "id" => 42, "allocation" => 900 } })
+
+  posted = {}
+  Stacks::Forecast.expects(:post).once.with do |path, opts|
+    posted[:path] = path
+    posted[:body] = JSON.parse(opts[:body])
+    true
+  end.returns(response)
+
+  result = fc.create_assignment(
+    project_id: 5039734, person_id: 324711,
+    start_date: Date.new(2035, 6, 1), end_date: Date.new(2035, 6, 1),
+    allocation: 900, notes: "hi", active_on_days_off: false,
+  )
+
+  assert_equal 42, result["id"]
+  assert_equal "/assignments", posted[:path]
+  assert_equal 5039734, posted[:body]["assignment"]["project_id"]
+  assert_equal "2035-06-01", posted[:body]["assignment"]["start_date"]
+  assert_equal 900, posted[:body]["assignment"]["allocation"]
+end
+
+test "create_assignment raises on failure" do
+  fc = build_forecast_client
+  response = mock("response")
+  response.stubs(:success?).returns(false)
+  response.stubs(:code).returns(422)
+  response.stubs(:body).returns("nope")
+  Stacks::Forecast.stubs(:post).returns(response)
+
+  assert_raises(RuntimeError) do
+    fc.create_assignment(project_id: 1, person_id: 2, start_date: Date.today, end_date: Date.today, allocation: 900)
+  end
+end
+
+test "delete_assignment DELETEs by id and treats 404 as already-gone" do
+  fc = build_forecast_client
+
+  ok = mock("ok"); ok.stubs(:success?).returns(true)
+  Stacks::Forecast.expects(:delete).once.with("/assignments/99", has_entry(:headers, instance_of(Hash))).returns(ok)
+  assert_equal true, fc.delete_assignment(99)
+
+  gone = mock("gone"); gone.stubs(:success?).returns(false); gone.stubs(:code).returns(404)
+  Stacks::Forecast.expects(:delete).once.returns(gone)
+  assert_equal true, fc.delete_assignment(1234)
+end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bin/rails test test/lib/stacks/forecast_test.rb`
+Expected: FAIL — `NoMethodError: undefined method 'create_assignment'`.
+
+- [ ] **Step 3: Implement the write methods**
+
+In `lib/stacks/forecast.rb`, add these public methods (after `roles`, before `private`):
+
+```ruby
+def create_assignment(project_id:, person_id:, start_date:, end_date:, allocation:, notes: "", active_on_days_off: false)
+  body = { assignment: {
+    project_id: project_id,
+    person_id: person_id,
+    start_date: start_date.to_s,
+    end_date: end_date.to_s,
+    allocation: allocation,
+    notes: notes.to_s,
+    active_on_days_off: active_on_days_off,
+  } }
+  response = self.class.post("/assignments", headers: write_headers, body: JSON.dump(body))
+  raise "Forecast create_assignment failed: #{response.code} #{response.body}" unless response.success?
+  response.parsed_response["assignment"]
+end
+
+def delete_assignment(forecast_id)
+  response = self.class.delete("/assignments/#{forecast_id}", headers: write_headers)
+  return true if response.success?
+  return true if response.code == 404 # already gone — idempotent
+  raise "Forecast delete_assignment failed: #{response.code} #{response.body}"
+end
+```
+
+And in the `private` section add:
+
+```ruby
+def write_headers
+  @headers.merge("Content-Type": "application/json")
+end
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bin/rails test test/lib/stacks/forecast_test.rb`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/stacks/forecast.rb test/lib/stacks/forecast_test.rb
+git commit -m "feat(forecast): add create_assignment/delete_assignment write methods"
+```
+
+---
+
+### Task 2: Migrations + models
+
+**Files:**
+- Create: `db/migrate/20260730000001_create_recurring_assignments.rb`
+- Create: `db/migrate/20260730000002_create_recurring_assignment_occurrences.rb`
+- Create: `app/models/recurring_assignment.rb`
+- Create: `app/models/recurring_assignment_occurrence.rb`
+- Test: `test/models/recurring_assignment_test.rb`
+- Test: `test/models/recurring_assignment_occurrence_test.rb`
+
+**Interfaces:**
+- Produces:
+  - `RecurringAssignment` columns: `forecast_person_id:bigint`, `forecast_project_id:bigint`, `allocation:integer` (sec/day), `active_on_days_off:boolean`, `notes:text`, `weekdays:integer[]` (0=Sun..6=Sat), `starts_on:date`, `ends_on:date?`, `paused_at:datetime?`.
+  - `RecurringAssignment.active` scope (`where(paused_at: nil)`), `#paused?`, `HORIZON = 26.weeks`, `allocation_in_hours` / `allocation_in_hours=` accessors.
+  - `RecurringAssignmentOccurrence` columns: `recurring_assignment_id`, `occurs_on:date`, `forecast_assignment_id:bigint?`, `status:string` (`materialized`|`deleted`). Scopes `.materialized`, `.deleted`. `STATUSES` constant.
+
+- [ ] **Step 1: Write the migrations**
+
+`db/migrate/20260730000001_create_recurring_assignments.rb`:
+
+```ruby
+class CreateRecurringAssignments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :recurring_assignments do |t|
+      t.bigint :forecast_person_id, null: false
+      t.bigint :forecast_project_id, null: false
+      t.integer :allocation, null: false
+      t.boolean :active_on_days_off, null: false, default: false
+      t.text :notes, null: false, default: ""
+      t.integer :weekdays, array: true, null: false, default: [1, 2, 3, 4, 5]
+      t.date :starts_on, null: false
+      t.date :ends_on
+      t.datetime :paused_at
+      t.timestamps
+    end
+    add_index :recurring_assignments, :forecast_person_id
+    add_index :recurring_assignments, :forecast_project_id
+    add_index :recurring_assignments, :paused_at
+  end
+end
+```
+
+`db/migrate/20260730000002_create_recurring_assignment_occurrences.rb`:
+
+```ruby
+class CreateRecurringAssignmentOccurrences < ActiveRecord::Migration[6.1]
+  def change
+    create_table :recurring_assignment_occurrences do |t|
+      t.references :recurring_assignment, null: false, foreign_key: true
+      t.date :occurs_on, null: false
+      t.bigint :forecast_assignment_id
+      t.string :status, null: false, default: "materialized"
+      t.timestamps
+    end
+    add_index :recurring_assignment_occurrences,
+      [:recurring_assignment_id, :occurs_on],
+      unique: true,
+      name: "idx_recurring_occurrences_on_rule_and_date"
+    add_index :recurring_assignment_occurrences, :forecast_assignment_id
+  end
+end
+```
+
+- [ ] **Step 2: Run the migrations**
+
+Run: `bin/rails db:migrate`
+Expected: both tables created; `db/schema.rb` updated.
+
+- [ ] **Step 3: Write the failing model tests**
+
+`test/models/recurring_assignment_test.rb`:
+
+```ruby
+require "test_helper"
+
+class RecurringAssignmentTest < ActiveSupport::TestCase
+  def valid_attrs(overrides = {})
+    { forecast_person_id: 1, forecast_project_id: 2, allocation: 28_800,
+      weekdays: [1, 2, 3, 4, 5], starts_on: Date.new(2026, 8, 3) }.merge(overrides)
+  end
+
+  test "valid with default attrs" do
+    assert RecurringAssignment.new(valid_attrs).valid?
+  end
+
+  test "requires positive integer allocation" do
+    assert_not RecurringAssignment.new(valid_attrs(allocation: 0)).valid?
+    assert_not RecurringAssignment.new(valid_attrs(allocation: nil)).valid?
+  end
+
+  test "weekdays must be present and within 0..6" do
+    assert_not RecurringAssignment.new(valid_attrs(weekdays: [])).valid?
+    assert_not RecurringAssignment.new(valid_attrs(weekdays: [7])).valid?
+    assert RecurringAssignment.new(valid_attrs(weekdays: [0, 6])).valid?
+  end
+
+  test "ends_on must not precede starts_on" do
+    assert_not RecurringAssignment.new(valid_attrs(ends_on: Date.new(2026, 8, 2))).valid?
+    assert RecurringAssignment.new(valid_attrs(ends_on: Date.new(2026, 8, 3))).valid?
+  end
+
+  test "active scope excludes paused rows" do
+    a = RecurringAssignment.create!(valid_attrs)
+    b = RecurringAssignment.create!(valid_attrs(paused_at: Time.current))
+    assert_includes RecurringAssignment.active, a
+    assert_not_includes RecurringAssignment.active, b
+  end
+
+  test "allocation_in_hours converts to/from seconds" do
+    ra = RecurringAssignment.new(valid_attrs(allocation: 28_800))
+    assert_equal 8.0, ra.allocation_in_hours
+    ra.allocation_in_hours = 4
+    assert_equal 14_400, ra.allocation
+  end
+end
+```
+
+`test/models/recurring_assignment_occurrence_test.rb`:
+
+```ruby
+require "test_helper"
+
+class RecurringAssignmentOccurrenceTest < ActiveSupport::TestCase
+  setup do
+    @ra = RecurringAssignment.create!(
+      forecast_person_id: 1, forecast_project_id: 2, allocation: 900,
+      weekdays: [1], starts_on: Date.new(2026, 8, 3),
+    )
+  end
+
+  test "status must be a known value" do
+    occ = @ra.recurring_assignment_occurrences.new(occurs_on: Date.new(2026, 8, 3), status: "bogus")
+    assert_not occ.valid?
+  end
+
+  test "materialized/deleted scopes" do
+    m = @ra.recurring_assignment_occurrences.create!(occurs_on: Date.new(2026, 8, 3), status: "materialized")
+    d = @ra.recurring_assignment_occurrences.create!(occurs_on: Date.new(2026, 8, 10), status: "deleted")
+    assert_includes RecurringAssignmentOccurrence.materialized, m
+    assert_includes RecurringAssignmentOccurrence.deleted, d
+  end
+
+  test "occurs_on is unique per rule" do
+    @ra.recurring_assignment_occurrences.create!(occurs_on: Date.new(2026, 8, 3))
+    dup = @ra.recurring_assignment_occurrences.new(occurs_on: Date.new(2026, 8, 3))
+    assert_raises(ActiveRecord::RecordNotUnique) { dup.save!(validate: false) }
+  end
+end
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `bin/rails test test/models/recurring_assignment_test.rb test/models/recurring_assignment_occurrence_test.rb`
+Expected: FAIL — models not defined.
+
+- [ ] **Step 5: Write the models**
+
+`app/models/recurring_assignment.rb`:
+
+```ruby
+class RecurringAssignment < ApplicationRecord
+  HORIZON = 26.weeks
+
+  belongs_to :forecast_person, class_name: "ForecastPerson",
+    foreign_key: "forecast_person_id", primary_key: "forecast_id", optional: true
+  belongs_to :forecast_project, class_name: "ForecastProject",
+    foreign_key: "forecast_project_id", primary_key: "forecast_id", optional: true
+  has_many :recurring_assignment_occurrences, dependent: :destroy
+
+  validates :forecast_person_id, presence: true
+  validates :forecast_project_id, presence: true
+  validates :allocation, presence: true, numericality: { greater_than: 0, only_integer: true }
+  validates :starts_on, presence: true
+  validate :weekdays_valid
+  validate :ends_on_not_before_starts_on
+
+  scope :active, -> { where(paused_at: nil) }
+
+  def paused?
+    paused_at.present?
+  end
+
+  def allocation_in_hours
+    allocation && allocation / 3600.0
+  end
+
+  def allocation_in_hours=(hours)
+    self.allocation = (hours.to_f * 3600).round
+  end
+
+  private
+
+  def weekdays_valid
+    if weekdays.blank?
+      errors.add(:weekdays, "must include at least one day")
+    elsif weekdays.any? { |d| !(0..6).cover?(d) }
+      errors.add(:weekdays, "must be integers 0 (Sun) through 6 (Sat)")
+    end
+  end
+
+  def ends_on_not_before_starts_on
+    return if ends_on.blank? || starts_on.blank?
+    errors.add(:ends_on, "cannot be before starts_on") if ends_on < starts_on
+  end
+end
+```
+
+`app/models/recurring_assignment_occurrence.rb`:
+
+```ruby
+class RecurringAssignmentOccurrence < ApplicationRecord
+  STATUSES = %w[materialized deleted].freeze
+
+  belongs_to :recurring_assignment
+
+  validates :occurs_on, presence: true
+  validates :status, inclusion: { in: STATUSES }
+
+  scope :materialized, -> { where(status: "materialized") }
+  scope :deleted, -> { where(status: "deleted") }
+end
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `bin/rails test test/models/recurring_assignment_test.rb test/models/recurring_assignment_occurrence_test.rb`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add db/migrate/20260730000001_create_recurring_assignments.rb db/migrate/20260730000002_create_recurring_assignment_occurrences.rb db/schema.rb app/models/recurring_assignment.rb app/models/recurring_assignment_occurrence.rb test/models/recurring_assignment_test.rb test/models/recurring_assignment_occurrence_test.rb
+git commit -m "feat(recurring-assignments): add RecurringAssignment + Occurrence models"
+```
+
+---
+
+### Task 3: `RecurringAssignment#materialize!`
+
+**Files:**
+- Modify: `app/models/recurring_assignment.rb`
+- Test: `test/models/recurring_assignment_materialize_test.rb`
+
+**Interfaces:**
+- Consumes: `Stacks::Forecast#create_assignment` (Task 1), `ForecastAssignment.exists?(forecast_id:)`.
+- Produces: `RecurringAssignment#materialize!(forecast_client: nil)` — deletion-detection pass then creation pass; idempotent; returns nothing meaningful. `#expected_occurrence_dates` (public, for testing the horizon).
+
+- [ ] **Step 1: Write the failing tests**
+
+`test/models/recurring_assignment_materialize_test.rb`:
+
+```ruby
+require "test_helper"
+
+class RecurringAssignmentMaterializeTest < ActiveSupport::TestCase
+  def build_client
+    Stacks::Forecast.allocate.tap { |c| c.instance_variable_set(:@headers, {}) }
+  end
+
+  def rule(overrides = {})
+    RecurringAssignment.create!({
+      forecast_person_id: 324711, forecast_project_id: 3033811, allocation: 900,
+      weekdays: [1], starts_on: Date.new(2026, 8, 3), ends_on: Date.new(2026, 8, 24),
+    }.merge(overrides))
+  end
+
+  test "creates one Forecast assignment per expected weekday and records occurrences" do
+    ra = rule # Mondays 2026-08-03,10,17,24 => 4 occurrences
+    client = build_client
+    seq = sequence("ids")
+    client.expects(:create_assignment).times(4).returns(
+      { "id" => 1 }, { "id" => 2 }, { "id" => 3 }, { "id" => 4 }
+    )
+
+    ra.materialize!(forecast_client: client)
+
+    occ = ra.recurring_assignment_occurrences.order(:occurs_on)
+    assert_equal 4, occ.count
+    assert_equal [Date.new(2026,8,3), Date.new(2026,8,10), Date.new(2026,8,17), Date.new(2026,8,24)], occ.map(&:occurs_on)
+    assert occ.all? { |o| o.status == "materialized" && o.forecast_assignment_id.present? }
+  end
+
+  test "is idempotent — a second run POSTs nothing new" do
+    ra = rule
+    c1 = build_client
+    c1.stubs(:create_assignment).returns({ "id" => 1 })
+    ra.materialize!(forecast_client: c1)
+    assert_equal 4, ra.recurring_assignment_occurrences.count
+
+    c2 = build_client
+    c2.expects(:create_assignment).never
+    ra.materialize!(forecast_client: c2)
+    assert_equal 4, ra.recurring_assignment_occurrences.count
+  end
+
+  test "tombstones an occurrence whose Forecast assignment was deleted in the UI" do
+    ra = rule(ends_on: Date.new(2026, 8, 3)) # single Monday
+    # present-in-mirror occurrence stays materialized; absent one gets tombstoned.
+    # save!(validate: false) skips the required belongs_to person/project — we only
+    # need a bare mirror row for the exists?(forecast_id:) check.
+    ForecastAssignment.new(forecast_id: 555).save!(validate: false)
+    kept = ra.recurring_assignment_occurrences.create!(occurs_on: Date.new(2026, 8, 3), status: "materialized", forecast_assignment_id: 555)
+    gone = ra.recurring_assignment_occurrences.create!(occurs_on: Date.new(2026, 7, 27), status: "materialized", forecast_assignment_id: 999)
+
+    client = build_client
+    client.expects(:create_assignment).never # both dates already have occurrence rows
+    ra.materialize!(forecast_client: client)
+
+    assert_equal "materialized", kept.reload.status
+    assert_equal "deleted", gone.reload.status
+  end
+
+  test "never recreates a tombstoned occurrence" do
+    ra = rule(ends_on: Date.new(2026, 8, 3)) # single Monday 08-03
+    ra.recurring_assignment_occurrences.create!(occurs_on: Date.new(2026, 8, 3), status: "deleted", forecast_assignment_id: 111)
+
+    client = build_client
+    client.expects(:create_assignment).never
+    ra.materialize!(forecast_client: client)
+
+    assert_equal 1, ra.recurring_assignment_occurrences.count
+    assert_equal "deleted", ra.recurring_assignment_occurrences.first.status
+  end
+
+  test "open-ended rule stops at the 26-week horizon" do
+    ra = rule(starts_on: Date.today, ends_on: nil, weekdays: [Date.today.wday])
+    dates = ra.expected_occurrence_dates
+    assert dates.max <= Date.today + RecurringAssignment::HORIZON
+    assert dates.max > Date.today + (RecurringAssignment::HORIZON - 1.week)
+  end
+end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bin/rails test test/models/recurring_assignment_materialize_test.rb`
+Expected: FAIL — `materialize!` / `expected_occurrence_dates` undefined.
+
+- [ ] **Step 3: Implement `materialize!`**
+
+Add to `app/models/recurring_assignment.rb` (public section):
+
+```ruby
+# Idempotent. Pass 1 tombstones occurrences deleted in Forecast (absent from the
+# freshly-synced ForecastAssignment mirror); Pass 2 creates any missing occurrence.
+# MUST run after Stacks::Forecast#sync_all! so the mirror is authoritative — see the
+# daily_tasks wiring. Detection runs BEFORE creation so this-run creations are never
+# mistaken for deletions.
+def materialize!(forecast_client: nil)
+  return if paused?
+  detect_deletions!
+  create_missing_occurrences!(forecast_client || Stacks::Forecast.new)
+end
+
+def expected_occurrence_dates
+  last = [ends_on, Date.today + HORIZON].compact.min
+  return [] if starts_on > last
+  (starts_on..last).select { |d| weekdays.include?(d.wday) }
+end
+```
+
+And in the `private` section:
+
+```ruby
+def detect_deletions!
+  recurring_assignment_occurrences.materialized.where.not(forecast_assignment_id: nil).find_each do |occ|
+    next if ForecastAssignment.exists?(forecast_id: occ.forecast_assignment_id)
+    occ.update!(status: "deleted")
+  end
+end
+
+def create_missing_occurrences!(forecast_client)
+  existing = recurring_assignment_occurrences.pluck(:occurs_on).to_set
+  expected_occurrence_dates.each do |date|
+    next if existing.include?(date)
+    begin
+      assignment = forecast_client.create_assignment(
+        project_id: forecast_project_id,
+        person_id: forecast_person_id,
+        start_date: date,
+        end_date: date,
+        allocation: allocation,
+        notes: notes,
+        active_on_days_off: active_on_days_off,
+      )
+      recurring_assignment_occurrences.create!(
+        occurs_on: date,
+        status: "materialized",
+        forecast_assignment_id: assignment["id"],
+      )
+    rescue => e
+      Sentry.capture_exception(e)
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bin/rails test test/models/recurring_assignment_materialize_test.rb`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/models/recurring_assignment.rb test/models/recurring_assignment_materialize_test.rb
+git commit -m "feat(recurring-assignments): materialize! with tombstone-on-delete"
+```
+
+---
+
+### Task 4: Destroy cleanup — remove future Forecast assignments
+
+**Files:**
+- Modify: `app/models/recurring_assignment.rb`
+- Test: `test/models/recurring_assignment_destroy_test.rb`
+
+**Interfaces:**
+- Consumes: `Stacks::Forecast#delete_assignment` (Task 1).
+- Produces: `before_destroy` deletes future (`occurs_on >= Date.today`) materialized occurrences from Forecast via `#remove_future_forecast_assignments!(forecast_client = Stacks::Forecast.new)`.
+
+- [ ] **Step 1: Write the failing test**
+
+`test/models/recurring_assignment_destroy_test.rb`:
+
+```ruby
+require "test_helper"
+
+class RecurringAssignmentDestroyTest < ActiveSupport::TestCase
+  test "destroying a rule deletes future materialized occurrences from Forecast, not past ones" do
+    ra = RecurringAssignment.create!(
+      forecast_person_id: 1, forecast_project_id: 2, allocation: 900,
+      weekdays: [1], starts_on: Date.today - 30,
+    )
+    past   = ra.recurring_assignment_occurrences.create!(occurs_on: Date.today - 7, status: "materialized", forecast_assignment_id: 100)
+    future = ra.recurring_assignment_occurrences.create!(occurs_on: Date.today + 7, status: "materialized", forecast_assignment_id: 200)
+    tomb   = ra.recurring_assignment_occurrences.create!(occurs_on: Date.today + 8, status: "deleted",      forecast_assignment_id: 300)
+
+    client = Stacks::Forecast.allocate.tap { |c| c.instance_variable_set(:@headers, {}) }
+    Stacks::Forecast.stubs(:new).returns(client)
+    client.expects(:delete_assignment).with(200).once.returns(true)
+    # past (100) and tombstoned (300) must NOT be deleted
+    client.expects(:delete_assignment).with(100).never
+    client.expects(:delete_assignment).with(300).never
+
+    ra.destroy!
+    assert_equal 0, RecurringAssignmentOccurrence.where(recurring_assignment_id: ra.id).count
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bin/rails test test/models/recurring_assignment_destroy_test.rb`
+Expected: FAIL — no delete happens (`delete_assignment` expected once, called never).
+
+- [ ] **Step 3: Implement the callback**
+
+Add to `app/models/recurring_assignment.rb`:
+
+```ruby
+# (near the associations)
+before_destroy :remove_future_forecast_assignments!
+```
+
+```ruby
+# (public method)
+# Deletes only FUTURE materialized occurrences from Forecast on rule teardown;
+# past occurrences are left for historical accuracy, tombstoned ones are already gone.
+def remove_future_forecast_assignments!(forecast_client = Stacks::Forecast.new)
+  recurring_assignment_occurrences
+    .materialized
+    .where.not(forecast_assignment_id: nil)
+    .where("occurs_on >= ?", Date.today)
+    .find_each { |occ| forecast_client.delete_assignment(occ.forecast_assignment_id) }
+end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bin/rails test test/models/recurring_assignment_destroy_test.rb`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/models/recurring_assignment.rb test/models/recurring_assignment_destroy_test.rb
+git commit -m "feat(recurring-assignments): delete future Forecast assignments on rule destroy"
+```
+
+---
+
+### Task 5: Wire materialization into the daily cron
+
+**Files:**
+- Modify: `lib/tasks/stacks.rake` (inside `stacks:daily_tasks`, immediately after line 511 `Stacks::Forecast.new.sync_all!`)
+
+**Interfaces:**
+- Consumes: `RecurringAssignment.active`, `#materialize!` (Task 3).
+
+- [ ] **Step 1: Add the materialization loop**
+
+In `lib/tasks/stacks.rake`, directly after `Stacks::Forecast.new.sync_all!` (~line 511), insert:
+
+```ruby
+      # Materialize Stacks-owned recurring assignments into Forecast. MUST run
+      # right after sync_all! so the ForecastAssignment mirror is fresh — that's
+      # how materialize! distinguishes "deleted in the UI" from "not yet synced".
+      forecast_client = Stacks::Forecast.new
+      RecurringAssignment.active.find_each do |ra|
+        begin
+          ra.materialize!(forecast_client: forecast_client)
+        rescue => e
+          Sentry.capture_exception(e)
+        end
+      end
+```
+
+- [ ] **Step 2: Verify the file parses**
+
+Run: `bin/rails runner 'puts "ok"'`
+Expected: prints `ok` (Rails loads the rake-adjacent code without syntax error). Also run `ruby -c lib/tasks/stacks.rake` → `Syntax OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/tasks/stacks.rake
+git commit -m "feat(recurring-assignments): materialize active rules after daily Forecast sync"
+```
+
+---
+
+### Task 6: ActiveAdmin UI
+
+**Files:**
+- Create: `app/admin/recurring_assignments.rb`
+
+**Interfaces:**
+- Consumes: `RecurringAssignment` (models + `materialize!` + `allocation_in_hours`), `ForecastPerson.active`, `ForecastProject.active`.
+
+- [ ] **Step 1: Write the admin resource**
+
+`app/admin/recurring_assignments.rb`:
+
+```ruby
+ActiveAdmin.register RecurringAssignment do
+  menu label: "Recurring Assignments", parent: "Team"
+  config.filters = false
+  actions :index, :new, :create, :edit, :update, :destroy
+
+  WEEKDAY_CHOICES = [%w[Mon 1], %w[Tue 2], %w[Wed 3], %w[Thu 4], %w[Fri 5], %w[Sat 6], %w[Sun 0]].freeze
+
+  permit_params :forecast_person_id, :forecast_project_id, :allocation_in_hours,
+    :active_on_days_off, :notes, :starts_on, :ends_on, :paused_at, weekdays: []
+
+  controller do
+    def scoped_collection
+      super.includes(:forecast_person, :forecast_project, :recurring_assignment_occurrences)
+    end
+  end
+
+  action_item :materialize_now, only: :edit do
+    link_to "Materialize Now",
+      materialize_now_admin_recurring_assignment_path(resource),
+      method: :post,
+      data: { confirm: "Create/refresh Forecast assignments for this rule now?" }
+  end
+
+  member_action :materialize_now, method: :post do
+    resource.materialize!
+    redirect_to edit_admin_recurring_assignment_path(resource), notice: "Materialized."
+  rescue => e
+    redirect_to edit_admin_recurring_assignment_path(resource), alert: e.message
+  end
+
+  action_item :toggle_pause, only: :edit do
+    link_to(resource.paused? ? "Resume" : "Pause",
+      toggle_pause_admin_recurring_assignment_path(resource), method: :post)
+  end
+
+  member_action :toggle_pause, method: :post do
+    resource.update!(paused_at: resource.paused? ? nil : Time.current)
+    redirect_to edit_admin_recurring_assignment_path(resource),
+      notice: resource.paused? ? "Paused." : "Resumed."
+  end
+
+  index download_links: false do
+    column(:person) { |r| r.forecast_person&.email || "Person ##{r.forecast_person_id}" }
+    column(:project) { |r| r.forecast_project&.name || "Project ##{r.forecast_project_id}" }
+    column(:hours_per_day) { |r| r.allocation_in_hours }
+    column(:weekdays) { |r| r.weekdays.sort.map { |d| Date::ABBR_DAYNAMES[d] }.join(", ") }
+    column :starts_on
+    column :ends_on
+    column(:occurrences) do |r|
+      m = r.recurring_assignment_occurrences.count { |o| o.status == "materialized" }
+      d = r.recurring_assignment_occurrences.count { |o| o.status == "deleted" }
+      "#{m} live / #{d} deleted"
+    end
+    column(:status) { |r| r.paused? ? status_tag("Paused") : status_tag("Active") }
+    actions
+  end
+
+  show do
+    attributes_table do
+      row(:person) { |r| r.forecast_person&.email }
+      row(:project) { |r| r.forecast_project&.name }
+      row(:hours_per_day) { |r| r.allocation_in_hours }
+      row(:weekdays) { |r| r.weekdays.sort.map { |d| Date::ABBR_DAYNAMES[d] }.join(", ") }
+      row :starts_on
+      row :ends_on
+      row :active_on_days_off
+      row :notes
+      row(:status) { |r| r.paused? ? "Paused" : "Active" }
+    end
+    panel "Occurrences" do
+      table_for resource.recurring_assignment_occurrences.order(occurs_on: :desc) do
+        column :occurs_on
+        column :status
+        column(:forecast_assignment) do |o|
+          if o.forecast_assignment_id
+            link_to o.forecast_assignment_id,
+              "https://forecastapp.com/#{Stacks::Utils.config[:forecast][:account_id]}/schedule/projects/#{o.recurring_assignment.forecast_project_id}/assignments/#{o.forecast_assignment_id}/edit",
+              target: "_blank"
+          end
+        end
+      end
+    end
+  end
+
+  form do |f|
+    f.semantic_errors
+    f.inputs do
+      f.input :forecast_person_id, as: :select,
+        collection: ForecastPerson.active.order(:email).map { |p| [p.email, p.forecast_id] },
+        prompt: "Choose a person…"
+      f.input :forecast_project_id, as: :select,
+        collection: ForecastProject.active.map { |p| [p.name, p.forecast_id] }.sort_by(&:first),
+        prompt: "Choose a project…"
+      f.input :allocation_in_hours, label: "Hours per day", hint: "Stored as seconds/day for Forecast."
+      f.input :weekdays, as: :check_boxes, collection: WEEKDAY_CHOICES
+      f.input :starts_on, as: :datepicker
+      f.input :ends_on, as: :datepicker, hint: "Leave blank for open-ended (materializes 26 weeks ahead, extending each day)."
+      f.input :active_on_days_off
+      f.input :notes
+    end
+    f.actions
+  end
+end
+```
+
+- [ ] **Step 2: Smoke-test that admin + app boot cleanly**
+
+Run: `bin/rails runner 'ActiveAdmin.application.namespaces[:admin].resources.keys.include?("RecurringAssignment") ? puts("registered") : abort("missing")'`
+Expected: prints `registered` (resource loads, no NameError/syntax error in the admin file).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/admin/recurring_assignments.rb
+git commit -m "feat(recurring-assignments): ActiveAdmin CRUD + materialize-now UI"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Ownership model (create + respect-delete, no reconcile) → Task 3 (`materialize!`).
+- Data model (both tables/models, validations, scopes) → Task 2.
+- Forecast write API (create + delete only) → Task 1.
+- Deletion detection before creation, inline-after-sync rationale → Task 3 + Task 5.
+- 26-week horizon → Task 3 (`expected_occurrence_dates` + test).
+- One-assignment-per-day → Task 3 (`start_date == end_date == date`).
+- Scheduling/wiring → Task 5.
+- Rule destroy (future-only cleanup) → Task 4.
+- Admin UI (form/index/show/materialize-now, hours↔seconds, weekdays checkboxes) → Task 6.
+- Testing conventions (Mocha class-method stubs, `allocate`+`@headers`) → Tasks 1 & 3.
+
+**Placeholder scan:** none — every step has concrete code/commands.
+
+**Type consistency:** `create_assignment` keyword args match between Task 1 definition and Task 3 call site; `forecast_assignment_id`, `status` (`"materialized"`/`"deleted"`), `occurs_on`, `allocation_in_hours`, `expected_occurrence_dates`, `materialize!(forecast_client:)`, `remove_future_forecast_assignments!` are used identically across tasks.

--- a/docs/superpowers/specs/2026-07-30-recurring-forecast-assignments-design.md
+++ b/docs/superpowers/specs/2026-07-30-recurring-forecast-assignments-design.md
@@ -94,13 +94,16 @@ recreate. This is the "deleted in the UI, don't recreate" mechanism.
 > If `sync_all!` raises, the `SystemTask` rescue skips `materialize!` entirely — so
 > `materialize!` only ever runs against a freshly-synced mirror.
 
-**Pass 2 — creation:**
-Compute expected occurrence dates = days in `[starts_on, min(ends_on, today + HORIZON)]` whose
-weekday ∈ `weekdays`. `HORIZON = 26.weeks` (open-ended rules extend each run). For each expected
-date with **no** occurrence row (any status), `POST` a 1-day Forecast assignment
-(`start_date == end_date == occurs_on`) and record the occurrence as `materialized` with the
-returned `forecast_assignment_id`. Dates that already have an occurrence row — `materialized`
-**or** `deleted` — are skipped (tombstones are permanent).
+**Pass 2 — creation (retrospect-only):**
+Compute expected occurrence dates = days in `[starts_on, min(ends_on, today)]` whose
+weekday ∈ `weekdays`. Occurrences are **only ever created on/before today — never in advance.**
+A blank `ends_on` means "never ends": the rule simply materializes each day's occurrence once
+that day arrives. (Bounding creation to today, rather than a future horizon, also guarantees
+every occurrence falls inside the Forecast sync window — the second half of what makes
+deletion-detection safe.) For each expected date with **no** occurrence row (any status), `POST`
+a 1-day Forecast assignment (`start_date == end_date == occurs_on`) and record the occurrence as
+`materialized` with the returned `forecast_assignment_id`. Dates that already have an occurrence
+row — `materialized` **or** `deleted` — are skipped (tombstones are permanent).
 
 Per-occurrence work is wrapped so one Forecast API failure doesn't abort the rule
 (`rescue` + `Sentry.capture_exception`, matching the `daily_enterprise_tasks` loop).
@@ -169,6 +172,9 @@ per `test/lib/stacks/runn_test.rb`.
 2. **v1 = create + respect-delete only; no edit reconciliation.** Rule edits affect only
    future unmaterialized occurrences.
 3. **People only** (no placeholder assignees) in v1.
-4. **26-week rolling horizon** for open-ended rules.
-5. **Destroy deletes future occurrences only** from Forecast; past left intact.
+4. **Retrospect-only creation** — occurrences are created only on/before today, never in
+   advance. A blank `ends_on` means "never ends" (materializes each day as it arrives); there is
+   no forward horizon.
+5. **Destroy deletes future occurrences only** from Forecast; past left intact. (Under
+   retrospect-only this now only ever affects today's occurrence — see open question in PR.)
 6. **Rides `daily_tasks`** (daily cadence) rather than a dedicated scheduler entry.

--- a/docs/superpowers/specs/2026-07-30-recurring-forecast-assignments-design.md
+++ b/docs/superpowers/specs/2026-07-30-recurring-forecast-assignments-design.md
@@ -1,0 +1,174 @@
+# Recurring Forecast Assignments — Design
+
+**Date:** 2026-07-30
+**Status:** Approved (autonomous build; flagged decisions surfaced at PR review)
+
+## Problem
+
+Forecast (Harvest) has a native "repeat" feature, but its `repeated_assignment_set_id`
+is server-owned and cannot be set through the write endpoints we have access to
+(verified live: sending a value on `POST /assignments` returns `nil`; no repeat/expansion
+param is honored). We want Stacks to own recurring scheduling as a first-class concept and
+**materialize** each occurrence as an ordinary Forecast assignment via the (undocumented but
+confirmed) `api.forecastapp.com` write API.
+
+Hard requirement: **if a user deletes a materialized assignment directly in the Forecast UI,
+the materialization job must not recreate it.**
+
+## Ownership model
+
+- **Stacks owns creation.** The rule generates concrete Forecast assignments.
+- **Deletion in Forecast is an intentional opt-out.** A materialized occurrence that
+  disappears from Forecast is *tombstoned* and never recreated.
+- **v1 does not reconcile edits.** Editing a rule affects only occurrences not yet
+  materialized; already-materialized assignments (and any manual hour edits made to them in
+  Forecast) are left as-is. (Flagged: reconcile-on-drift is a deliberate future extension,
+  not v1.)
+
+## Data model
+
+Two new **local** models (default bigint `id`; they reference Forecast mirror rows by
+`forecast_id`, following the `Contributor → ForecastPerson` convention — model-level
+`belongs_to` with `primary_key: "forecast_id"`, no DB FK to the pruned mirror tables).
+
+### `RecurringAssignment` (the rule)
+
+| column | type | notes |
+|---|---|---|
+| `forecast_person_id` | bigint, null: false | the assignee (v1: people only; placeholder is future) |
+| `forecast_project_id` | bigint, null: false | target project |
+| `allocation` | integer, null: false | seconds/day (Forecast native; admin enters hours) |
+| `active_on_days_off` | boolean, null: false, default: false | |
+| `notes` | text, null: false, default: "" | copied onto each Forecast assignment |
+| `weekdays` | integer[], null: false, default: `[1,2,3,4,5]` | 0=Sun..6=Sat; which weekdays get an occurrence |
+| `starts_on` | date, null: false | window start |
+| `ends_on` | date, null: true | window end; null ⇒ open-ended (rolling horizon) |
+| `paused_at` | datetime, null: true | `scope :active` = `where(paused_at: nil)` |
+| timestamps | | |
+
+Validations (mirroring `RecurringLedgerAdjustment`): presence of person/project/allocation/
+starts_on; `allocation > 0`; `weekdays` non-empty and ⊆ 0..6; `ends_on >= starts_on` when
+present.
+
+Associations: `belongs_to :forecast_person`, `belongs_to :forecast_project`
+(both `primary_key: "forecast_id"`), `has_many :recurring_assignment_occurrences, dependent: :destroy`.
+
+### `RecurringAssignmentOccurrence` (one row per occurrence date)
+
+| column | type | notes |
+|---|---|---|
+| `recurring_assignment_id` | references, null: false, FK | |
+| `occurs_on` | date, null: false | the single day this assignment covers |
+| `forecast_assignment_id` | bigint, null: true | id returned by Forecast `POST` |
+| `status` | string, null: false, default: `"materialized"` | `materialized` \| `deleted` |
+| timestamps | | |
+
+Unique index on `[recurring_assignment_id, occurs_on]` (idempotency key). Index on
+`forecast_assignment_id`.
+
+## Forecast write API (net-new — `Stacks::Forecast` is currently read-only)
+
+Add two methods (only what v1 uses), copying the `Stacks::Runn#create_assignment`
+write/`handle_response` pattern (`self.class.post/delete(path, body: JSON.dump(...), headers: @headers)`):
+
+- `create_assignment(project_id:, person_id:, start_date:, end_date:, allocation:, notes:, active_on_days_off:)` → `POST /assignments`, body wrapped `{ assignment: {...} }`, returns parsed `assignment` (incl. new `id`).
+- `delete_assignment(forecast_id)` → `DELETE /assignments/:id` (204).
+
+`Content-Type: application/json`. (`PUT`/update is deliberately omitted — no v1 caller;
+it lands with the future reconcile-on-drift work.)
+
+## Materialization
+
+`RecurringAssignment#materialize!` — idempotent, safe to re-run, per-rule. Two ordered passes:
+
+**Pass 1 — deletion detection (BEFORE creation):**
+For each existing `status: "materialized"` occurrence, if its `forecast_assignment_id` is
+**absent from the `ForecastAssignment` mirror**, set `status: "deleted"` (tombstone). Do not
+recreate. This is the "deleted in the UI, don't recreate" mechanism.
+
+> **Why no timestamp/race guard is needed:** `materialize!` is invoked *inline immediately
+> after* `Stacks::Forecast#sync_all!` in `stacks:daily_tasks`, and detection runs before
+> creation. Therefore every occurrence eligible for detection was created in a *prior* run
+> and has been through ≥1 sync, so the mirror is authoritative for it. Occurrences created in
+> the current run are made in Pass 2 (after detection) and so are never falsely tombstoned.
+> If `sync_all!` raises, the `SystemTask` rescue skips `materialize!` entirely — so
+> `materialize!` only ever runs against a freshly-synced mirror.
+
+**Pass 2 — creation:**
+Compute expected occurrence dates = days in `[starts_on, min(ends_on, today + HORIZON)]` whose
+weekday ∈ `weekdays`. `HORIZON = 26.weeks` (open-ended rules extend each run). For each expected
+date with **no** occurrence row (any status), `POST` a 1-day Forecast assignment
+(`start_date == end_date == occurs_on`) and record the occurrence as `materialized` with the
+returned `forecast_assignment_id`. Dates that already have an occurrence row — `materialized`
+**or** `deleted` — are skipped (tombstones are permanent).
+
+Per-occurrence work is wrapped so one Forecast API failure doesn't abort the rule
+(`rescue` + `Sentry.capture_exception`, matching the `daily_enterprise_tasks` loop).
+
+## Scheduling / wiring
+
+Add, in `lib/tasks/stacks.rake` inside `stacks:daily_tasks`, **immediately after**
+`Stacks::Forecast.new.sync_all!` (~line 511):
+
+```ruby
+RecurringAssignment.active.find_each do |ra|
+  begin
+    ra.materialize!
+  rescue => e
+    Sentry.capture_exception(e)
+  end
+end
+```
+
+No new Heroku Scheduler entry required (rides the existing daily sync → correct ordering for free).
+
+## Rule lifecycle
+
+- **Pause** (`paused_at`): rule skipped by `active` scope; existing Forecast assignments left intact.
+- **Destroy:** before destroying the rule, delete **future** (`occurs_on >= Date.today`),
+  non-tombstoned materialized occurrences from Forecast (`delete_assignment`), then destroy
+  occurrences via `dependent: :destroy`. Past occurrences are left in Forecast for historical
+  accuracy. (Flagged decision: future-only cleanup.)
+
+## Admin UI (ActiveAdmin — primary internal UI)
+
+`app/admin/recurring_assignments.rb`, modeled on `recurring_ledger_adjustments.rb`:
+
+- `menu parent: "Team"`, `config.filters = false`, `actions :index,:new,:create,:edit,:update,:destroy`.
+- **Form:** person `as: :select` (non-archived `ForecastPerson`), project `as: :select`
+  (non-archived `ForecastProject`), allocation **entered in hours** (helper converts ⇄ seconds),
+  `weekdays` as multi-select checkboxes (Mon–Sun), `starts_on`/`ends_on` datepickers,
+  `active_on_days_off`, `notes`.
+- **Index:** person, project, cadence summary (weekdays + window), allocation (hours),
+  materialized / tombstoned occurrence counts, `status_tag` for paused.
+- **Show:** rule details + occurrences table (date, status, link to the Forecast assignment).
+- **`action_item :materialize_now` → `member_action`** calling `resource.materialize!`
+  (with `notice`/`alert`), mirroring the RLA "materialize now" button.
+
+## Testing (Minitest + Mocha; no WebMock/VCR)
+
+Stub Forecast HTTP at the class method (`Stacks::Forecast.expects(:post)/:put/:delete`),
+per `test/lib/stacks/runn_test.rb`.
+
+- **`Stacks::Forecast` writes:** POST/PUT/DELETE hit right path + body envelope; parse response.
+- **Model validations:** allocation, weekdays subset, date ordering.
+- **Materialize — create:** new rule POSTs one assignment per expected weekday in horizon,
+  records occurrences; second run is a no-op (no duplicate POST).
+- **Materialize — tombstone:** a materialized occurrence whose `forecast_assignment_id` is
+  absent from the `ForecastAssignment` mirror flips to `deleted`, no POST.
+- **Materialize — no-recreate:** a `deleted` occurrence is never re-POSTed on subsequent runs
+  (the core requirement).
+- **Materialize — horizon:** open-ended rule stops at `today + 26.weeks`; extends next run.
+- **Destroy cleanup:** destroying a rule DELETEs future materialized occurrences from Forecast,
+  leaves past ones.
+
+## Flagged decisions (for PR review)
+
+1. **One Forecast assignment per occurrence day** (1:1 occurrence↔row↔tombstone). Simplest to
+   reason about; trades row count (week-block batching is a future optimization).
+2. **v1 = create + respect-delete only; no edit reconciliation.** Rule edits affect only
+   future unmaterialized occurrences.
+3. **People only** (no placeholder assignees) in v1.
+4. **26-week rolling horizon** for open-ended rules.
+5. **Destroy deletes future occurrences only** from Forecast; past left intact.
+6. **Rides `daily_tasks`** (daily cadence) rather than a dedicated scheduler entry.

--- a/docs/superpowers/specs/2026-07-30-recurring-forecast-assignments-design.md
+++ b/docs/superpowers/specs/2026-07-30-recurring-forecast-assignments-design.md
@@ -128,10 +128,10 @@ No new Heroku Scheduler entry required (rides the existing daily sync → correc
 ## Rule lifecycle
 
 - **Pause** (`paused_at`): rule skipped by `active` scope; existing Forecast assignments left intact.
-- **Destroy:** before destroying the rule, delete **future** (`occurs_on >= Date.today`),
-  non-tombstoned materialized occurrences from Forecast (`delete_assignment`), then destroy
-  occurrences via `dependent: :destroy`. Past occurrences are left in Forecast for historical
-  accuracy. (Flagged decision: future-only cleanup.)
+- **Destroy:** removes the rule and its occurrence tracking rows (`dependent: :destroy`) but
+  **leaves every already-created Forecast assignment intact**. Under retrospect-only
+  materialization each occurrence is a record of allocation that already happened, so it's
+  historical — not ours to erase. Destroying simply stops future materialization.
 
 ## Admin UI (ActiveAdmin — primary internal UI)
 
@@ -175,6 +175,7 @@ per `test/lib/stacks/runn_test.rb`.
 4. **Retrospect-only creation** — occurrences are created only on/before today, never in
    advance. A blank `ends_on` means "never ends" (materializes each day as it arrives); there is
    no forward horizon.
-5. **Destroy deletes future occurrences only** from Forecast; past left intact. (Under
-   retrospect-only this now only ever affects today's occurrence — see open question in PR.)
+5. **Destroy leaves all Forecast assignments intact** — every materialized occurrence is
+   historical allocation; destroying a rule only stops future materialization and drops the
+   local tracking rows.
 6. **Rides `daily_tasks`** (daily cadence) rather than a dedicated scheduler entry.

--- a/lib/stacks/forecast.rb
+++ b/lib/stacks/forecast.rb
@@ -100,7 +100,33 @@ class Stacks::Forecast
     self.class.get("/roles", headers: @headers)
   end
 
+  def create_assignment(project_id:, person_id:, start_date:, end_date:, allocation:, notes: "", active_on_days_off: false)
+    body = { assignment: {
+      project_id: project_id,
+      person_id: person_id,
+      start_date: start_date.to_s,
+      end_date: end_date.to_s,
+      allocation: allocation,
+      notes: notes.to_s,
+      active_on_days_off: active_on_days_off,
+    } }
+    response = self.class.post("/assignments", headers: write_headers, body: JSON.dump(body))
+    raise "Forecast create_assignment failed: #{response.code} #{response.body}" unless response.success?
+    response.parsed_response["assignment"]
+  end
+
+  def delete_assignment(forecast_id)
+    response = self.class.delete("/assignments/#{forecast_id}", headers: write_headers)
+    return true if response.success?
+    return true if response.code == 404 # already gone — idempotent
+    raise "Forecast delete_assignment failed: #{response.code} #{response.body}"
+  end
+
   private
+
+  def write_headers
+    @headers.merge("Content-Type": "application/json")
+  end
 
   # Forecast re-sends every record that overlaps each sync window, and sync_all_assignments!
   # walks month-by-month from 2020, so an unconditional `upsert_all` rewrites unchanged rows

--- a/lib/tasks/stacks.rake
+++ b/lib/tasks/stacks.rake
@@ -510,6 +510,18 @@ namespace :stacks do
 
       Stacks::Forecast.new.sync_all! # Has internal retry counter
 
+      # Materialize Stacks-owned recurring assignments into Forecast. MUST run
+      # right after sync_all! so the ForecastAssignment mirror is fresh — that's
+      # how materialize! distinguishes "deleted in the UI" from "not yet synced".
+      forecast_client = Stacks::Forecast.new
+      RecurringAssignment.active.find_each do |ra|
+        begin
+          ra.materialize!(forecast_client: forecast_client)
+        rescue => e
+          Sentry.capture_exception(e)
+        end
+      end
+
       Retriable.retriable(tries: 3, base_interval: 5, multiplier: 2, max_interval: 60) do
         Stacks::OptixSync.new(OptixOrganization.first).sync_all!
       end

--- a/test/lib/stacks/forecast_test.rb
+++ b/test/lib/stacks/forecast_test.rb
@@ -56,4 +56,61 @@ class StacksForecastTest < ActiveSupport::TestCase
     forecast.send(:upsert_changed!, ForecastAssignment, [row(1, "2024-02-01T00:00:00Z", allocation: 42)])
     assert_equal 42, ForecastAssignment.find_by(forecast_id: 1).allocation
   end
+
+  def build_forecast_client
+    fc = Stacks::Forecast.allocate
+    fc.instance_variable_set(:@headers, { "Authorization": "Bearer test" })
+    fc
+  end
+
+  test "create_assignment POSTs the assignment envelope and returns the assignment hash" do
+    fc = build_forecast_client
+    response = mock("response")
+    response.stubs(:success?).returns(true)
+    response.stubs(:parsed_response).returns({ "assignment" => { "id" => 42, "allocation" => 900 } })
+
+    posted = {}
+    Stacks::Forecast.expects(:post).once.with do |path, opts|
+      posted[:path] = path
+      posted[:body] = JSON.parse(opts[:body])
+      true
+    end.returns(response)
+
+    result = fc.create_assignment(
+      project_id: 5039734, person_id: 324711,
+      start_date: Date.new(2035, 6, 1), end_date: Date.new(2035, 6, 1),
+      allocation: 900, notes: "hi", active_on_days_off: false,
+    )
+
+    assert_equal 42, result["id"]
+    assert_equal "/assignments", posted[:path]
+    assert_equal 5039734, posted[:body]["assignment"]["project_id"]
+    assert_equal "2035-06-01", posted[:body]["assignment"]["start_date"]
+    assert_equal 900, posted[:body]["assignment"]["allocation"]
+  end
+
+  test "create_assignment raises on failure" do
+    fc = build_forecast_client
+    response = mock("response")
+    response.stubs(:success?).returns(false)
+    response.stubs(:code).returns(422)
+    response.stubs(:body).returns("nope")
+    Stacks::Forecast.stubs(:post).returns(response)
+
+    assert_raises(RuntimeError) do
+      fc.create_assignment(project_id: 1, person_id: 2, start_date: Date.today, end_date: Date.today, allocation: 900)
+    end
+  end
+
+  test "delete_assignment DELETEs by id and treats 404 as already-gone" do
+    fc = build_forecast_client
+
+    ok = mock("ok"); ok.stubs(:success?).returns(true)
+    Stacks::Forecast.expects(:delete).once.with("/assignments/99", has_entry(:headers, instance_of(Hash))).returns(ok)
+    assert_equal true, fc.delete_assignment(99)
+
+    gone = mock("gone"); gone.stubs(:success?).returns(false); gone.stubs(:code).returns(404)
+    Stacks::Forecast.expects(:delete).once.returns(gone)
+    assert_equal true, fc.delete_assignment(1234)
+  end
 end

--- a/test/models/recurring_assignment_destroy_test.rb
+++ b/test/models/recurring_assignment_destroy_test.rb
@@ -1,23 +1,22 @@
 require "test_helper"
 
 class RecurringAssignmentDestroyTest < ActiveSupport::TestCase
-  test "destroying a rule deletes future materialized occurrences from Forecast, not past ones" do
+  test "destroying a rule leaves its Forecast assignments intact (they are historical records)" do
     ra = RecurringAssignment.create!(
       forecast_person_id: 1, forecast_project_id: 2, allocation: 900,
       weekdays: [1], starts_on: Date.today - 30,
     )
-    past   = ra.recurring_assignment_occurrences.create!(occurs_on: Date.today - 7, status: "materialized", forecast_assignment_id: 100)
-    future = ra.recurring_assignment_occurrences.create!(occurs_on: Date.today + 7, status: "materialized", forecast_assignment_id: 200)
-    tomb   = ra.recurring_assignment_occurrences.create!(occurs_on: Date.today + 8, status: "deleted",      forecast_assignment_id: 300)
+    ra.recurring_assignment_occurrences.create!(occurs_on: Date.today - 7, status: "materialized", forecast_assignment_id: 100)
+    ra.recurring_assignment_occurrences.create!(occurs_on: Date.today, status: "materialized", forecast_assignment_id: 200)
 
-    client = Stacks::Forecast.allocate.tap { |c| c.instance_variable_set(:@headers, {}) }
-    Stacks::Forecast.stubs(:new).returns(client)
-    client.expects(:delete_assignment).with(200).once.returns(true)
-    # past (100) and tombstoned (300) must NOT be deleted
-    client.expects(:delete_assignment).with(100).never
-    client.expects(:delete_assignment).with(300).never
+    # Destroy makes NO Forecast API calls — every materialized assignment is a record of
+    # allocation that already happened, so it's left untouched; only tracking rows go.
+    Stacks::Forecast.expects(:new).never
+    Stacks::Forecast.expects(:delete).never
 
     ra.destroy!
-    assert_equal 0, RecurringAssignmentOccurrence.where(recurring_assignment_id: ra.id).count
+
+    assert_equal 0, RecurringAssignmentOccurrence.where(recurring_assignment_id: ra.id).count,
+      "occurrence tracking rows are removed, but the Forecast assignments remain"
   end
 end

--- a/test/models/recurring_assignment_destroy_test.rb
+++ b/test/models/recurring_assignment_destroy_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class RecurringAssignmentDestroyTest < ActiveSupport::TestCase
+  test "destroying a rule deletes future materialized occurrences from Forecast, not past ones" do
+    ra = RecurringAssignment.create!(
+      forecast_person_id: 1, forecast_project_id: 2, allocation: 900,
+      weekdays: [1], starts_on: Date.today - 30,
+    )
+    past   = ra.recurring_assignment_occurrences.create!(occurs_on: Date.today - 7, status: "materialized", forecast_assignment_id: 100)
+    future = ra.recurring_assignment_occurrences.create!(occurs_on: Date.today + 7, status: "materialized", forecast_assignment_id: 200)
+    tomb   = ra.recurring_assignment_occurrences.create!(occurs_on: Date.today + 8, status: "deleted",      forecast_assignment_id: 300)
+
+    client = Stacks::Forecast.allocate.tap { |c| c.instance_variable_set(:@headers, {}) }
+    Stacks::Forecast.stubs(:new).returns(client)
+    client.expects(:delete_assignment).with(200).once.returns(true)
+    # past (100) and tombstoned (300) must NOT be deleted
+    client.expects(:delete_assignment).with(100).never
+    client.expects(:delete_assignment).with(300).never
+
+    ra.destroy!
+    assert_equal 0, RecurringAssignmentOccurrence.where(recurring_assignment_id: ra.id).count
+  end
+end

--- a/test/models/recurring_assignment_materialize_test.rb
+++ b/test/models/recurring_assignment_materialize_test.rb
@@ -5,15 +5,21 @@ class RecurringAssignmentMaterializeTest < ActiveSupport::TestCase
     Stacks::Forecast.allocate.tap { |c| c.instance_variable_set(:@headers, {}) }
   end
 
+  # Monday of the current week — always on/before today (weeks start Monday),
+  # so it's a safe anchor for "retrospective" occurrence dates in any run.
+  def recent_monday
+    Date.today.beginning_of_week
+  end
+
   def rule(overrides = {})
     RecurringAssignment.create!({
       forecast_person_id: 324711, forecast_project_id: 3033811, allocation: 900,
-      weekdays: [1], starts_on: Date.new(2026, 8, 3), ends_on: Date.new(2026, 8, 24),
+      weekdays: [1], starts_on: recent_monday - 3.weeks, ends_on: nil,
     }.merge(overrides))
   end
 
-  test "creates one Forecast assignment per expected weekday and records occurrences" do
-    ra = rule # Mondays 2026-08-03,10,17,24 => 4 occurrences
+  test "creates one Forecast assignment per past weekday occurrence, up to today" do
+    ra = rule # Mondays: recent_monday-3w, -2w, -1w, recent_monday (all <= today)
     client = build_client
     client.expects(:create_assignment).times(4).returns(
       { "id" => 1 }, { "id" => 2 }, { "id" => 3 }, { "id" => 4 }
@@ -23,8 +29,22 @@ class RecurringAssignmentMaterializeTest < ActiveSupport::TestCase
 
     occ = ra.recurring_assignment_occurrences.order(:occurs_on)
     assert_equal 4, occ.count
-    assert_equal [Date.new(2026,8,3), Date.new(2026,8,10), Date.new(2026,8,17), Date.new(2026,8,24)], occ.map(&:occurs_on)
+    assert_equal [recent_monday - 3.weeks, recent_monday - 2.weeks, recent_monday - 1.week, recent_monday],
+      occ.map(&:occurs_on)
     assert occ.all? { |o| o.status == "materialized" && o.forecast_assignment_id.present? }
+    assert occ.all? { |o| o.occurs_on <= Date.today }, "no occurrence may be in the future"
+  end
+
+  test "never creates an occurrence after today, even with a future or blank end date" do
+    ra = rule(weekdays: (0..6).to_a, starts_on: Date.today - 2, ends_on: Date.today + 30)
+    client = build_client
+    client.stubs(:create_assignment).returns({ "id" => 1 })
+
+    ra.materialize!(forecast_client: client)
+
+    dates = ra.recurring_assignment_occurrences.order(:occurs_on).map(&:occurs_on)
+    assert_equal [Date.today - 2, Date.today - 1, Date.today], dates
+    assert dates.all? { |d| d <= Date.today }, "must never create a future-dated occurrence"
   end
 
   test "is idempotent — a second run POSTs nothing new" do
@@ -32,22 +52,23 @@ class RecurringAssignmentMaterializeTest < ActiveSupport::TestCase
     c1 = build_client
     c1.stubs(:create_assignment).returns({ "id" => 1 })
     ra.materialize!(forecast_client: c1)
-    assert_equal 4, ra.recurring_assignment_occurrences.count
+    count = ra.recurring_assignment_occurrences.count
+    assert count.positive?
 
     c2 = build_client
     c2.expects(:create_assignment).never
     ra.materialize!(forecast_client: c2)
-    assert_equal 4, ra.recurring_assignment_occurrences.count
+    assert_equal count, ra.recurring_assignment_occurrences.count
   end
 
   test "tombstones an occurrence whose Forecast assignment was deleted in the UI" do
-    ra = rule(ends_on: Date.new(2026, 8, 3)) # single Monday
+    ra = rule(starts_on: recent_monday - 1.week, ends_on: recent_monday)
     # present-in-mirror occurrence stays materialized; absent one gets tombstoned.
     # save!(validate: false) skips the required belongs_to person/project — we only
     # need a bare mirror row for the exists?(forecast_id:) check.
     ForecastAssignment.new(forecast_id: 555).save!(validate: false)
-    kept = ra.recurring_assignment_occurrences.create!(occurs_on: Date.new(2026, 8, 3), status: "materialized", forecast_assignment_id: 555)
-    gone = ra.recurring_assignment_occurrences.create!(occurs_on: Date.new(2026, 7, 27), status: "materialized", forecast_assignment_id: 999)
+    kept = ra.recurring_assignment_occurrences.create!(occurs_on: recent_monday, status: "materialized", forecast_assignment_id: 555)
+    gone = ra.recurring_assignment_occurrences.create!(occurs_on: recent_monday - 1.week, status: "materialized", forecast_assignment_id: 999)
 
     client = build_client
     client.expects(:create_assignment).never # both dates already have occurrence rows
@@ -58,8 +79,8 @@ class RecurringAssignmentMaterializeTest < ActiveSupport::TestCase
   end
 
   test "never recreates a tombstoned occurrence" do
-    ra = rule(ends_on: Date.new(2026, 8, 3)) # single Monday 08-03
-    ra.recurring_assignment_occurrences.create!(occurs_on: Date.new(2026, 8, 3), status: "deleted", forecast_assignment_id: 111)
+    ra = rule(starts_on: recent_monday, ends_on: recent_monday) # single past Monday
+    ra.recurring_assignment_occurrences.create!(occurs_on: recent_monday, status: "deleted", forecast_assignment_id: 111)
 
     client = build_client
     client.expects(:create_assignment).never
@@ -69,18 +90,13 @@ class RecurringAssignmentMaterializeTest < ActiveSupport::TestCase
     assert_equal "deleted", ra.recurring_assignment_occurrences.first.status
   end
 
-  test "open-ended rule stops at the 26-week horizon" do
-    ra = rule(starts_on: Date.today, ends_on: nil, weekdays: [Date.today.wday])
-    dates = ra.expected_occurrence_dates
-    assert dates.max <= Date.today + RecurringAssignment::HORIZON
-    assert dates.max > Date.today + (RecurringAssignment::HORIZON - 1.week)
-  end
-
-  test "does not tombstone a future occurrence merely absent from the month-bounded mirror" do
-    # Future-dated assignments are never in the ForecastAssignment mirror (sync only
-    # walks up to the current month), so absence must NOT be read as a UI deletion.
-    ra = rule(starts_on: Date.today, ends_on: Date.today)
-    future = ra.recurring_assignment_occurrences.create!(
+  test "does not tombstone an out-of-window occurrence absent from the mirror (defense-in-depth)" do
+    # Detection is bounded to end-of-current-month — the sync's coverage edge — so a
+    # row dated beyond it (which retrospect-only creation never produces, but which we
+    # guard against anyway) is never judged against the mirror and can't be falsely
+    # tombstoned. Permanent tombstones warrant the belt-and-suspenders.
+    ra = rule(starts_on: recent_monday, ends_on: recent_monday)
+    out_of_window = ra.recurring_assignment_occurrences.create!(
       occurs_on: Date.today.next_month.beginning_of_month + 10,
       status: "materialized", forecast_assignment_id: 424242,
     )
@@ -89,7 +105,7 @@ class RecurringAssignmentMaterializeTest < ActiveSupport::TestCase
 
     ra.materialize!(forecast_client: client)
 
-    assert_equal "materialized", future.reload.status, "future occurrence must not be falsely tombstoned"
+    assert_equal "materialized", out_of_window.reload.status
   end
 
   test "tombstones a past occurrence absent from the mirror" do

--- a/test/models/recurring_assignment_materialize_test.rb
+++ b/test/models/recurring_assignment_materialize_test.rb
@@ -75,4 +75,33 @@ class RecurringAssignmentMaterializeTest < ActiveSupport::TestCase
     assert dates.max <= Date.today + RecurringAssignment::HORIZON
     assert dates.max > Date.today + (RecurringAssignment::HORIZON - 1.week)
   end
+
+  test "does not tombstone a future occurrence merely absent from the month-bounded mirror" do
+    # Future-dated assignments are never in the ForecastAssignment mirror (sync only
+    # walks up to the current month), so absence must NOT be read as a UI deletion.
+    ra = rule(starts_on: Date.today, ends_on: Date.today)
+    future = ra.recurring_assignment_occurrences.create!(
+      occurs_on: Date.today.next_month.beginning_of_month + 10,
+      status: "materialized", forecast_assignment_id: 424242,
+    )
+    client = build_client
+    client.stubs(:create_assignment).returns({ "id" => 1 })
+
+    ra.materialize!(forecast_client: client)
+
+    assert_equal "materialized", future.reload.status, "future occurrence must not be falsely tombstoned"
+  end
+
+  test "tombstones a past occurrence absent from the mirror" do
+    ra = rule(starts_on: Date.today - 60, ends_on: Date.today - 60)
+    past = ra.recurring_assignment_occurrences.create!(
+      occurs_on: Date.today - 40, status: "materialized", forecast_assignment_id: 777,
+    )
+    client = build_client
+    client.stubs(:create_assignment).returns({ "id" => 1 })
+
+    ra.materialize!(forecast_client: client)
+
+    assert_equal "deleted", past.reload.status
+  end
 end

--- a/test/models/recurring_assignment_materialize_test.rb
+++ b/test/models/recurring_assignment_materialize_test.rb
@@ -1,0 +1,78 @@
+require "test_helper"
+
+class RecurringAssignmentMaterializeTest < ActiveSupport::TestCase
+  def build_client
+    Stacks::Forecast.allocate.tap { |c| c.instance_variable_set(:@headers, {}) }
+  end
+
+  def rule(overrides = {})
+    RecurringAssignment.create!({
+      forecast_person_id: 324711, forecast_project_id: 3033811, allocation: 900,
+      weekdays: [1], starts_on: Date.new(2026, 8, 3), ends_on: Date.new(2026, 8, 24),
+    }.merge(overrides))
+  end
+
+  test "creates one Forecast assignment per expected weekday and records occurrences" do
+    ra = rule # Mondays 2026-08-03,10,17,24 => 4 occurrences
+    client = build_client
+    client.expects(:create_assignment).times(4).returns(
+      { "id" => 1 }, { "id" => 2 }, { "id" => 3 }, { "id" => 4 }
+    )
+
+    ra.materialize!(forecast_client: client)
+
+    occ = ra.recurring_assignment_occurrences.order(:occurs_on)
+    assert_equal 4, occ.count
+    assert_equal [Date.new(2026,8,3), Date.new(2026,8,10), Date.new(2026,8,17), Date.new(2026,8,24)], occ.map(&:occurs_on)
+    assert occ.all? { |o| o.status == "materialized" && o.forecast_assignment_id.present? }
+  end
+
+  test "is idempotent — a second run POSTs nothing new" do
+    ra = rule
+    c1 = build_client
+    c1.stubs(:create_assignment).returns({ "id" => 1 })
+    ra.materialize!(forecast_client: c1)
+    assert_equal 4, ra.recurring_assignment_occurrences.count
+
+    c2 = build_client
+    c2.expects(:create_assignment).never
+    ra.materialize!(forecast_client: c2)
+    assert_equal 4, ra.recurring_assignment_occurrences.count
+  end
+
+  test "tombstones an occurrence whose Forecast assignment was deleted in the UI" do
+    ra = rule(ends_on: Date.new(2026, 8, 3)) # single Monday
+    # present-in-mirror occurrence stays materialized; absent one gets tombstoned.
+    # save!(validate: false) skips the required belongs_to person/project — we only
+    # need a bare mirror row for the exists?(forecast_id:) check.
+    ForecastAssignment.new(forecast_id: 555).save!(validate: false)
+    kept = ra.recurring_assignment_occurrences.create!(occurs_on: Date.new(2026, 8, 3), status: "materialized", forecast_assignment_id: 555)
+    gone = ra.recurring_assignment_occurrences.create!(occurs_on: Date.new(2026, 7, 27), status: "materialized", forecast_assignment_id: 999)
+
+    client = build_client
+    client.expects(:create_assignment).never # both dates already have occurrence rows
+    ra.materialize!(forecast_client: client)
+
+    assert_equal "materialized", kept.reload.status
+    assert_equal "deleted", gone.reload.status
+  end
+
+  test "never recreates a tombstoned occurrence" do
+    ra = rule(ends_on: Date.new(2026, 8, 3)) # single Monday 08-03
+    ra.recurring_assignment_occurrences.create!(occurs_on: Date.new(2026, 8, 3), status: "deleted", forecast_assignment_id: 111)
+
+    client = build_client
+    client.expects(:create_assignment).never
+    ra.materialize!(forecast_client: client)
+
+    assert_equal 1, ra.recurring_assignment_occurrences.count
+    assert_equal "deleted", ra.recurring_assignment_occurrences.first.status
+  end
+
+  test "open-ended rule stops at the 26-week horizon" do
+    ra = rule(starts_on: Date.today, ends_on: nil, weekdays: [Date.today.wday])
+    dates = ra.expected_occurrence_dates
+    assert dates.max <= Date.today + RecurringAssignment::HORIZON
+    assert dates.max > Date.today + (RecurringAssignment::HORIZON - 1.week)
+  end
+end

--- a/test/models/recurring_assignment_occurrence_test.rb
+++ b/test/models/recurring_assignment_occurrence_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class RecurringAssignmentOccurrenceTest < ActiveSupport::TestCase
+  setup do
+    @ra = RecurringAssignment.create!(
+      forecast_person_id: 1, forecast_project_id: 2, allocation: 900,
+      weekdays: [1], starts_on: Date.new(2026, 8, 3),
+    )
+  end
+
+  test "status must be a known value" do
+    occ = @ra.recurring_assignment_occurrences.new(occurs_on: Date.new(2026, 8, 3), status: "bogus")
+    assert_not occ.valid?
+  end
+
+  test "materialized/deleted scopes" do
+    m = @ra.recurring_assignment_occurrences.create!(occurs_on: Date.new(2026, 8, 3), status: "materialized")
+    d = @ra.recurring_assignment_occurrences.create!(occurs_on: Date.new(2026, 8, 10), status: "deleted")
+    assert_includes RecurringAssignmentOccurrence.materialized, m
+    assert_includes RecurringAssignmentOccurrence.deleted, d
+  end
+
+  test "occurs_on is unique per rule" do
+    @ra.recurring_assignment_occurrences.create!(occurs_on: Date.new(2026, 8, 3))
+    dup = @ra.recurring_assignment_occurrences.new(occurs_on: Date.new(2026, 8, 3))
+    assert_raises(ActiveRecord::RecordNotUnique) { dup.save!(validate: false) }
+  end
+end

--- a/test/models/recurring_assignment_test.rb
+++ b/test/models/recurring_assignment_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class RecurringAssignmentTest < ActiveSupport::TestCase
+  def valid_attrs(overrides = {})
+    { forecast_person_id: 1, forecast_project_id: 2, allocation: 28_800,
+      weekdays: [1, 2, 3, 4, 5], starts_on: Date.new(2026, 8, 3) }.merge(overrides)
+  end
+
+  test "valid with default attrs" do
+    assert RecurringAssignment.new(valid_attrs).valid?
+  end
+
+  test "requires positive integer allocation" do
+    assert_not RecurringAssignment.new(valid_attrs(allocation: 0)).valid?
+    assert_not RecurringAssignment.new(valid_attrs(allocation: nil)).valid?
+  end
+
+  test "weekdays must be present and within 0..6" do
+    assert_not RecurringAssignment.new(valid_attrs(weekdays: [])).valid?
+    assert_not RecurringAssignment.new(valid_attrs(weekdays: [7])).valid?
+    assert RecurringAssignment.new(valid_attrs(weekdays: [0, 6])).valid?
+  end
+
+  test "ends_on must not precede starts_on" do
+    assert_not RecurringAssignment.new(valid_attrs(ends_on: Date.new(2026, 8, 2))).valid?
+    assert RecurringAssignment.new(valid_attrs(ends_on: Date.new(2026, 8, 3))).valid?
+  end
+
+  test "active scope excludes paused rows" do
+    a = RecurringAssignment.create!(valid_attrs)
+    b = RecurringAssignment.create!(valid_attrs(paused_at: Time.current))
+    assert_includes RecurringAssignment.active, a
+    assert_not_includes RecurringAssignment.active, b
+  end
+
+  test "allocation_in_hours converts to/from seconds" do
+    ra = RecurringAssignment.new(valid_attrs(allocation: 28_800))
+    assert_equal 8.0, ra.allocation_in_hours
+    ra.allocation_in_hours = 4
+    assert_equal 14_400, ra.allocation
+  end
+end


### PR DESCRIPTION
## What this adds

A **Stacks-owned "recurring assignment"** that materializes concrete Forecast (Harvest) assignments via the `api.forecastapp.com` write API. You define a rule once (person, project, hours/day, weekdays, date window); a daily job creates one Forecast assignment per occurrence.

**Hard requirement, met:** deleting a materialized assignment directly in the Forecast UI **never** recreates it — it's tombstoned.

## How it works

- **`Stacks::Forecast`** gains write methods (`create_assignment`, `delete_assignment`) — it was previously read-only. (`delete_assignment` is 404-idempotent; currently a client primitive not called by this feature, kept for the imminent reconcile-on-drift work.)
- **`RecurringAssignment`** (the rule) + **`RecurringAssignmentOccurrence`** (one row per occurrence date, tracking the materialized `forecast_assignment_id` and a `materialized`/`deleted` status; unique on `(rule, date)`).
- **`RecurringAssignment#materialize!`** runs two ordered passes: **(1) deletion-detection** — a materialized occurrence absent from the local `ForecastAssignment` mirror is tombstoned; **(2) creation** — any expected weekday date without an occurrence row gets a 1-day Forecast assignment. A date that already has a row (materialized *or* deleted) is never (re)created.
- **Retrospect-only:** occurrences are created **only on/before today, never in advance.** A blank "Ends At" means *never ends* — the rule materializes each day's occurrence as that day arrives. There's no forward horizon. This also keeps deletion-detection sound: every occurrence is inside the sync's coverage window, so "absent from mirror" unambiguously means "deleted in the UI."
- **Wiring:** `materialize!` runs inline right after `Stacks::Forecast#sync_all!` in `stacks:daily_tasks`, so the mirror is fresh. No new scheduler entry.
- **Admin:** ActiveAdmin CRUD under Team → Recurring Assignments, with hours↔seconds conversion, weekday checkboxes, a **Materialize Now** button, pause/resume, and a show page listing occurrences with Forecast deep-links.
- **Destroy:** removing a rule stops future materialization and drops its local tracking rows, but **leaves all already-created Forecast assignments intact** — every occurrence is a historical record of allocation that happened.

## Design decisions

1. **One Forecast assignment per occurrence day** (clean 1:1 occurrence↔row↔tombstone; week-block batching is a future optimization).
2. **v1 respects deletes but does NOT reconcile edits** — editing a rule only affects not-yet-materialized occurrences; manual hour edits in Forecast are left alone.
3. **People only** (no placeholder assignees) in v1.
4. **Retrospect-only creation** — never creates future-dated assignments; blank end date = never ends.
5. **Destroy leaves Forecast assignments intact** (historical); only stops future materialization.
6. **Rides `daily_tasks`** (daily cadence) rather than a dedicated scheduler entry.

## Notable: a bug the adversarial review caught

An earlier iteration created future-dated assignments and treated "absent from the mirror" as "deleted." But the mirror sync only walks up to the current month, so every future occurrence would have been falsely tombstoned on the *second* daily run. Fixed first with a synced-window guard on detection, then more fundamentally by making creation retrospect-only — future rows never exist, so the failure mode is designed out. A defense-in-depth `end_of_month` guard on detection remains (a false tombstone is permanent).

## Testing

- 24 feature tests (Forecast writes + 4 recurring-assignment model test files), including the tombstone/no-recreate guarantee and the retrospect-only boundary; date-relative so they're stable across run dates. Broader safety net: **642 model + stacks-lib tests, 0 failures**. CI green.
- Write API validated live against Forecast (create/update/delete lifecycle, cleaned up) before building.

Spec: `docs/superpowers/specs/2026-07-30-recurring-forecast-assignments-design.md`
Plan: `docs/superpowers/plans/2026-07-30-recurring-forecast-assignments.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
