### PR TITLE
feat(resourcing): adopt-into-N — atomic multi-segment adopt (fixes #3 C1)

### DIFF
--- a/app/controllers/api/v1/projected_assignments_controller.rb
+++ b/app/controllers/api/v1/projected_assignments_controller.rb
@@ -50,6 +50,37 @@ class Api::V1::ProjectedAssignmentsController < ApiController
     render json: { results: results }, status: :ok
   end
 
+  # Atomic N-way split: replaces ONE human-authored Runn assignment with N
+  # stacksbot-owned rows via WriteThrough#adopt_into (see that method for the
+  # rollback ordering). Segments are upserted by source_key like upsert/batch,
+  # but validated as a whole BEFORE anything is saved or written to Runn —
+  # any invalid segment aborts the entire request with no side effects.
+  def adopt
+    adopt_expected = params[:adopt_expected]&.permit!&.to_h
+    rows = Array(params[:segments]).map do |seg|
+      permitted = seg.permit(:source_key, *ATTRS)
+      r = ProjectedAssignment.find_or_initialize_by(source_key: permitted[:source_key])
+      r.assign_attributes(permitted.except(:source_key).to_h.symbolize_keys)
+      r
+    end
+    invalid = rows.reject(&:valid?)
+    if invalid.any?
+      return render json: { results: invalid.map { |r| { status: "invalid", source_key: r.source_key, errors: r.errors.full_messages } } },
+        status: :unprocessable_entity
+    end
+
+    rows.each(&:save!)
+    results = write_through.adopt_into(rows: rows, adopt_expected: adopt_expected, preview: preview?)
+    render json: { results: rows.zip(results).map { |r, res|
+      { status: res.status.to_s, source_key: r.source_key, before: res.before,
+        after: res.after, runn_assignment_id: res.runn_assignment_id, conflict: res.conflict }.compact
+    } }, status: :ok
+  rescue Mcp::WriteGuard::CapExceeded => e
+    render json: { status: "error", error: e.message }, status: :unprocessable_entity
+  rescue Resourcing::WriteThrough::UnresolvedContributor, Resourcing::WriteThrough::UnresolvableRole => e
+    render json: { status: "error", error: e.message }, status: :unprocessable_entity
+  end
+
   private
 
   # Applies a single upsert. Returns a Hash whose :status is a String

--- a/app/controllers/api/v1/projected_assignments_controller.rb
+++ b/app/controllers/api/v1/projected_assignments_controller.rb
@@ -57,7 +57,13 @@ class Api::V1::ProjectedAssignmentsController < ApiController
   # any invalid segment aborts the entire request with no side effects.
   def adopt
     adopt_expected = params[:adopt_expected]&.permit!&.to_h
-    rows = Array(params[:segments]).map do |seg|
+    segments = Array(params[:segments])
+    if adopt_expected.blank? || segments.blank?
+      return render json: { status: "error", error: "adopt requires adopt_expected and at least one segment" },
+        status: :unprocessable_entity
+    end
+
+    rows = segments.map do |seg|
       permitted = seg.permit(:source_key, *ATTRS)
       r = ProjectedAssignment.find_or_initialize_by(source_key: permitted[:source_key])
       r.assign_attributes(permitted.except(:source_key).to_h.symbolize_keys)

--- a/app/services/resourcing/write_through.rb
+++ b/app/services/resourcing/write_through.rb
@@ -214,7 +214,9 @@ module Resourcing
       if live.nil? ||                                          # target gone → human already changed it
          live["note"].to_s.include?("[stacksbot:") ||          # already owned — never re-adopt
          !same_state?(live, adopt_expected) ||                 # target moved since the snapshot
-         fresh.any? { |r| r.runn_project_id.to_i != live["projectId"].to_i } # never split a human across projects
+         fresh.any? { |r| r.runn_project_id.to_i != live["projectId"].to_i } || # never split a human across projects
+         runn_person_id.to_i != live["personId"].to_i ||        # resolved person ≠ the human being replaced
+         fresh.any? { |r| r.contributor_id != fresh.first.contributor_id } # mixed contributors in one adopt group
         return fresh.each_with_object({}) { |r, h| h[r.source_key] = conflict(live) }
       end
 

--- a/app/services/resourcing/write_through.rb
+++ b/app/services/resourcing/write_through.rb
@@ -76,6 +76,40 @@ module Resourcing
       Result.new(status: :applied, before: current, after: new_hash, runn_assignment_id: new_hash["id"])
     end
 
+    # Adopts ONE human-authored Runn assignment into N stacksbot-owned
+    # projected_assignment rows, as a single atomic operation.
+    #
+    # Emitting N independent apply(adopt_expected:) calls for one human is
+    # unsafe: the first adopt deletes the human assignment and creates
+    # segment 1's replacement; every subsequent adopt then finds the target
+    # already gone and conflicts (or, worse, races another human edit into
+    # the gap) — data loss on segments 2..N. adopt_into instead treats the
+    # split as one unit: validate the WHOLE group against the live human
+    # snapshot up front (zero writes if any guard fails), then create every
+    # replacement assignment FIRST, and only once ALL creates have
+    # succeeded delete the original human assignment ONCE. Ordering matters
+    # for the rollback story:
+    #   - a create fails partway through  → roll back every create so far,
+    #     the human assignment is never touched, re-raise.
+    #   - all creates succeed but the single delete fails → roll back EVERY
+    #     created assignment (total rollback), the human assignment survives
+    #     untouched, re-raise.
+    # Either way, a failure anywhere leaves Runn exactly as it was before
+    # the call — never a half-adopted mess with some segments live and
+    # others missing.
+    #
+    # Rows that already own a Runn assignment are routed through the
+    # ordinary apply() path (no adopt) instead of group_adopt — this is
+    # what makes re-running adopt_into after a prior success a no-op rather
+    # than a re-adopt attempt against an already-consumed human assignment.
+    def adopt_into(rows:, adopt_expected:, preview: false)
+      owned, fresh = rows.partition(&:runn_assignment_id)
+      by_key = {}
+      owned.each { |r| by_key[r.source_key] = apply(r, preview: preview) }
+      by_key.merge!(group_adopt(fresh, adopt_expected, preview)) if fresh.any?
+      rows.map { |r| by_key[r.source_key] }
+    end
+
     # DELETE ?archive_runn=true — remove the owned Runn assignment, CAS-guarded.
     # Does NOT mutate/destroy the row — the caller destroys it only on non-conflict.
     def archive(row)
@@ -162,5 +196,76 @@ module Resourcing
     end
 
     def conflict(current) = Result.new(status: :conflict, conflict: current, before: current)
+
+    # The group half of adopt_into: takes the "fresh" (unowned) rows of a
+    # split, validates them as one unit against the live human snapshot,
+    # and either returns an all-conflict Hash (zero writes) or performs the
+    # create-all-then-delete-once sequence. Returns Hash{source_key => Result}.
+    def group_adopt(fresh, adopt_expected, preview)
+      runn_person_id = resolver.runn_person_id_for(fresh.first.contributor)
+      if runn_person_id.nil?
+        raise UnresolvedContributor,
+          "contributor #{fresh.first.contributor_id} has no unique active Runn person (email matched 0 or multiple)"
+      end
+
+      assignments = @runn.get_assignments
+      live = assignments.find { |a| a["id"] == adopt_expected["id"] }
+
+      if live.nil? ||                                          # target gone → human already changed it
+         live["note"].to_s.include?("[stacksbot:") ||          # already owned — never re-adopt
+         !same_state?(live, adopt_expected) ||                 # target moved since the snapshot
+         fresh.any? { |r| r.runn_project_id.to_i != live["projectId"].to_i } # never split a human across projects
+        return fresh.each_with_object({}) { |r, h| h[r.source_key] = conflict(live) }
+      end
+
+      role_id = live["roleId"]
+      desired_by_key = fresh.each_with_object({}) do |r, h|
+        h[r.source_key] = {
+          "personId" => runn_person_id, "projectId" => r.runn_project_id, "roleId" => role_id,
+          "startDate" => r.start_date.iso8601, "endDate" => r.end_date.iso8601,
+          "minutesPerDay" => r.minutes_per_day,
+        }
+      end
+
+      if preview
+        return fresh.each_with_object({}) do |r, h|
+          h[r.source_key] = Result.new(status: :preview, before: live, after: desired_by_key[r.source_key])
+        end
+      end
+
+      created = [] # [{ row:, hash: }, ...] in create order, for compensating rollback
+      begin
+        fresh.each do |row|
+          desired = desired_by_key[row.source_key]
+          Mcp::WriteGuard.check!
+          resp = @runn.create_assignment(
+            person_id: desired["personId"], project_id: desired["projectId"], role_id: role_id,
+            start_date: desired["startDate"], end_date: desired["endDate"],
+            minutes_per_day: desired["minutesPerDay"], note: provenance_note(row.source_key, row.note)
+          )
+          hash = normalize_created(resp, desired, row.source_key, row.note)
+          created << { row: row, hash: hash }
+        end
+      rescue StandardError => e
+        created.each { |c| @runn.delete_assignment(c[:hash]["id"]) rescue nil }
+        raise e
+      end
+
+      begin
+        Mcp::WriteGuard.check!
+        @runn.delete_assignment(live["id"])
+      rescue StandardError => e
+        # total rollback: every create succeeded but the one delete didn't —
+        # undo all of them so the human assignment is the only survivor.
+        created.each { |c| @runn.delete_assignment(c[:hash]["id"]) rescue nil }
+        raise e
+      end
+
+      created.each_with_object({}) do |c, h|
+        c[:row].update!(runn_assignment_id: c[:hash]["id"], last_synced_runn_state: c[:hash])
+        h[c[:row].source_key] =
+          Result.new(status: :applied, before: live, after: c[:hash], runn_assignment_id: c[:hash]["id"])
+      end
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
 
     namespace :v1 do
       post "projected_assignments/batch", to: "projected_assignments#batch", defaults: { format: :json }
+      post "projected_assignments/adopt", to: "projected_assignments#adopt", defaults: { format: :json }
       put "projected_assignments/*source_key", to: "projected_assignments#upsert", format: false, defaults: { format: :json }
       delete "projected_assignments/*source_key", to: "projected_assignments#destroy", format: false, defaults: { format: :json }
     end

--- a/test/integration/resourcing_projected_assignments_test.rb
+++ b/test/integration/resourcing_projected_assignments_test.rb
@@ -264,6 +264,50 @@ class ResourcingProjectedAssignmentsTest < ActionDispatch::IntegrationTest
     assert_equal "error", result["status"]
   end
 
+  test "POST adopt splits one human assignment into N owned segments" do
+    snapshot = { "id" => 9001, "personId" => 10, "projectId" => 91_100, "roleId" => 7,
+      "startDate" => "2030-01-01", "endDate" => "2030-12-31", "minutesPerDay" => 480, "note" => "hand-authored" }
+    Stacks::Runn.any_instance.stubs(:get_assignments).returns([snapshot])
+    Stacks::Runn.any_instance.stubs(:get_people).returns(people_stub(10))
+    Stacks::Runn.any_instance.expects(:create_assignment).twice.returns({ "id" => 9101 }, { "id" => 9102 })
+    Stacks::Runn.any_instance.expects(:delete_assignment).once.with(9001).returns({})
+    segments = [
+      body(start_date: "2030-01-01", end_date: "2030-08-31").merge(source_key: "adopt:seg:1"),
+      body(start_date: "2030-10-01", end_date: "2030-12-31").merge(source_key: "adopt:seg:2"),
+    ]
+    post "/api/v1/projected_assignments/adopt",
+      headers: auth_headers, params: { adopt_expected: snapshot, segments: segments }.to_json
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal 2, json["results"].size
+    results = json["results"].index_by { |r| r["source_key"] }
+    assert_equal "applied", results["adopt:seg:1"]["status"]
+    assert_equal "applied", results["adopt:seg:2"]["status"]
+    assert_equal 9101, ProjectedAssignment.find_by(source_key: "adopt:seg:1").runn_assignment_id
+    assert_equal 9102, ProjectedAssignment.find_by(source_key: "adopt:seg:2").runn_assignment_id
+  end
+
+  test "POST adopt with all-invalid segments returns 422, per-segment errors, and writes nothing" do
+    snapshot = { "id" => 9001, "personId" => 10, "projectId" => 91_100, "roleId" => 7,
+      "startDate" => "2030-01-01", "endDate" => "2030-12-31", "minutesPerDay" => 480, "note" => "hand-authored" }
+    Stacks::Runn.any_instance.expects(:create_assignment).never
+    Stacks::Runn.any_instance.expects(:delete_assignment).never
+    segments = [
+      body(minutes_per_day: 9999).merge(source_key: "adopt:bad:1"),
+      body(end_date: "2020-01-01").merge(source_key: "adopt:bad:2"), # end before start
+    ]
+    post "/api/v1/projected_assignments/adopt",
+      headers: auth_headers, params: { adopt_expected: snapshot, segments: segments }.to_json
+    assert_response :unprocessable_entity
+    json = JSON.parse(response.body)
+    results = json["results"].index_by { |r| r["source_key"] }
+    assert_equal "invalid", results["adopt:bad:1"]["status"]
+    assert_equal "invalid", results["adopt:bad:2"]["status"]
+    assert results["adopt:bad:1"]["errors"].present?
+    assert_nil ProjectedAssignment.find_by(source_key: "adopt:bad:1")
+    assert_nil ProjectedAssignment.find_by(source_key: "adopt:bad:2")
+  end
+
   test "POST batch marks remaining items deferred when WriteGuard cap is hit" do
     store = ActiveSupport::Cache::MemoryStore.new
     Rails.stubs(:cache).returns(store)

--- a/test/integration/resourcing_projected_assignments_test.rb
+++ b/test/integration/resourcing_projected_assignments_test.rb
@@ -308,6 +308,32 @@ class ResourcingProjectedAssignmentsTest < ActionDispatch::IntegrationTest
     assert_nil ProjectedAssignment.find_by(source_key: "adopt:bad:2")
   end
 
+  test "POST adopt without adopt_expected returns 422 and writes nothing" do
+    Stacks::Runn.any_instance.expects(:create_assignment).never
+    Stacks::Runn.any_instance.expects(:delete_assignment).never
+    segments = [
+      body(start_date: "2030-01-01", end_date: "2030-08-31").merge(source_key: "adopt:noexp:1"),
+    ]
+    post "/api/v1/projected_assignments/adopt",
+      headers: auth_headers, params: { segments: segments }.to_json
+    assert_response :unprocessable_entity
+    json = JSON.parse(response.body)
+    assert_equal "error", json["status"]
+    assert_nil ProjectedAssignment.find_by(source_key: "adopt:noexp:1")
+  end
+
+  test "POST adopt with empty segments returns 422 and writes nothing" do
+    snapshot = { "id" => 9001, "personId" => 10, "projectId" => 91_100, "roleId" => 7,
+      "startDate" => "2030-01-01", "endDate" => "2030-12-31", "minutesPerDay" => 480, "note" => "hand-authored" }
+    Stacks::Runn.any_instance.expects(:create_assignment).never
+    Stacks::Runn.any_instance.expects(:delete_assignment).never
+    post "/api/v1/projected_assignments/adopt",
+      headers: auth_headers, params: { adopt_expected: snapshot, segments: [] }.to_json
+    assert_response :unprocessable_entity
+    json = JSON.parse(response.body)
+    assert_equal "error", json["status"]
+  end
+
   test "POST batch marks remaining items deferred when WriteGuard cap is hit" do
     store = ActiveSupport::Cache::MemoryStore.new
     Rails.stubs(:cache).returns(store)

--- a/test/services/resourcing/write_through_test.rb
+++ b/test/services/resourcing/write_through_test.rb
@@ -301,4 +301,158 @@ class Resourcing::WriteThroughTest < ActiveSupport::TestCase
     runn.expects(:delete_assignment).never
     assert_equal :noop, service(runn).archive(w).status
   end
+
+  # --- adopt_into: atomic N-way split of one human assignment ---
+
+  test "adopt_into: splits one human assignment into N owned segments (creates first, deletes once)" do
+    tr = tracker
+    c = contributor_for(10)
+    snapshot = human(9001, Date.new(2030, 1, 1), Date.new(2030, 12, 31))
+    r1 = row(tr, Date.new(2030, 1, 1), Date.new(2030, 8, 31), contributor: c, key: "seg:1")
+    r2 = row(tr, Date.new(2030, 10, 1), Date.new(2030, 12, 31), contributor: c, key: "seg:2")
+    runn = mock("runn")
+    runn.stubs(:get_assignments).returns([snapshot])
+    runn.stubs(:get_people).returns(people_stub(10))
+    runn.expects(:create_assignment).twice.returns({ "id" => 9101 }, { "id" => 9102 })
+    runn.expects(:delete_assignment).once.with(9001).returns({})
+    results = service(runn).adopt_into(rows: [r1, r2], adopt_expected: snapshot)
+    assert_equal [:applied, :applied], results.map(&:status)
+    assert_equal 9101, r1.reload.runn_assignment_id
+    assert_equal 9102, r2.reload.runn_assignment_id
+    assert r1.last_synced_runn_state.present?
+    assert r2.last_synced_runn_state.present?
+    assert_equal snapshot, results[0].before
+    assert_equal snapshot, results[1].before
+  end
+
+  test "adopt_into: group CAS conflict (target moved since snapshot) → all segments conflict, no writes" do
+    tr = tracker
+    c = contributor_for(10)
+    snapshot = human(9001, Date.new(2030, 1, 1), Date.new(2030, 12, 31))
+    moved    = human(9001, Date.new(2030, 1, 1), Date.new(2030, 10, 15))
+    r1 = row(tr, Date.new(2030, 1, 1), Date.new(2030, 8, 31), contributor: c, key: "seg:1")
+    r2 = row(tr, Date.new(2030, 10, 1), Date.new(2030, 12, 31), contributor: c, key: "seg:2")
+    runn = mock("runn")
+    runn.stubs(:get_assignments).returns([moved])
+    runn.stubs(:get_people).returns(people_stub(10))
+    runn.expects(:create_assignment).never
+    runn.expects(:delete_assignment).never
+    results = service(runn).adopt_into(rows: [r1, r2], adopt_expected: snapshot)
+    assert_equal [:conflict, :conflict], results.map(&:status)
+  end
+
+  test "adopt_into: target vanished from Runn → all segments conflict, no writes" do
+    tr = tracker
+    c = contributor_for(10)
+    snapshot = human(9001, Date.new(2030, 1, 1), Date.new(2030, 12, 31))
+    r1 = row(tr, Date.new(2030, 1, 1), Date.new(2030, 8, 31), contributor: c, key: "seg:1")
+    r2 = row(tr, Date.new(2030, 10, 1), Date.new(2030, 12, 31), contributor: c, key: "seg:2")
+    runn = mock("runn")
+    runn.stubs(:get_assignments).returns([])
+    runn.stubs(:get_people).returns(people_stub(10))
+    runn.expects(:create_assignment).never
+    runn.expects(:delete_assignment).never
+    results = service(runn).adopt_into(rows: [r1, r2], adopt_expected: snapshot)
+    assert_equal [:conflict, :conflict], results.map(&:status)
+  end
+
+  test "adopt_into: target already stacksbot-owned (marked) → all segments conflict, no writes" do
+    tr = tracker
+    c = contributor_for(10)
+    owned = human(9001, Date.new(2030, 1, 1), Date.new(2030, 12, 31)).merge(
+      "note" => Resourcing::WriteThrough.provenance_marker("some-other-key"))
+    r1 = row(tr, Date.new(2030, 1, 1), Date.new(2030, 8, 31), contributor: c, key: "seg:1")
+    r2 = row(tr, Date.new(2030, 10, 1), Date.new(2030, 12, 31), contributor: c, key: "seg:2")
+    runn = mock("runn")
+    runn.stubs(:get_assignments).returns([owned])
+    runn.stubs(:get_people).returns(people_stub(10))
+    runn.expects(:create_assignment).never
+    runn.expects(:delete_assignment).never
+    results = service(runn).adopt_into(rows: [r1, r2], adopt_expected: owned)
+    assert_equal [:conflict, :conflict], results.map(&:status)
+  end
+
+  test "adopt_into: a segment on a different project than the human → all segments conflict, no writes" do
+    tr = tracker
+    other_tr = tracker(runn_project_id: 91_200)
+    c = contributor_for(10)
+    snapshot = human(9001, Date.new(2030, 1, 1), Date.new(2030, 12, 31)) # project 91_100
+    r1 = row(tr, Date.new(2030, 1, 1), Date.new(2030, 8, 31), contributor: c, key: "seg:1")
+    r2 = row(other_tr, Date.new(2030, 10, 1), Date.new(2030, 12, 31), contributor: c, key: "seg:2")
+    runn = mock("runn")
+    runn.stubs(:get_assignments).returns([snapshot])
+    runn.stubs(:get_people).returns(people_stub(10))
+    runn.expects(:create_assignment).never
+    runn.expects(:delete_assignment).never
+    results = service(runn).adopt_into(rows: [r1, r2], adopt_expected: snapshot)
+    assert_equal [:conflict, :conflict], results.map(&:status)
+  end
+
+  test "adopt_into: create failure rolls back prior creates, leaves the human assignment untouched" do
+    tr = tracker
+    c = contributor_for(10)
+    snapshot = human(9001, Date.new(2030, 1, 1), Date.new(2030, 12, 31))
+    r1 = row(tr, Date.new(2030, 1, 1), Date.new(2030, 8, 31), contributor: c, key: "seg:1")
+    r2 = row(tr, Date.new(2030, 10, 1), Date.new(2030, 12, 31), contributor: c, key: "seg:2")
+    runn = mock("runn")
+    runn.stubs(:get_assignments).returns([snapshot])
+    runn.stubs(:get_people).returns(people_stub(10))
+    seq = sequence("adopt_into")
+    runn.expects(:create_assignment).in_sequence(seq).returns({ "id" => 9101 })
+    runn.expects(:create_assignment).in_sequence(seq).raises(RuntimeError, "runn 500")
+    runn.expects(:delete_assignment).with(9101).once.returns({}) # compensating rollback of the first create
+    runn.expects(:delete_assignment).with(9001).never             # human never touched
+    assert_raises(RuntimeError) { service(runn).adopt_into(rows: [r1, r2], adopt_expected: snapshot) }
+    assert_nil r1.reload.runn_assignment_id
+    assert_nil r2.reload.runn_assignment_id
+  end
+
+  test "adopt_into: final delete failure rolls back ALL creates (total rollback)" do
+    tr = tracker
+    c = contributor_for(10)
+    snapshot = human(9001, Date.new(2030, 1, 1), Date.new(2030, 12, 31))
+    r1 = row(tr, Date.new(2030, 1, 1), Date.new(2030, 8, 31), contributor: c, key: "seg:1")
+    r2 = row(tr, Date.new(2030, 10, 1), Date.new(2030, 12, 31), contributor: c, key: "seg:2")
+    runn = mock("runn")
+    runn.stubs(:get_assignments).returns([snapshot])
+    runn.stubs(:get_people).returns(people_stub(10))
+    runn.expects(:create_assignment).twice.returns({ "id" => 9101 }, { "id" => 9102 })
+    runn.expects(:delete_assignment).with(9001).raises(RuntimeError, "runn 500")
+    runn.expects(:delete_assignment).with(9101).once.returns({})
+    runn.expects(:delete_assignment).with(9102).once.returns({})
+    assert_raises(RuntimeError) { service(runn).adopt_into(rows: [r1, r2], adopt_expected: snapshot) }
+    assert_nil r1.reload.runn_assignment_id
+    assert_nil r2.reload.runn_assignment_id
+  end
+
+  test "adopt_into: an already-owned row re-runs through apply() as a no-op (idempotent re-run)" do
+    tr = tracker
+    c = contributor_for(10)
+    base = live(9101, "seg:1", Date.new(2030, 1, 1), Date.new(2030, 8, 31))
+    r1 = row(tr, Date.new(2030, 1, 1), Date.new(2030, 8, 31), contributor: c, owned_id: 9101, baseline: base, key: "seg:1")
+    runn = mock("runn")
+    runn.stubs(:get_assignments).returns([live(9101, "seg:1", Date.new(2030, 1, 1), Date.new(2030, 8, 31))])
+    runn.stubs(:get_people).returns(people_stub(10))
+    runn.expects(:create_assignment).never
+    runn.expects(:delete_assignment).never
+    results = service(runn).adopt_into(rows: [r1], adopt_expected: { "id" => 9999 })
+    assert_equal [:noop], results.map(&:status)
+  end
+
+  test "adopt_into preview: computes the delta for every segment but writes nothing" do
+    tr = tracker
+    c = contributor_for(10)
+    snapshot = human(9001, Date.new(2030, 1, 1), Date.new(2030, 12, 31))
+    r1 = row(tr, Date.new(2030, 1, 1), Date.new(2030, 8, 31), contributor: c, key: "seg:1")
+    r2 = row(tr, Date.new(2030, 10, 1), Date.new(2030, 12, 31), contributor: c, key: "seg:2")
+    runn = mock("runn")
+    runn.stubs(:get_assignments).returns([snapshot])
+    runn.stubs(:get_people).returns(people_stub(10))
+    runn.expects(:create_assignment).never
+    runn.expects(:delete_assignment).never
+    results = service(runn).adopt_into(rows: [r1, r2], adopt_expected: snapshot, preview: true)
+    assert_equal [:preview, :preview], results.map(&:status)
+    assert_nil r1.reload.runn_assignment_id
+    assert_nil r2.reload.runn_assignment_id
+  end
 end

--- a/test/services/resourcing/write_through_test.rb
+++ b/test/services/resourcing/write_through_test.rb
@@ -439,6 +439,37 @@ class Resourcing::WriteThroughTest < ActiveSupport::TestCase
     assert_equal [:noop], results.map(&:status)
   end
 
+  test "adopt_into: resolved person differs from the live assignment's personId → all segments conflict, no writes" do
+    tr = tracker
+    c = contributor_for(11) # resolves to runn person 11 ("Bob")
+    snapshot = human(9001, Date.new(2030, 1, 1), Date.new(2030, 12, 31), person: 10) # live assignment belongs to person 10 ("Alice")
+    r1 = row(tr, Date.new(2030, 1, 1), Date.new(2030, 8, 31), contributor: c, key: "seg:1")
+    r2 = row(tr, Date.new(2030, 10, 1), Date.new(2030, 12, 31), contributor: c, key: "seg:2")
+    runn = mock("runn")
+    runn.stubs(:get_assignments).returns([snapshot])
+    runn.stubs(:get_people).returns(people_stub(11))
+    runn.expects(:create_assignment).never
+    runn.expects(:delete_assignment).never
+    results = service(runn).adopt_into(rows: [r1, r2], adopt_expected: snapshot)
+    assert_equal [:conflict, :conflict], results.map(&:status)
+  end
+
+  test "adopt_into: mixed contributors across segments → all conflict, no writes" do
+    tr = tracker
+    c1 = contributor_for(10)
+    c2 = contributor_for(11)
+    snapshot = human(9001, Date.new(2030, 1, 1), Date.new(2030, 12, 31), person: 10)
+    r1 = row(tr, Date.new(2030, 1, 1), Date.new(2030, 8, 31), contributor: c1, key: "seg:1")
+    r2 = row(tr, Date.new(2030, 10, 1), Date.new(2030, 12, 31), contributor: c2, key: "seg:2")
+    runn = mock("runn")
+    runn.stubs(:get_assignments).returns([snapshot])
+    runn.stubs(:get_people).returns(people_stub(10)) # resolver only resolves fresh.first's contributor (c1 → person 10)
+    runn.expects(:create_assignment).never
+    runn.expects(:delete_assignment).never
+    results = service(runn).adopt_into(rows: [r1, r2], adopt_expected: snapshot)
+    assert_equal [:conflict, :conflict], results.map(&:status)
+  end
+
   test "adopt_into preview: computes the delta for every segment but writes nothing" do
     tr = tracker
     c = contributor_for(10)


### PR DESCRIPTION
## Why
The #3 "structured Observe capture" whole-branch review found a **Critical** data-loss bug in the multi-segment adopt path: a mid-window PTO or `reduced` intent emitted N independent single-adopt recipes, each carrying the *same* snapshot of the *one* human assignment. Recipe 1 adopts it (deletes the human); recipes 2..N then find it gone → CAS conflict → dropped. Net: the person is left **unallocated after their PTO/window** — worse than before — with a false "hand-edited" audit reason.

## What
New **atomic** primitive `Resourcing::WriteThrough#adopt_into(rows:, adopt_expected:, preview:)` — replaces ONE human Runn assignment with N stacksbot-owned segments in a single guarded operation:
- Partitions rows into already-owned (→ existing idempotent `apply`, so re-runs are no-ops) and fresh.
- **Group guards** (all-or-nothing → every fresh row `:conflict`, zero writes): human gone / already stacksbot-owned / `!same_state?` (moved since snapshot) / any segment's project ≠ human's project / **resolved person ≠ human's person** / mixed contributors.
- **Create-all-first → delete-human-once**, with compensating rollback: create-loop failure deletes the already-created + leaves the human untouched; human-delete failure deletes all created (total rollback).
- New endpoint `POST /api/v1/projected_assignments/adopt` `{ adopt_expected, segments: [...] }`; validates all segments before any write (malformed → 422, no writes). Existing single-shot `PUT …/{source_key}` + `adopt_expected` path unchanged.

Additive, no migration.

## Tests
`bin/rails test test/services/resourcing/ test/integration/resourcing_projected_assignments_test.rb` green — applies (1→N, human deleted once, all marked+persisted); every group-conflict guard (human moved/gone/owned, project mismatch, person mismatch, mixed contributors); create-failure + delete-failure rollbacks; idempotent owned re-run → noop; preview → no writes; endpoint validation.

Reviewed adversarially (verdict READY); the person-identity guard (F1) was added on review — for a primitive whose failure mode is "a person's real allocation destroyed," it ties the created person to the deleted one, the one hole the CAS snapshot didn't cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)