### PR TITLE
feat(surveys): lower elevated-service bar to 1 qualifying month

### DIFF
--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -2,9 +2,9 @@ class Contributor < ApplicationRecord
   ELEVATED_SERVICE_MIN_HOURS  = 120
   ELEVATED_SERVICE_MIN_INCOME = 9_000
   # How many of the supplied months must individually meet the threshold for a
-  # contributor to count as "in elevated service" over the window (e.g. 3 of the
+  # contributor to count as "in elevated service" over the window (e.g. 1 of the
   # trailing 6 months). Callers choose the window length by how many periods they pass.
-  ELEVATED_SERVICE_MIN_QUALIFYING_MONTHS = 3
+  ELEVATED_SERVICE_MIN_QUALIFYING_MONTHS = 1
 
   def self.elevated_service?(total_hours:, total_income:)
     total_hours >= ELEVATED_SERVICE_MIN_HOURS || total_income >= ELEVATED_SERVICE_MIN_INCOME

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -48,7 +48,7 @@ class Survey < ApplicationRecord
     ref = reference_date.beginning_of_month
     # The trailing 6 completed months before reference_date. A contributor counts as
     # "elevated" if they met the threshold in at least
-    # Contributor::ELEVATED_SERVICE_MIN_QUALIFYING_MONTHS (3) of these.
+    # Contributor::ELEVATED_SERVICE_MIN_QUALIFYING_MONTHS (1) of these.
     # NOTE: Stacks::Period.for_gradation excludes the month CONTAINING `through`
     # (it stops at through.last_month.end_of_month), so passing `ref` (first of the
     # current month) yields exactly the 6 completed months before it.

--- a/test/models/contributor_test.rb
+++ b/test/models/contributor_test.rb
@@ -436,7 +436,7 @@ class ContributorElevatedServiceAdminUserIdsTest < ActiveSupport::TestCase
     ).save!(validate: false)
   end
 
-  test "elevated_service_admin_user_ids includes a contributor elevated in at least 3 of the months" do
+  test "elevated_service_admin_user_ids includes a contributor elevated in at least 1 of the months" do
     au = AdminUser.create!(email: "heavy@sanctuary.computer", password: "password12345", password_confirmation: "password12345")
     fp = ForecastPerson.create!(forecast_id: 55_501, email: au.email, first_name: "H", last_name: "Y")
     contributor = Contributor.create!(forecast_person: fp)
@@ -447,25 +447,23 @@ class ContributorElevatedServiceAdminUserIdsTest < ActiveSupport::TestCase
     periods = Stacks::Period.for_gradation(:month, Date.new(2026, 1, 1), Date.new(2026, 7, 1))
     assert_equal 6, periods.size
 
-    # $9000 income in exactly 3 of the 6 months -> qualifies (>= 3 of 6)
-    [periods[0], periods[2], periods[4]].each do |p|
-      create_payout!(p, 9_000, ledger, au)
-    end
+    # $9000 income in exactly 1 of the 6 months -> qualifies (>= 1 of 6)
+    create_payout!(periods[2], 9_000, ledger, au)
 
     ids = Contributor.elevated_service_admin_user_ids(periods, [fp.forecast_id])
     assert_includes ids, au.id
   end
 
-  test "elevated_service_admin_user_ids excludes a contributor elevated in fewer than 3 months" do
+  test "elevated_service_admin_user_ids excludes a contributor with no elevated months" do
     au = AdminUser.create!(email: "gap@sanctuary.computer", password: "password12345", password_confirmation: "password12345")
     fp = ForecastPerson.create!(forecast_id: 55_502, email: au.email, first_name: "G", last_name: "P")
     contributor = Contributor.create!(forecast_person: fp)
     ledger = contributor.ledgers.find_by!(enterprise: @sanctuary)
 
     periods = Stacks::Period.for_gradation(:month, Date.new(2026, 1, 1), Date.new(2026, 7, 1))
-    # Only 2 of the 6 months have income -> below the 3-month bar.
+    # Income in the window, but never meeting the monthly threshold -> no elevated months.
     [periods[0], periods[2]].each do |p|
-      create_payout!(p, 9_000, ledger, au)
+      create_payout!(p, 8_000, ledger, au)
     end
 
     ids = Contributor.elevated_service_admin_user_ids(periods, [fp.forecast_id])

--- a/test/models/survey_test.rb
+++ b/test/models/survey_test.rb
@@ -44,7 +44,7 @@ class SurveyTest < ActiveSupport::TestCase
 
     # Qualify via the HOURS path (avoids the payout/ledger/qbo fixture chain):
     # one assignment spanning 3 of the 6 window months, 8h/day => ~240h each >= 120,
-    # so 3 of 6 months are elevated (meets the >= 3 bar).
+    # so 3 of 6 months are elevated (meets the >= 1 bar).
     project = ForecastProject.new(forecast_id: 77_601, name: "Client Work", client_id: 123_456)
     project.save!(validate: false)
     fa = ForecastAssignment.new(


### PR DESCRIPTION
## Summary
- Lowers `Contributor::ELEVATED_SERVICE_MIN_QUALIFYING_MONTHS` from 3 → 1.
- Studio-wide survey audiences (Stacks admin tasks + Thursday Twist nags) now include anyone with **≥1 elevated month** (≥120 billed hours or ≥$9k income) in the trailing 6 completed months, instead of requiring 3.
- This pulls occasional New Deal contributors into the survey cohort ahead of the upcoming companywide survey.

The constant is only consumed by the survey expected-responder logic (`Survey#expected_responder?` / `#expected_responder_status` via `Contributor.elevated_service_admin_user_ids`), so no other features change.

## Testing
- Updated `contributor_test.rb` to pin the new bar from both sides: qualifies with exactly 1 month of $9k income; excluded when no month meets the threshold.
- `bin/rails test test/models/contributor_test.rb test/models/survey_test.rb` — 31 runs, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)