### PR TITLE
fix(forecast,twist): https base_uri so writes don't die on the http->https redirect

### DIFF
--- a/lib/stacks/forecast.rb
+++ b/lib/stacks/forecast.rb
@@ -1,6 +1,6 @@
 class Stacks::Forecast
   include HTTParty
-  base_uri 'api.forecastapp.com'
+  base_uri 'https://api.forecastapp.com'
 
   def initialize()
     @headers = {

--- a/lib/stacks/twist.rb
+++ b/lib/stacks/twist.rb
@@ -1,6 +1,6 @@
 class Stacks::Twist
   include HTTParty
-  base_uri 'api.twist.com/api/v3'
+  base_uri 'https://api.twist.com/api/v3'
 
   def initialize()
     @headers = {

--- a/test/lib/stacks/https_base_uri_test.rb
+++ b/test/lib/stacks/https_base_uri_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+# Regression guard for a silent, production-only class of bug:
+#
+# A scheme-less HTTParty `base_uri` (e.g. "api.forecastapp.com") defaults to
+# http://. Forecast (and Twist) 301-redirect http -> https. GETs survive the
+# redirect, but a redirected POST/PUT/DELETE arrives malformed and the API
+# returns 400 — so READS work while WRITES silently fail. Stubbed unit tests
+# never catch it because they don't hit the network; it only surfaces against
+# the live API. `Stacks::Forecast#create_assignment` hitting this is exactly
+# what stopped recurring-assignment materialization from reaching Forecast.
+#
+# Pin every HTTParty API client to an explicit https base_uri.
+class Stacks::HttpsBaseUriTest < ActiveSupport::TestCase
+  CLIENTS = [
+    Stacks::Forecast,
+    Stacks::Twist,
+    Stacks::Runn,
+    Stacks::Deel,
+    Stacks::Notion,
+    Stacks::Apollo,
+  ].freeze
+
+  test "every HTTParty API client uses an https base_uri (writes must not ride an http->https redirect)" do
+    CLIENTS.each do |klass|
+      assert klass.base_uri.to_s.start_with?("https://"),
+        "#{klass}.base_uri must be https to avoid write-mangling redirects; got #{klass.base_uri.inspect}"
+    end
+  end
+end


### PR DESCRIPTION
## The bug

`Stacks::Forecast` declared `base_uri 'api.forecastapp.com'` — **no scheme**, so HTTParty defaulted to `http://`. Forecast **301-redirects http → https**. GETs survive the redirect (reads worked), but a redirected **POST arrives malformed and Forecast returns `400 Bad Request`**. So:

- `create_assignment` raised on the 400, and `RecurringAssignment#materialize!`'s per-occurrence `rescue => e; Sentry.capture_exception(e)` swallowed it — **no occurrence recorded, no Forecast assignment, nothing in the admin UI.**
- This affects **every Forecast write** through the class: recurring-assignment materialization, the provisioning tools (create project/client/workstream/rate), and the write-through work. It passed CI the whole time because the tests stub the HTTP layer — it only surfaces against the live API.

### Verified live (against the real account)
| Request | Result |
|---|---|
| via the class (`http` → 301 → `https`) | **400 Bad Request** (malformed) |
| direct `https://…/assignments`, same body/headers | **201 Created** |

## The fix

One line each: `base_uri 'https://api.forecastapp.com'` and — same scheme-less pattern, also a writer — `base_uri 'https://api.twist.com/api/v3'`. Every other API client (Runn, Deel, Notion, Apollo) already used `https://`.

Added `test/lib/stacks/https_base_uri_test.rb` — a guard that fails if any HTTParty client's `base_uri` isn't `https://`, so this silent-write-failure class can't return.

## Testing

Guard test fails on the old code (`got "http://api.forecastapp.com"`), passes after. Full `test/lib/stacks` suite green (284 runs, 0 failures). No behavior change for reads; writes now hit https directly instead of a mangling redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
