### PR TITLE
feat(surveys): add "Respond anyway" link for off-audience members

### DIFF
--- a/app/admin/surveys.rb
+++ b/app/admin/surveys.rb
@@ -104,14 +104,13 @@ ActiveAdmin.register Survey do
       if resource.status == :draft
         # No options
       elsif resource.status == :open
-        if resource.expected_responder?(current_admin_user)
-          if SurveyResponder.find_by(survey: resource, admin_user: current_admin_user).present?
-            span("✓ Responded", class: "pill yes")
-          else
-            link_to "Submit Response →", new_admin_survey_response_path(survey_id: resource.id)
-          end
+        if SurveyResponder.find_by(survey: resource, admin_user: current_admin_user).present?
+          span("✓ Responded", class: "pill yes")
+        elsif resource.expected_responder?(current_admin_user)
+          link_to "Submit Response →", new_admin_survey_response_path(survey_id: resource.id)
         else
-          "You aren't required to respond to this survey"
+          span("You aren't required to respond to this survey. ")
+          text_node link_to("Respond anyway →", new_admin_survey_response_path(survey_id: resource.id))
         end
       else
         # Closed

--- a/app/views/admin/surveys/_show.html.erb
+++ b/app/views/admin/surveys/_show.html.erb
@@ -24,6 +24,9 @@
     <div class="dashboard-module">
       <div class="module-body factoid-parent">
         <p>🍃 <strong>Note!</strong> You aren't required to respond to this survey.</p>
+        <% if resource.status == :open && survey_responder.nil? %>
+          <%= link_to "Respond anyway →", new_admin_survey_response_path(survey_id: resource.id) %>
+        <% end %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Off-audience members viewing an open survey used to hit a dead end: "You aren't required to respond to this survey." Submission was never actually gated — `app/admin/survey_responses.rb` only blocks double-submits and non-open surveys, and extra respondents already file under **Other respondents** without inflating expected counts. This PR just surfaces that path with a **Respond anyway →** link.
- Shown on both the survey show page and the surveys index `Respond` column, only while the survey is open and the viewer hasn't already responded.
- Also reorders the index column checks so someone outside the expected audience who *has* responded sees the "✓ Responded" pill instead of the "not required" text.

## Context
Prompted by connor@xxix.co: he misses the elevated-service window for the 2026 surveys (opened Jul 31, window Jan–Jun; his only active month, June, came in at 86h / $8.6k vs the 120h / $9k bar), so he isn't required — but should still be able to opt in easily.

## Testing
- `ruby -c` on `app/admin/surveys.rb` and ERB compile check on the edited partial both pass.
- View-only change; no model/controller behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)