### PR TITLE
feat(resourcing): relinquish — yield an owned assignment when a human hand-edits it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ yarn-debug.log*
 .yarn-integrity
 .DS_Store
 .superpowers/
+
+.claude/

--- a/app/controllers/api/v1/projected_assignments_controller.rb
+++ b/app/controllers/api/v1/projected_assignments_controller.rb
@@ -66,7 +66,9 @@ class Api::V1::ProjectedAssignmentsController < ApiController
     rows = segments.map do |seg|
       permitted = seg.permit(:source_key, *ATTRS)
       r = ProjectedAssignment.find_or_initialize_by(source_key: permitted[:source_key])
-      r.assign_attributes(permitted.except(:source_key).to_h.symbolize_keys)
+      # never let an upsert overwrite a permanently-yielded row (WriteThrough#apply
+      # then no-ops it via the owned partition); leaving managed_by intact is the guard.
+      r.assign_attributes(permitted.except(:source_key).to_h.symbolize_keys) unless r.managed_by == "relinquished"
       r
     end
     invalid = rows.reject(&:valid?)
@@ -95,6 +97,11 @@ class Api::V1::ProjectedAssignmentsController < ApiController
   def apply_one(attrs, adopt: nil)
     source_key = attrs[:source_key]
     row = ProjectedAssignment.find_or_initialize_by(source_key: source_key)
+    # a human took this assignment back — the row is permanently yielded. Return
+    # before assign_attributes so an incoming upsert can't overwrite managed_by
+    # and resurrect management (the guard in WriteThrough#apply reads the row,
+    # but the controller must not clobber the stored value first).
+    return { status: "noop", source_key: source_key } if row.managed_by == "relinquished"
     row.assign_attributes(attrs.except(:source_key).to_h.symbolize_keys)
     unless row.valid?
       return { status: "invalid", source_key: source_key, errors: row.errors.full_messages }

--- a/app/services/resourcing/write_through.rb
+++ b/app/services/resourcing/write_through.rb
@@ -18,6 +18,10 @@ module Resourcing
     end
 
     def apply(row, preview: false, adopt_expected: nil)
+      # A relinquished row is one a human took back (see the CAS block below). We
+      # permanently stop managing it — never write, never re-flag.
+      return Result.new(status: :noop) if row.managed_by == "relinquished"
+
       runn_person_id = resolver.runn_person_id_for(row.contributor)
       if runn_person_id.nil?
         raise UnresolvedContributor,
@@ -53,9 +57,18 @@ module Resourcing
 
       # CAS + provenance: if we think we own an assignment, it must still be ours & unchanged.
       if row.runn_assignment_id
-        return conflict(current) if current.nil? # human deleted it
-        return conflict(current) unless current["note"].to_s.include?(self.class.provenance_marker(row.source_key))
-        return conflict(current) unless same_state?(current, row.last_synced_runn_state)
+        return conflict(current) if current.nil? # human deleted it → Decision
+        return conflict(current) unless current["note"].to_s.include?(self.class.provenance_marker(row.source_key)) # human replaced it → Decision
+        # human hand-edited an assignment we own (marker still present, same id, but
+        # the fields drifted from what we last wrote): the human is taking it back.
+        # We never undo their edit — we RELINQUISH management (yield permanently), so
+        # this assignment is left exactly as they set it and never touched or re-flagged
+        # again. Persist the yield (except in preview) by marking the row relinquished;
+        # the top-of-apply guard then no-ops every future write to it.
+        unless same_state?(current, row.last_synced_runn_state)
+          row.update!(managed_by: "relinquished") unless preview
+          return Result.new(status: :relinquished, before: current)
+        end
       end
 
       role_id = current ? current["roleId"] : most_recent_role_id(runn_person_id, row.runn_project_id, assignments)
@@ -113,6 +126,7 @@ module Resourcing
     # DELETE ?archive_runn=true — remove the owned Runn assignment, CAS-guarded.
     # Does NOT mutate/destroy the row — the caller destroys it only on non-conflict.
     def archive(row)
+      return Result.new(status: :noop) if row.managed_by == "relinquished" # yielded to a human — never touch
       return Result.new(status: :noop) if row.runn_assignment_id.nil?
 
       current = @runn.get_assignments.find { |a| a["id"] == row.runn_assignment_id }

--- a/test/integration/resourcing_projected_assignments_test.rb
+++ b/test/integration/resourcing_projected_assignments_test.rb
@@ -368,4 +368,24 @@ class ResourcingProjectedAssignmentsTest < ActionDispatch::IntegrationTest
     statuses = JSON.parse(response.body)["results"].map { |r| r["status"] }
     assert statuses.all? { |s| s == "deferred" }
   end
+  test "PUT on a relinquished row is a no-op that survives an incoming upsert (managed_by not clobbered)" do
+    marker = Resourcing::WriteThrough.provenance_marker("relinq:key")
+    ProjectedAssignment.create!(source_key: "relinq:key", project_tracker: @tr, contributor: @contributor,
+      start_date: "2030-05-01", end_date: "2030-05-31", minutes_per_day: 480,
+      runn_assignment_id: 7001, managed_by: "relinquished",
+      last_synced_runn_state: { "id" => 7001, "note" => marker })
+    # the sweep re-derives a write (managed_by:'detector') for the same source_key —
+    # must NOT resurrect management or touch Runn.
+    Stacks::Runn.any_instance.expects(:get_assignments).never
+    Stacks::Runn.any_instance.expects(:create_assignment).never
+    Stacks::Runn.any_instance.expects(:delete_assignment).never
+    put "/api/v1/projected_assignments/relinq:key",
+      headers: auth_headers, params: body(end_date: "2030-06-15", managed_by: "detector").to_json
+    assert_response :success
+    assert_equal "noop", JSON.parse(response.body)["status"]
+    row = ProjectedAssignment.find_by(source_key: "relinq:key")
+    assert_equal "relinquished", row.managed_by, "the yield must survive the upsert"
+    assert_equal Date.new(2030, 5, 31), row.end_date, "the row must not be mutated"
+  end
+
 end

--- a/test/integration/resourcing_projected_assignments_test.rb
+++ b/test/integration/resourcing_projected_assignments_test.rb
@@ -76,19 +76,39 @@ class ResourcingProjectedAssignmentsTest < ActionDispatch::IntegrationTest
     assert_equal "preview", JSON.parse(response.body)["status"]
   end
 
-  test "PUT returns 409 on a CAS conflict" do
+  test "PUT relinquishes (200) when a human hand-edited an assignment we own" do
     marker = Resourcing::WriteThrough.provenance_marker("cas:key")
     ProjectedAssignment.create!(source_key: "cas:key", project_tracker: @tr, contributor: @contributor,
       start_date: "2030-05-01", end_date: "2030-05-31", minutes_per_day: 480,
       runn_assignment_id: 5001,
       last_synced_runn_state: { "personId" => 10, "projectId" => 91_100, "roleId" => 7,
         "startDate" => "2030-05-01", "endDate" => "2030-05-31", "minutesPerDay" => 480, "id" => 5001, "note" => marker })
-    # human moved it in Runn
+    # human moved it in Runn (marker + id intact) → we yield permanently, never undo it
     Stacks::Runn.any_instance.stubs(:get_assignments).returns([{ "id" => 5001, "personId" => 10, "projectId" => 91_100,
       "roleId" => 7, "startDate" => "2030-05-01", "endDate" => "2030-05-10", "minutesPerDay" => 480, "note" => marker }])
     Stacks::Runn.any_instance.stubs(:get_people).returns(people_stub(10))
     Stacks::Runn.any_instance.expects(:create_assignment).never
+    Stacks::Runn.any_instance.expects(:delete_assignment).never
     put "/api/v1/projected_assignments/cas:key",
+      headers: auth_headers, params: body(end_date: "2030-06-15").to_json
+    assert_response :success
+    assert_equal "relinquished", JSON.parse(response.body)["status"]
+    assert_equal "relinquished", ProjectedAssignment.find_by(source_key: "cas:key").managed_by
+  end
+
+  test "PUT returns 409 when a claimed-owned assignment lost our marker (human replaced it)" do
+    marker = Resourcing::WriteThrough.provenance_marker("cas2:key")
+    ProjectedAssignment.create!(source_key: "cas2:key", project_tracker: @tr, contributor: @contributor,
+      start_date: "2030-05-01", end_date: "2030-05-31", minutes_per_day: 480,
+      runn_assignment_id: 5002,
+      last_synced_runn_state: { "personId" => 10, "projectId" => 91_100, "roleId" => 7,
+        "startDate" => "2030-05-01", "endDate" => "2030-05-31", "minutesPerDay" => 480, "id" => 5002, "note" => marker })
+    # marker gone → not a clean yield, a genuine conflict for a human to resolve
+    Stacks::Runn.any_instance.stubs(:get_assignments).returns([{ "id" => 5002, "personId" => 10, "projectId" => 91_100,
+      "roleId" => 7, "startDate" => "2030-05-01", "endDate" => "2030-05-31", "minutesPerDay" => 480, "note" => "hand-authored" }])
+    Stacks::Runn.any_instance.stubs(:get_people).returns(people_stub(10))
+    Stacks::Runn.any_instance.expects(:create_assignment).never
+    put "/api/v1/projected_assignments/cas2:key",
       headers: auth_headers, params: body(end_date: "2030-06-15").to_json
     assert_response :conflict
     assert_equal "conflict", JSON.parse(response.body)["status"]

--- a/test/services/resourcing/write_through_test.rb
+++ b/test/services/resourcing/write_through_test.rb
@@ -167,37 +167,37 @@ class Resourcing::WriteThroughTest < ActiveSupport::TestCase
     assert_equal 5002, w.reload.runn_assignment_id
   end
 
-  test "CAS conflict: live owned no longer equals baseline → conflict, no Runn write" do
+  test "CAS: live owned no longer equals baseline (human edited it) → relinquished, no Runn write" do
     tr = tracker
     c = contributor_for(10)
     base = live(5001, "wkey", Date.new(2030, 5, 1), Date.new(2030, 5, 31))
     w = row(tr, Date.new(2030, 5, 1), Date.new(2030, 6, 15), contributor: c, owned_id: 5001, baseline: base, key: "wkey")
     runn = mock("runn")
-    # human moved the end date in Runn since we last synced
+    # human moved the end date in Runn since we last synced → we yield permanently
     runn.stubs(:get_assignments).returns([live(5001, "wkey", Date.new(2030, 5, 1), Date.new(2030, 5, 20))])
     runn.stubs(:get_people).returns(people_stub(10))
     runn.expects(:create_assignment).never
     runn.expects(:delete_assignment).never
     result = service(runn).apply(w)
-    assert_equal :conflict, result.status
-    assert result.conflict.present?
+    assert_equal :relinquished, result.status
+    assert_equal "relinquished", w.reload.managed_by
   end
 
-  test "CAS conflict: minutes-only drift (same person/project/role/dates) → conflict, no Runn write" do
+  test "CAS: minutes-only drift (human edited it) → relinquished, no Runn write" do
     tr = tracker
     c = contributor_for(10)
     base = live(5001, "wkey", Date.new(2030, 5, 1), Date.new(2030, 5, 31), minutes: 480)
     w = row(tr, Date.new(2030, 5, 1), Date.new(2030, 5, 31), minutes: 480, contributor: c,
       owned_id: 5001, baseline: base, key: "wkey")
     runn = mock("runn")
-    # human changed only minutesPerDay in Runn since we last synced
+    # human changed only minutesPerDay in Runn since we last synced → we yield
     runn.stubs(:get_assignments).returns([live(5001, "wkey", Date.new(2030, 5, 1), Date.new(2030, 5, 31), minutes: 240)])
     runn.stubs(:get_people).returns(people_stub(10))
     runn.expects(:create_assignment).never
     runn.expects(:delete_assignment).never
     result = service(runn).apply(w)
-    assert_equal :conflict, result.status
-    assert result.conflict.present?
+    assert_equal :relinquished, result.status
+    assert_equal "relinquished", w.reload.managed_by
   end
 
   test "provenance conflict: a claimed-owned assignment lost our marker → conflict, no write" do
@@ -486,4 +486,63 @@ class Resourcing::WriteThroughTest < ActiveSupport::TestCase
     assert_nil r1.reload.runn_assignment_id
     assert_nil r2.reload.runn_assignment_id
   end
+  # --- relinquish: a human hand-edit to an owned assignment yields it permanently ---
+  test "apply: human hand-edited our owned assignment → relinquished, no write, row marked" do
+    tr = tracker
+    c = contributor_for(10)
+    key = "obs:owned:1"
+    baseline = live(555, key, Date.new(2030, 1, 1), Date.new(2030, 6, 30)) # what we last wrote
+    w = row(tr, Date.new(2030, 1, 1), Date.new(2030, 6, 30), contributor: c, owned_id: 555, baseline: baseline, key: key)
+    edited = live(555, key, Date.new(2030, 1, 1), Date.new(2030, 9, 30)) # human moved the end date; marker + id intact
+    runn = mock("runn")
+    runn.stubs(:get_assignments).returns([edited])
+    runn.stubs(:get_people).returns(people_stub(10))
+    runn.expects(:create_assignment).never
+    runn.expects(:delete_assignment).never
+    result = service(runn).apply(w)
+    assert_equal :relinquished, result.status
+    assert_equal edited, result.before
+    assert_equal "relinquished", w.reload.managed_by
+  end
+
+  test "apply: a relinquished row is never touched again (noop, no Runn calls at all)" do
+    tr = tracker
+    c = contributor_for(11)
+    w = ProjectedAssignment.create!(source_key: "obs:relinq:1", project_tracker: tr, contributor: c,
+      start_date: Date.new(2030, 1, 1), end_date: Date.new(2030, 6, 30), minutes_per_day: 480,
+      runn_assignment_id: 556, last_synced_runn_state: live(556, "obs:relinq:1", Date.new(2030, 1, 1), Date.new(2030, 6, 30)),
+      managed_by: "relinquished")
+    runn = mock("runn")
+    runn.expects(:get_assignments).never
+    runn.expects(:get_people).never
+    assert_equal :noop, service(runn).apply(w).status
+  end
+
+  test "apply preview: relinquish is detected but NOT persisted" do
+    tr = tracker
+    c = contributor_for(12)
+    key = "obs:owned:2"
+    baseline = live(557, key, Date.new(2030, 1, 1), Date.new(2030, 6, 30))
+    w = row(tr, Date.new(2030, 1, 1), Date.new(2030, 6, 30), contributor: c, owned_id: 557, baseline: baseline, key: key)
+    edited = live(557, key, Date.new(2030, 1, 1), Date.new(2030, 9, 30))
+    runn = mock("runn")
+    runn.stubs(:get_assignments).returns([edited])
+    runn.stubs(:get_people).returns(people_stub(12))
+    assert_equal :relinquished, service(runn).apply(w, preview: true).status
+    assert_nil w.reload.managed_by, "preview must not persist the yield"
+  end
+
+  test "archive: a relinquished row is never touched (noop)" do
+    tr = tracker
+    c = contributor_for(13)
+    w = ProjectedAssignment.create!(source_key: "obs:relinq:2", project_tracker: tr, contributor: c,
+      start_date: Date.new(2030, 1, 1), end_date: Date.new(2030, 6, 30), minutes_per_day: 480,
+      runn_assignment_id: 558, last_synced_runn_state: live(558, "obs:relinq:2", Date.new(2030, 1, 1), Date.new(2030, 6, 30)),
+      managed_by: "relinquished")
+    runn = mock("runn")
+    runn.expects(:get_assignments).never
+    runn.expects(:delete_assignment).never
+    assert_equal :noop, service(runn).archive(w).status
+  end
+
 end


### PR DESCRIPTION
Product directive: maximum autonomy, with one carve-out — **a human's manual Runn edit makes the bot leave that assignment alone, forever.**

## Behavior change
When the sweep would write an assignment the bot owns but CAS detects a human hand-edited it (marker present, same id, fields drifted), the bot no longer just files a ⚖️ Decision — it **relinquishes**: marks the `projected_assignment` `managed_by:"relinquished"` and never writes or re-flags it again. The human's edit is never undone. (The two other conflict cases — the assignment was deleted, or lost our marker — still return `409` for a human to resolve.)

- `WriteThrough#apply`: the `same_state?`-mismatch branch → `:relinquished` (+ `row.update!(managed_by:"relinquished")`, except in preview). Top of `apply`/`archive`: no-op any relinquished row.
- **Enforced server-side (review Critical):** the controller short-circuits on the *persisted* `managed_by` **before** `assign_attributes`, so an incoming upsert (which carries `managed_by:'detector'/'observe'`) can't overwrite the yield and resurrect management. Covered by a controller-path integration test.
- Relinquished rows stay in the `managed` overlay (so the detector keeps treating the assignment as ours and never re-adopts it).

Terminal by design — un-relinquishing is a manual DB action (matches "the human takes it back").

## Tests
`bin/rails test test/services/resourcing/ test/integration/resourcing_projected_assignments_test.rb` → 63 runs, 0 failures. Adversarial review (Opus) caught the server-side-enforcement gap; fixed + regression-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)