### PR TITLE
fix(recurring-assignments): weekday checkboxes render checked + save cleanly

### DIFF
--- a/app/admin/recurring_assignments.rb
+++ b/app/admin/recurring_assignments.rb
@@ -3,7 +3,10 @@ ActiveAdmin.register RecurringAssignment do
   config.filters = false
   actions :index, :new, :create, :edit, :update, :destroy, :show
 
-  WEEKDAY_CHOICES = [%w[Mon 1], %w[Tue 2], %w[Wed 3], %w[Thu 4], %w[Fri 5], %w[Sat 6], %w[Sun 0]].freeze
+  # Integer values (not strings): Formtastic's check_boxes marks a box checked via
+  # selected_values.include?(value), comparing against the record's integer weekdays.
+  # String values here would never match, so every box would render unchecked.
+  WEEKDAY_CHOICES = [["Mon", 1], ["Tue", 2], ["Wed", 3], ["Thu", 4], ["Fri", 5], ["Sat", 6], ["Sun", 0]].freeze
 
   permit_params :forecast_person_id, :forecast_project_id, :allocation_in_hours,
     :active_on_days_off, :notes, :starts_on, :ends_on, :paused_at, weekdays: []

--- a/app/models/recurring_assignment.rb
+++ b/app/models/recurring_assignment.rb
@@ -31,6 +31,14 @@ class RecurringAssignment < ApplicationRecord
     self.allocation = (hours.to_f * 3600).round
   end
 
+  # Normalize incoming weekdays to a clean integer array. HTML checkbox forms submit
+  # strings plus a hidden "" (Formtastic's unchecked placeholder); the "" casts to nil
+  # in the integer[] column, which then fails the 0..6 range validation. Strip blanks
+  # and coerce to Integer so form/MCP/API callers all land on the same shape.
+  def weekdays=(value)
+    super(Array(value).map { |v| v.to_s.strip }.reject(&:empty?).map(&:to_i))
+  end
+
   # Idempotent. Pass 1 tombstones occurrences deleted in Forecast (absent from the
   # freshly-synced ForecastAssignment mirror); Pass 2 creates any missing occurrence.
   # MUST run after Stacks::Forecast#sync_all! so the mirror is authoritative — see the

--- a/test/integration/admin_recurring_assignments_test.rb
+++ b/test/integration/admin_recurring_assignments_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+# Guards the weekday checkbox UI on the Recurring Assignment admin form. Two coupled
+# bugs it pins: (1) integer-valued collection so Formtastic marks the right box checked
+# (string values never matched the record's integer weekdays -> everything rendered
+# unchecked); (2) the model strips Formtastic's hidden "" placeholder so a submit does
+# not land nil in the integer[] column and trip the 0..6 range validation.
+class AdminRecurringAssignmentsTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @admin = AdminUser.create!(
+      email: "admin-#{SecureRandom.hex(4)}@example.com",
+      password: "password12345", password_confirmation: "password12345", roles: ["admin"]
+    )
+    sign_in @admin
+  end
+
+  test "edit form checks exactly the record's weekdays (Friday) and no others" do
+    ra = RecurringAssignment.create!(
+      forecast_person_id: 1, forecast_project_id: 2, allocation: 7200,
+      weekdays: [5], starts_on: Date.today
+    )
+    get "/admin/recurring_assignments/#{ra.id}/edit"
+    assert_response :success
+
+    box = "input[type=checkbox][name='recurring_assignment[weekdays][]']"
+    assert_select "#{box}[value='5'][checked]", 1, "Friday checkbox should be checked for weekdays [5]"
+    assert_select "#{box}[value='1'][checked]", 0, "Monday checkbox should not be checked"
+    assert_select "#{box}[value='0'][checked]", 0, "Sunday checkbox should not be checked"
+  end
+
+  test "submitting a checked weekday (with the hidden placeholder) saves without a range error" do
+    ra = RecurringAssignment.create!(
+      forecast_person_id: 1, forecast_project_id: 2, allocation: 7200,
+      weekdays: [1, 2, 3, 4, 5], starts_on: Date.today
+    )
+    patch "/admin/recurring_assignments/#{ra.id}", params: {
+      recurring_assignment: {
+        forecast_person_id: 1, forecast_project_id: 2, allocation_in_hours: "0.5",
+        weekdays: ["", "5"], starts_on: Date.today.to_s, notes: "",
+      },
+    }
+    assert_redirected_to admin_recurring_assignment_path(ra)
+    assert_equal [5], ra.reload.weekdays
+  end
+end

--- a/test/models/recurring_assignment_test.rb
+++ b/test/models/recurring_assignment_test.rb
@@ -39,4 +39,25 @@ class RecurringAssignmentTest < ActiveSupport::TestCase
     ra.allocation_in_hours = 4
     assert_equal 14_400, ra.allocation
   end
+
+  test "weekdays= strips the blank checkbox placeholder and casts strings to ints" do
+    ra = RecurringAssignment.new(valid_attrs)
+    # HTML checkbox form: Friday checked, plus Formtastic's hidden "" placeholder
+    ra.weekdays = ["", "5"]
+    assert_equal [5], ra.weekdays
+    assert ra.valid?, ra.errors.full_messages.to_sentence
+  end
+
+  test "weekdays= with only the blank placeholder (nothing checked) is empty and invalid" do
+    ra = RecurringAssignment.new(valid_attrs)
+    ra.weekdays = [""]
+    assert_equal [], ra.weekdays
+    assert_not ra.valid?
+    assert_includes ra.errors[:weekdays], "must include at least one day"
+  end
+
+  test "weekdays= accepts plain string arrays and integer arrays alike" do
+    assert_equal [5, 6], RecurringAssignment.new(valid_attrs(weekdays: %w[5 6])).weekdays
+    assert_equal [1, 2], RecurringAssignment.new(valid_attrs(weekdays: [1, 2])).weekdays
+  end
 end


### PR DESCRIPTION
## The bug

On the Recurring Assignment admin form, the **Weekdays checkboxes were broken both ways**: an existing rule (e.g. `weekdays: [5]`) rendered with **every box unchecked**, and saving raised **"must be integers 0 (Sun) through 6 (Sat)"** — so the form couldn't be used at all.

Two independent root causes:

1. **Display** — the `check_boxes` collection used **string** values (`"5"`), but the column stores **integers** (`[5]`). Formtastic's `checked?(v)` is `selected_values.include?(v)`, comparing the collection value against the record's integer weekdays, so nothing ever matched → all unchecked.
2. **Submit** — Formtastic emits a hidden `""` placeholder (so "uncheck all" still posts a param). The posted array is e.g. `["", "5"]`; `""` casts to **`nil`** in the `integer[]` column → `(0..6).cover?(nil)` is false → the range validation rejects every save.

## The fix

- **Model:** normalize `weekdays=` to strip blanks and coerce to `Integer` (`["", "5"] → [5]`, `[""] → []`). This is the durable fix — it also hardens the MCP `create_recurring_assignment` and HTTP callers against the same shape.
- **Admin:** give `WEEKDAY_CHOICES` **integer** values so Formtastic's checked comparison matches the record.

## Testing

- Model unit tests: `weekdays=` strips the blank placeholder and casts strings; all-blank → empty → the existing "must include at least one day" validation.
- Admin request tests: the edit page renders the **Friday box checked** (Mon/Sun not), and a `["", "5"]` submit **saves as `[5]`** with no range error.

All green (model 9 runs, admin 2 runs / 7 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
