### PR TITLE
fix(daily-tasks): isolate per-account QBO failures so one revoked token can't block pay cycle generation

### DIFF
--- a/lib/tasks/stacks.rake
+++ b/lib/tasks/stacks.rake
@@ -30,16 +30,25 @@ namespace :stacks do
       # Step 1: proactively refresh every enterprise's QBO token so
       # downstream steps aren't racing the 10-minute staleness gate or
       # surprise-401-ing mid-job. Per-enterprise failures are isolated and
-      # only logged — downstream steps continue regardless (a stale token
-      # will surface as an AuthorizationFailure inside sync_all! /
-      # generate_snapshot!, which are already isolated per-enterprise).
+      # only logged — downstream steps continue regardless (a dead token
+      # surfaces again inside sync_all! / generate_snapshot!, which isolate
+      # per-account/per-enterprise below).
       refresh_results = QboTokens::RefreshAll.call
       failed_refreshes = refresh_results.reject(&:ok?)
       if failed_refreshes.any?
         Rails.logger.warn("[stacks:daily_enterprise_tasks] #{failed_refreshes.size}/#{refresh_results.size} QBO token refreshes failed: #{failed_refreshes.map { |r| "enterprise=#{r.qbo_account.enterprise_id}" }.join(', ')}")
       end
 
-      Parallel.map(QboAccount.all, in_threads: 2) { |e| e.sync_all! }
+      # Per-account errors are isolated: a revoked token on one realm (e.g.
+      # an enterprise temporarily locked out of QBO) must not abort the run
+      # before OpenScheduledCycles — payroll for every other enterprise
+      # depends on this task reaching that step.
+      Parallel.map(QboAccount.all, in_threads: 2) do |qa|
+        qa.sync_all!
+      rescue => e
+        Rails.logger.error("[stacks:daily_enterprise_tasks] sync_all! failed for qbo_account=#{qa.id} (#{qa.enterprise&.name}): #{e.class}: #{e.message}")
+        Sentry.capture_exception(e) if defined?(Sentry)
+      end
 
       # Sync vendors per-account so the Contributor-edit dropdown can offer
       # mappings across every enterprise's QBO realm. sync_all! above only
@@ -53,7 +62,15 @@ namespace :stacks do
         Sentry.capture_exception(e) if defined?(Sentry)
       end
 
-      Parallel.map(Enterprise.all, in_threads: 2) { |e| e.generate_snapshot! }
+      # Snapshots reach QBO live too (Stacks::Period#report →
+      # QboProfitAndLossReport.find_or_fetch_for_range fetches uncached
+      # periods), so the same per-enterprise isolation applies.
+      Parallel.map(Enterprise.all, in_threads: 2) do |e|
+        e.generate_snapshot!
+      rescue => err
+        Rails.logger.error("[stacks:daily_enterprise_tasks] generate_snapshot! failed for enterprise=#{e.id} (#{e.name}): #{err.class}: #{err.message}")
+        Sentry.capture_exception(err) if defined?(Sentry)
+      end
 
       # Backfill any missing Contributor rows for active ForecastPersons
       # FIRST — Contributor.after_create cascades into Ledger.ensure_for_contributor!,

--- a/test/lib/tasks/daily_enterprise_tasks_rake_test.rb
+++ b/test/lib/tasks/daily_enterprise_tasks_rake_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+require 'rake'
+
+# The daily task must reach PayCycles::OpenScheduledCycles even when a QBO
+# account is unreachable (revoked token, lockout). A revoked refresh token on
+# ONE enterprise's realm must never block payroll for every other enterprise.
+class DailyEnterpriseTasksRakeTest < ActiveSupport::TestCase
+  setup do
+    Stacks::Application.load_tasks if Rake::Task.tasks.empty?
+    Rake::Task['stacks:daily_enterprise_tasks'].reenable
+
+    # Neutralize every step that isn't under test so each test can poke
+    # exactly one failure point.
+    QboTokens::RefreshAll.stubs(:call).returns([])
+    QboAccount.any_instance.stubs(:sync_all!)
+    QboAccount.any_instance.stubs(:sync_all_vendors!)
+    Enterprise.any_instance.stubs(:generate_snapshot!)
+    Enterprise.any_instance.stubs(:daily_tasks)
+    Contributor.stubs(:ensure_all_for_forecast_people!).returns(0)
+    Ledger.stubs(:ensure_all!).returns(0)
+    PayCycles::OpenScheduledCycles.stubs(:call).returns([])
+    Ledgers::QboBoundMigrationCheck.stubs(:call).returns(stub(ready?: false))
+    Stacks::GhostSync.stubs(:sync_all_with_lock!).returns(nil)
+    Stacks::Notifications.stubs(:report_exception).returns(stub(record: nil))
+  end
+
+  test 'pay cycles still open when a QboAccount#sync_all! raises' do
+    QboAccount.any_instance.stubs(:sync_all!).raises(RuntimeError, 'invalid_grant: Incorrect or invalid refresh token')
+    PayCycles::OpenScheduledCycles.expects(:call).returns([])
+
+    Rake::Task['stacks:daily_enterprise_tasks'].invoke
+
+    task = SystemTask.where(name: 'stacks:daily_enterprise_tasks').last
+    assert task.settled_at.present?, 'expected task to settle'
+    assert_nil task.notification_id, 'expected success — a per-account sync failure must be isolated'
+  end
+
+  test 'pay cycles still open when an Enterprise#generate_snapshot! raises' do
+    Enterprise.any_instance.stubs(:generate_snapshot!).raises(RuntimeError, 'invalid_grant: Incorrect or invalid refresh token')
+    PayCycles::OpenScheduledCycles.expects(:call).returns([])
+
+    Rake::Task['stacks:daily_enterprise_tasks'].invoke
+
+    task = SystemTask.where(name: 'stacks:daily_enterprise_tasks').last
+    assert task.settled_at.present?, 'expected task to settle'
+    assert_nil task.notification_id, 'expected success — a per-enterprise snapshot failure must be isolated'
+  end
+end


### PR DESCRIPTION
## Why

USB Club's QBO refresh token was revoked (account lockout) on Jul 31. Since then, every `stacks:daily_enterprise_tasks` run has died with `OAuth2::Error invalid_grant` at the P&L sync step — **before** `PayCycles::OpenScheduledCycles` — so no enterprise's pay cycle opened. Index's Jul 16–31 cycle was never generated, even though Index's own QBO token is healthy.

Root cause: `Parallel.map(QboAccount.all) { |e| e.sync_all! }` and `Parallel.map(Enterprise.all) { |e| e.generate_snapshot! }` had no per-item error isolation, so one dead realm aborted the whole task. The step-1 comment even claimed these steps were "already isolated per-enterprise" — they weren't.

Note `PayCycles::GenerateStubs` itself is already QBO-resilient (no QBO calls on the happy path; the orphan-cleanup QBO check is rescued per-stub), so isolating the rake steps is the whole fix.

## What

- Wrap `sync_all!` in a per-account rescue (log + Sentry), mirroring the sibling vendor-sync step.
- Wrap `generate_snapshot!` in a per-enterprise rescue — snapshots also reach QBO live via `Stacks::Period#report → QboProfitAndLossReport.find_or_fetch_for_range` for uncached periods.
- Correct the misleading step-1 comment.

## Recovery behavior

Once merged and deployed, the next daily run reaches `OpenScheduledCycles` regardless of USB Club's token state, and the missed Index Jul 16–31 cycle self-heals (`open_cycle_for` appends from `latest.ends_at + 1.day`). USB Club's own P&L sync/snapshot stays degraded (logged + Sentry'd) until its QBO connection is reauthed.

## Tests

TDD'd: `test/lib/tasks/daily_enterprise_tasks_rake_test.rb` invokes the real rake task and asserts `OpenScheduledCycles` still runs and the SystemTask settles as success when (a) a `QboAccount#sync_all!` raises and (b) an `Enterprise#generate_snapshot!` raises. Both watched fail red before the fix, green after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)