### PR TITLE
MCP Tier-1.5: monthly-close report tools (get_membership_stats, get_invoice_passes, get_client_revenue)

### DIFF
--- a/app/services/mcp/get_client_revenue_tool.rb
+++ b/app/services/mcp/get_client_revenue_tool.rb
@@ -5,12 +5,18 @@ module Mcp
                 'report narrates: client x month amounts (zero-filled across the window), ' \
                 'window totals, share-of-total percentages, and a month-over-month total ' \
                 'series. Scope: EXTERNAL clients only; countable revenue = invoice trackers ' \
-                'with a linked, non-voided synced QBO invoice (June 2021 onward). The default ' \
-                'garden3d view counts full invoice totals; passing a sub-studio takes its ' \
-                'pro-rata share via blueprint person lines (trackers without usable lines are ' \
-                'omitted from sub-studio numbers). Months follow each invoice pass, not ' \
-                'payment dates. Reads stored invoice data only; blank mirrors are skipped ' \
-                'and counted in skipped_tracker_count (an all-time count, not window-scoped).'
+                'with a linked, non-voided synced QBO invoice; the requested window governs ' \
+                'which months appear (no fixed historical cutoff). Rows group by client NAME, ' \
+                'so duplicate-named ForecastClients merge into one row — the concentration ' \
+                'OKR datapoint groups by client record and can differ. The default garden3d ' \
+                'view counts full invoice totals; passing a sub-studio takes its pro-rata ' \
+                'share via blueprint person lines (trackers without usable lines are omitted ' \
+                'from sub-studio numbers). Months follow each invoice pass, not payment ' \
+                'dates. Reads stored invoice data only; blank mirrors are skipped and counted ' \
+                'in skipped_tracker_count (an all-time count, not window-scoped). Trackers ' \
+                'whose stored invoice data is malformed (e.g. sent with no due_date) are ' \
+                'likewise skipped and counted — get_invoice_passes buckets the same row as ' \
+                'status unknown and still counts its total.'
 
     SCOPE_NOTE = 'External clients only; countable revenue = invoice trackers with a linked, ' \
                  'non-voided synced QBO invoice, attributed to the month of their invoice pass. ' \

--- a/app/services/mcp/get_client_revenue_tool.rb
+++ b/app/services/mcp/get_client_revenue_tool.rb
@@ -1,0 +1,112 @@
+module Mcp
+  class GetClientRevenueTool < MCP::Tool
+    tool_name 'get_client_revenue'
+    description 'Per-client invoiced revenue by month, the rows the Client Services close ' \
+                'report narrates: client x month amounts (zero-filled across the window), ' \
+                'window totals, share-of-total percentages, and a month-over-month total ' \
+                'series. Scope: EXTERNAL clients only; countable revenue = invoice trackers ' \
+                'with a linked, non-voided synced QBO invoice (June 2021 onward). The default ' \
+                'garden3d view counts full invoice totals; passing a sub-studio takes its ' \
+                'pro-rata share via blueprint person lines (trackers without usable lines are ' \
+                'omitted from sub-studio numbers). Months follow each invoice pass, not ' \
+                'payment dates. Reads stored invoice data only; blank mirrors are skipped ' \
+                'and counted in skipped_tracker_count (an all-time count, not window-scoped).'
+
+    SCOPE_NOTE = 'External clients only; countable revenue = invoice trackers with a linked, ' \
+                 'non-voided synced QBO invoice, attributed to the month of their invoice pass. ' \
+                 'garden3d counts full invoice totals; sub-studios take a pro-rata share via ' \
+                 'blueprint person lines.'.freeze
+
+    MIN_MONTHS_BACK = 1
+    MAX_MONTHS_BACK = 24
+    DEFAULT_MONTHS_BACK = 6
+    MIN_TOP = 1
+    MAX_TOP = 50
+    DEFAULT_TOP = 15
+
+    input_schema(
+      properties: {
+        months_back: { type: 'integer', description: "Trailing months (default #{DEFAULT_MONTHS_BACK}, clamped #{MIN_MONTHS_BACK}..#{MAX_MONTHS_BACK})." },
+        top: { type: 'integer', description: "How many clients, by window total desc (default #{DEFAULT_TOP}, clamped #{MIN_TOP}..#{MAX_TOP}). Window totals still cover every client." },
+        studio: { type: 'string', description: 'Optional studio name or mini_name (case-insensitive). Default garden3d — full invoice totals; sub-studios get their blueprint pro-rata share.' },
+      },
+      required: []
+    )
+    annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true)
+
+    def self.call(months_back: DEFAULT_MONTHS_BACK, top: DEFAULT_TOP, studio: nil, server_context:)
+      months_back = months_back.to_i.clamp(MIN_MONTHS_BACK, MAX_MONTHS_BACK)
+      top = top.to_i.clamp(MIN_TOP, MAX_TOP)
+
+      all_studios = Studio.all.to_a
+      resolved = resolve_studio(studio, all_studios)
+      return resolved if resolved.is_a?(MCP::Tool::Response) # error envelope
+
+      # One instance per call, deliberately un-memoized (see
+      # Studio#client_revenue): its constructor builds the full Row set with
+      # the same stored-attribute-only guard the nightly snapshot relies on.
+      revenue = Stacks::ClientRevenue.new(resolved, all_studios)
+
+      months = window_months(months_back)
+      in_window = revenue.rows.select { |r| months.first <= r.month && r.month <= months.last }
+      by_client = in_window.group_by { |r| r.client.name }
+      totals = by_client.transform_values { |rs| rs.sum(&:amount) }
+      window_total = totals.values.sum
+
+      clients = totals
+        .sort_by { |name, total| [-total, name] }
+        .first(top)
+        .map do |name, total|
+          amounts_by_month = by_client[name].group_by(&:month).transform_values { |rs| rs.sum(&:amount) }
+          {
+            client: name,
+            monthly: months.map { |m| { month: m.iso8601, amount: amounts_by_month.fetch(m, 0.0).round(2) } },
+            total: total.round(2),
+            share_of_total_pct: window_total.zero? ? nil : ((total / window_total) * 100).round(1),
+          }
+        end
+
+      mom = in_window.group_by(&:month).transform_values { |rs| rs.sum(&:amount) }
+
+      Responses.ok({
+        as_of: Date.today.iso8601,
+        studio: resolved.name,
+        months_back: months_back,
+        scope: SCOPE_NOTE,
+        clients: clients,
+        client_count: by_client.length,
+        total_revenue: window_total.round(2),
+        mom_totals: months.map { |m| { month: m.iso8601, total: mom.fetch(m, 0.0).round(2) } },
+        skipped_tracker_count: revenue.skipped_tracker_count,
+      })
+    rescue StandardError => e
+      Rails.logger.warn("[Mcp::GetClientRevenueTool] #{e.class}: #{e.message}")
+      Sentry.capture_exception(e) if defined?(Sentry)
+      Responses.error('get_client_revenue failed; the error was logged')
+    end
+
+    # Same resolution get_studio_health uses: exact name matches, then
+    # mini_name matches. Default is garden3d (the full-invoice-total view).
+    def self.resolve_studio(studio, all_studios)
+      if studio.blank?
+        g3d = all_studios.find(&:is_garden3d?)
+        return g3d if g3d
+        return Responses.error('No garden3d studio exists; pass a studio explicitly.')
+      end
+
+      key = studio.to_s.strip
+      found =
+        all_studios.find { |s| s.name.to_s.casecmp?(key) } ||
+        all_studios.find { |s| s.mini_name.to_s.split(',').map(&:strip).any? { |m| m.casecmp?(key) } }
+      return found if found
+
+      valid = all_studios.map { |s| "#{s.name} (#{s.mini_name})" }.sort.join(', ')
+      Responses.error("Unknown studio '#{studio}'. Valid studios: #{valid}")
+    end
+
+    def self.window_months(months_back)
+      start = Date.today.beginning_of_month - (months_back - 1).months
+      (0...months_back).map { |i| start + i.months }
+    end
+  end
+end

--- a/app/services/mcp/get_invoice_passes_tool.rb
+++ b/app/services/mcp/get_invoice_passes_tool.rb
@@ -89,14 +89,21 @@ module Mcp
 
         invoiced_total += invoice.read_attribute(:data)['total'].to_f
         invoice_count += 1
-        # Stored data is present, so #status reads the stored jsonb (no lazy
-        # sync). It can still raise on malformed rows (e.g. EmailSent with no
+        # InvoiceTracker#status precedence: an invoice with no blueprint is
+        # :impossible, never the invoice's own status. Otherwise stored data
+        # is present, so #status reads the stored jsonb (no lazy sync). It
+        # can still raise on malformed rows (e.g. EmailSent with no
         # due_date): count those as unknown rather than dropping their total.
-        status = begin
-          invoice.status.to_s
-        rescue StandardError
-          'unknown'
-        end
+        status =
+          if tracker.blueprint.nil?
+            'impossible'
+          else
+            begin
+              invoice.status.to_s
+            rescue StandardError
+              'unknown'
+            end
+          end
         status_mix[status] += 1
       rescue StandardError => e
         Rails.logger.warn("[Mcp::GetInvoicePassesTool] skipping tracker id=#{tracker.id}: #{e.class}: #{e.message}")

--- a/app/services/mcp/get_invoice_passes_tool.rb
+++ b/app/services/mcp/get_invoice_passes_tool.rb
@@ -26,10 +26,15 @@ module Mcp
       months_back = months_back.to_i.clamp(MIN_MONTHS_BACK, MAX_MONTHS_BACK)
       window_start = Date.today.beginning_of_month - (months_back - 1).months
 
+      # NEVER preload :qbo_invoice here — the AR association matches on
+      # qbo_id alone, and qbo_id is only composite-unique with
+      # qbo_account_id. A preloaded wrong-account invoice would win inside
+      # HasQboInvoiceViaCompositeKey#qbo_invoice; unloaded, the concern does
+      # the correct (qbo_account_id, qbo_id) lookup.
       passes = InvoicePass
         .where('start_of_month >= ?', window_start)
         .order(:start_of_month)
-        .includes(invoice_trackers: [:qbo_invoice, { qbo_account: :enterprise }])
+        .includes(invoice_trackers: { qbo_account: :enterprise })
         .map { |pass| pass_block(pass) }
 
       Responses.ok({

--- a/app/services/mcp/get_invoice_passes_tool.rb
+++ b/app/services/mcp/get_invoice_passes_tool.rb
@@ -24,7 +24,8 @@ module Mcp
 
     def self.call(months_back: DEFAULT_MONTHS_BACK, server_context:)
       months_back = months_back.to_i.clamp(MIN_MONTHS_BACK, MAX_MONTHS_BACK)
-      window_start = Date.today.beginning_of_month - (months_back - 1).months
+      current_month = Date.today.beginning_of_month
+      window_start = current_month - (months_back - 1).months
 
       # NEVER preload :qbo_invoice here — the AR association matches on
       # qbo_id alone, and qbo_id is only composite-unique with
@@ -32,16 +33,23 @@ module Mcp
       # HasQboInvoiceViaCompositeKey#qbo_invoice; unloaded, the concern does
       # the correct (qbo_account_id, qbo_id) lookup.
       passes = InvoicePass
-        .where('start_of_month >= ?', window_start)
+        .where(start_of_month: window_start..current_month)
         .order(:start_of_month)
         .includes(invoice_trackers: { qbo_account: :enterprise })
         .map { |pass| pass_block(pass) }
+
+      # Zero-fill the MoM series across the whole window (consistent with
+      # get_client_revenue): months without a pass read as 0, and the series
+      # never runs past the current month.
+      totals_by_month = passes.group_by { |p| p[:month] }
+        .transform_values { |ps| ps.sum { |p| p[:total_invoiced] } }
+      months = (0...months_back).map { |i| (window_start + i.months).iso8601 }
 
       Responses.ok({
         as_of: Date.today.iso8601,
         months_back: months_back,
         passes: passes,
-        mom: passes.map { |p| { month: p[:month], total_invoiced: p[:total_invoiced] } },
+        mom: months.map { |m| { month: m, total_invoiced: (totals_by_month[m] || 0.0).round(2) } },
       })
     rescue StandardError => e
       Rails.logger.warn("[Mcp::GetInvoicePassesTool] #{e.class}: #{e.message}")

--- a/app/services/mcp/get_invoice_passes_tool.rb
+++ b/app/services/mcp/get_invoice_passes_tool.rb
@@ -1,0 +1,119 @@
+module Mcp
+  class GetInvoicePassesTool < MCP::Tool
+    tool_name 'get_invoice_passes'
+    description 'Monthly invoicing passes as the admin Invoicing surface shows them: for each ' \
+                'monthly pass, invoiced totals / invoice counts / invoice-status mix per legal ' \
+                'entity (attributed by each invoice tracker\'s issuing QBO account), whether ' \
+                'the pass completed or is stuck on missing hours, plus a month-over-month ' \
+                'total-invoiced series. Totals mirror the admin value column (every linked ' \
+                'invoice counts; the status mix separates voided/unpaid/paid). Reads STORED ' \
+                'QBO invoice data only — mirrors with no synced data yet are skipped and ' \
+                'counted per entity, never fetched live.'
+
+    MIN_MONTHS_BACK = 1
+    MAX_MONTHS_BACK = 24
+    DEFAULT_MONTHS_BACK = 6
+
+    input_schema(
+      properties: {
+        months_back: { type: 'integer', description: "Trailing months of passes (default #{DEFAULT_MONTHS_BACK}, clamped #{MIN_MONTHS_BACK}..#{MAX_MONTHS_BACK})." },
+      },
+      required: []
+    )
+    annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true)
+
+    def self.call(months_back: DEFAULT_MONTHS_BACK, server_context:)
+      months_back = months_back.to_i.clamp(MIN_MONTHS_BACK, MAX_MONTHS_BACK)
+      window_start = Date.today.beginning_of_month - (months_back - 1).months
+
+      passes = InvoicePass
+        .where('start_of_month >= ?', window_start)
+        .order(:start_of_month)
+        .includes(invoice_trackers: [:qbo_invoice, { qbo_account: :enterprise }])
+        .map { |pass| pass_block(pass) }
+
+      Responses.ok({
+        as_of: Date.today.iso8601,
+        months_back: months_back,
+        passes: passes,
+        mom: passes.map { |p| { month: p[:month], total_invoiced: p[:total_invoiced] } },
+      })
+    rescue StandardError => e
+      Rails.logger.warn("[Mcp::GetInvoicePassesTool] #{e.class}: #{e.message}")
+      Sentry.capture_exception(e) if defined?(Sentry)
+      Responses.error('get_invoice_passes failed; the error was logged')
+    end
+
+    def self.pass_block(pass)
+      entities = pass.invoice_trackers
+        .group_by { |t| t.qbo_account&.enterprise&.name || 'Unknown entity' }
+        .sort_by { |name, _| name }
+        .map { |name, trackers| entity_block(name, trackers) }
+
+      {
+        month: pass.start_of_month.iso8601,
+        label: pass.invoice_month,
+        completed_at: pass.completed_at&.iso8601,
+        missing_hours: missing_hours?(pass),
+        total_invoiced: entities.sum { |e| e[:invoiced_total] }.round(2),
+        entities: entities,
+      }
+    end
+
+    # NEVER InvoicePass#value / #statuses here — both walk each tracker into
+    # QboInvoice#data, whose blank-data path live-syncs (and can destroy the
+    # row, hazard H1/H3-adjacent). Totals and statuses come from stored
+    # attributes only, IncomeSeries-style: blank stored data → skip + count.
+    def self.entity_block(entity_name, trackers)
+      skipped = 0
+      invoiced_total = 0.0
+      invoice_count = 0
+      status_mix = Hash.new(0)
+
+      trackers.each do |tracker|
+        invoice = tracker.qbo_invoice
+        if invoice.nil?
+          # InvoiceTracker#status semantics without touching the invoice path.
+          status_mix[tracker.blueprint.nil? ? 'not_made' : 'deleted'] += 1
+          next
+        end
+        if invoice.read_attribute(:data).blank?
+          skipped += 1
+          next
+        end
+
+        invoiced_total += invoice.read_attribute(:data)['total'].to_f
+        invoice_count += 1
+        # Stored data is present, so #status reads the stored jsonb (no lazy
+        # sync). It can still raise on malformed rows (e.g. EmailSent with no
+        # due_date): count those as unknown rather than dropping their total.
+        status = begin
+          invoice.status.to_s
+        rescue StandardError
+          'unknown'
+        end
+        status_mix[status] += 1
+      rescue StandardError => e
+        Rails.logger.warn("[Mcp::GetInvoicePassesTool] skipping tracker id=#{tracker.id}: #{e.class}: #{e.message}")
+        Sentry.capture_exception(e) if defined?(Sentry)
+        skipped += 1
+      end
+
+      {
+        entity: entity_name,
+        invoiced_total: invoiced_total.round(2),
+        invoice_count: invoice_count,
+        status_mix: status_mix,
+        skipped_invoices: skipped,
+      }
+    end
+
+    # Mirrors InvoicePass#statuses' :missing_hours branch without calling it
+    # (the other branch of #statuses walks tracker → invoice → lazy #data).
+    def self.missing_hours?(pass)
+      (pass.data || {})['reminder_passes'].present? && pass.latest_reminder_pass.present?
+    rescue StandardError
+      false
+    end
+  end
+end

--- a/app/services/mcp/get_membership_stats_tool.rb
+++ b/app/services/mcp/get_membership_stats_tool.rb
@@ -1,0 +1,118 @@
+module Mcp
+  class GetMembershipStatsTool < MCP::Tool
+    tool_name 'get_membership_stats'
+    description 'Coworking membership stats from the synced Optix mirror, as the admin ' \
+                'organization report shows them: per-location trailing weekly paying-member ' \
+                'counts split Patron / Non-Patron (derived from plan start/end/cancel ' \
+                'timestamps, so weekly history is computed, not stored), the current plan mix ' \
+                'per location (ACTIVE/IN_TRIAL plans by plan-template name), 4-week growth, ' \
+                'and the org-wide distinct paying-member total. COUNTS AND PLAN NAMES ONLY — ' \
+                'never member names, emails, or ids. Members on an all-locations plan count ' \
+                'at every location, so per-location totals can sum past the org-wide distinct ' \
+                'total. Figures are as of the last Optix sync (see synced_at).'
+
+    MIN_WEEKS = 4
+    MAX_WEEKS = 26
+    DEFAULT_WEEKS = 13
+
+    input_schema(
+      properties: {
+        weeks: { type: 'integer', description: "Trailing weeks of history per location (default #{DEFAULT_WEEKS}, clamped #{MIN_WEEKS}..#{MAX_WEEKS})." },
+      },
+      required: []
+    )
+    annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true)
+
+    def self.call(weeks: DEFAULT_WEEKS, server_context:)
+      org = OptixOrganization.order(:id).first
+      unless org
+        return Responses.error('No Optix organization has been synced yet; membership stats are unavailable.')
+      end
+
+      weeks = weeks.to_i.clamp(MIN_WEEKS, MAX_WEEKS)
+      # Timestamp-derived, DB-only — never touches the live Optix API (H1).
+      weekly_rows = org.weekly_membership_snapshots(weeks: weeks).group_by { |r| r[:location] }
+
+      locations = org.optix_locations.order(:name).map do |loc|
+        location_block(org, loc, Array(weekly_rows[loc.name]))
+      rescue StandardError => e
+        Rails.logger.warn("[Mcp::GetMembershipStatsTool] skipping location '#{loc.name}': #{e.class}: #{e.message}")
+        Sentry.capture_exception(e) if defined?(Sentry)
+        nil
+      end.compact
+
+      Responses.ok({
+        as_of: Date.today.iso8601,
+        organization: org.name,
+        synced_at: org.synced_at&.iso8601,
+        weeks: weeks,
+        total_paying_members: total_paying_members(org),
+        locations: locations,
+      })
+    rescue StandardError => e
+      Rails.logger.warn("[Mcp::GetMembershipStatsTool] #{e.class}: #{e.message}")
+      Sentry.capture_exception(e) if defined?(Sentry)
+      Responses.error('get_membership_stats failed; the error was logged')
+    end
+
+    def self.location_block(org, loc, rows)
+      weekly_counts = rows.map do |r|
+        { week_end: r[:week_end].iso8601, patron: r[:patron], non_patron: r[:non_patron], total: r[:total] }
+      end
+      latest = weekly_counts.last || { patron: 0, non_patron: 0, total: 0 }
+
+      {
+        location: loc.name,
+        paying_members: latest[:total],
+        patron_members: latest[:patron],
+        non_patron_members: latest[:non_patron],
+        growth_4w_pct: growth_4w_pct(weekly_counts),
+        weekly_counts: weekly_counts,
+        plan_mix: plan_mix(org, loc),
+      }
+    end
+
+    # Latest week vs 4 weeks earlier ([-5] in a weekly series that includes
+    # the current week). nil when the window is too short or the baseline is
+    # zero — a percentage against nothing is noise, not signal.
+    def self.growth_4w_pct(weekly_counts)
+      return nil if weekly_counts.length < 5
+      baseline = weekly_counts[-5][:total]
+      return nil if baseline.zero?
+      (((weekly_counts.last[:total] - baseline) / baseline.to_f) * 100).round(1)
+    end
+
+    # Current paying (ACTIVE/IN_TRIAL) plans by plan-template name, for plans
+    # scoped to this location plus all-locations plans (their holders are
+    # members here too — same inclusion the weekly counts use). NOTE: the
+    # weekly series is timestamp-derived while this mix is status-derived,
+    # exactly as the two admin panels differ.
+    def self.plan_mix(org, loc)
+      specific = org.optix_account_plans.paying
+        .joins(optix_plan_template: :optix_plan_template_locations)
+        .where(optix_plan_template_locations: { optix_location_id: loc.optix_id })
+        .group('optix_plan_templates.name')
+        .count
+      in_all = org.optix_account_plans.paying
+        .joins(:optix_plan_template)
+        .where(optix_plan_templates: { in_all_locations: true })
+        .group('optix_plan_templates.name')
+        .count
+
+      specific.merge(in_all) { |_name, a, b| a + b }
+        .map { |name, count| { plan_type: name, count: count } }
+        .sort_by { |r| [-r[:count], r[:plan_type].to_s] }
+    end
+
+    # Org-wide DISTINCT members with a currently-running plan, derived from
+    # timestamps like the weekly series (status-agnostic), so all-locations
+    # members are counted once here even though they appear at every location.
+    def self.total_paying_members(org)
+      org.optix_account_plans
+        .active_at(Time.current)
+        .where.not(access_usage_user_optix_id: nil)
+        .distinct
+        .count(:access_usage_user_optix_id)
+    end
+  end
+end

--- a/app/services/mcp/get_membership_stats_tool.rb
+++ b/app/services/mcp/get_membership_stats_tool.rb
@@ -1,15 +1,19 @@
 module Mcp
   class GetMembershipStatsTool < MCP::Tool
     tool_name 'get_membership_stats'
-    description 'Coworking membership stats from the synced Optix mirror, as the admin ' \
-                'organization report shows them: per-location trailing weekly paying-member ' \
-                'counts split Patron / Non-Patron (derived from plan start/end/cancel ' \
-                'timestamps, so weekly history is computed, not stored), the current plan mix ' \
-                'per location (ACTIVE/IN_TRIAL plans by plan-template name), 4-week growth, ' \
-                'and the org-wide distinct paying-member total. COUNTS AND PLAN NAMES ONLY — ' \
-                'never member names, emails, or ids. Members on an all-locations plan count ' \
-                'at every location, so per-location totals can sum past the org-wide distinct ' \
-                'total. Figures are as of the last Optix sync (see synced_at).'
+    description 'Coworking membership stats from the synced Optix mirror: per-location ' \
+                'trailing weekly paying-member counts split Patron / Non-Patron (derived from ' \
+                'plan start/end/cancel timestamps, so weekly history is computed, not stored), ' \
+                'the current plan mix per location (ACTIVE/IN_TRIAL plans by plan-template ' \
+                'name), 4-week growth, and the org-wide distinct paying-member total. ' \
+                'plan_mix folds all-locations plans into EVERY location\'s mix — the admin ' \
+                'tier panel buckets those separately. total_paying_members is ' \
+                'timestamp-derived at call time, so it differs from the admin\'s status-based ' \
+                'Active Members figure (which also counts UPCOMING plans) and from the weekly ' \
+                'rows, which count at each Sunday end-of-day. Members on an all-locations ' \
+                'plan count at every location, so per-location totals can sum past the ' \
+                'org-wide distinct total. COUNTS AND PLAN NAMES ONLY — never member names, ' \
+                'emails, or ids. Figures are as of the last Optix sync (see synced_at).'
 
     MIN_WEEKS = 4
     MAX_WEEKS = 26

--- a/app/services/mcp/server.rb
+++ b/app/services/mcp/server.rb
@@ -36,6 +36,7 @@ module Mcp
       Mcp::GetQuarterlyReportTool,
       Mcp::GetCapacityTool,
       Mcp::GetMembershipStatsTool,
+      Mcp::GetInvoicePassesTool,
     ].freeze
 
     def self.build

--- a/app/services/mcp/server.rb
+++ b/app/services/mcp/server.rb
@@ -35,6 +35,7 @@ module Mcp
       Mcp::GetPersonMetricsTool,
       Mcp::GetQuarterlyReportTool,
       Mcp::GetCapacityTool,
+      Mcp::GetMembershipStatsTool,
     ].freeze
 
     def self.build

--- a/app/services/mcp/server.rb
+++ b/app/services/mcp/server.rb
@@ -37,6 +37,7 @@ module Mcp
       Mcp::GetCapacityTool,
       Mcp::GetMembershipStatsTool,
       Mcp::GetInvoicePassesTool,
+      Mcp::GetClientRevenueTool,
     ].freeze
 
     def self.build

--- a/docs/superpowers/plans/2026-08-05-mcp-close-report-tools.md
+++ b/docs/superpowers/plans/2026-08-05-mcp-close-report-tools.md
@@ -28,9 +28,9 @@ Sketch: `{months_back (clamp 1..24, default 6), passes: [{month, completed_at?, 
 Sketch: `{months_back (clamp 1..24, default 6), scope note (external clients, countable revenue per Stacks::ClientRevenue), clients: [{client, monthly: [{month, amount}], total, share_of_total_pct}] sorted by total desc, top param (clamp 1..50, default 15), skipped_tracker_count, mom_totals: [{month, total}]}` + optional `studio` param using the studio-share path. Reuse `Stacks::ClientRevenue` (one instance per call — heed its un-memoized/thread-safety comment); never rebuild the math. TDD; commit.
 
 ### Task 4: Wrap
-- [ ] Endpoint array = 26 sorted names + one `tools/call` round-trip per new tool.
-- [ ] Full `test/services/mcp` + endpoint + touched model tests green; run `bin/rails test` full suite once, report pre-existing failures without fixing.
-- [ ] Commit; do NOT push.
+- [x] Endpoint array = 26 sorted names + one `tools/call` round-trip per new tool.
+- [x] Full `test/services/mcp` + endpoint + touched model tests green; run `bin/rails test` full suite once, report pre-existing failures without fixing.
+- [x] Commit; do NOT push.
 
 ## Self-review notes
 Scope covers exactly the three audited gaps; budgets/projections (Google Sheets) deliberately out of scope — noted in the stacksbot-side report. The stacksbot wiring (stacks-bi contract extension + monthly transition keys) happens after merge+deploy, not in this repo.

--- a/docs/superpowers/plans/2026-08-05-mcp-close-report-tools.md
+++ b/docs/superpowers/plans/2026-08-05-mcp-close-report-tools.md
@@ -1,0 +1,36 @@
+# MCP Monthly-Close Report Tools Implementation Plan (Tier 1.5)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Three read-only MCP tools closing the signal gaps found by auditing the controller's actual monthly-close reports (📈 Financial Reports, Datazone): `get_membership_stats` (Optix), `get_invoice_passes`, `get_client_revenue`. Spec context: `docs/superpowers/specs/2026-08-05-stacks-bi-mcp-assessment.md` (Global Constraints + hazards H1–H5 bind unchanged) — this plan is its Tier-1.5 addendum.
+
+**Why these three (grounded in the reports):** the Apr-26 Coworking report links `/admin/optix_organizations/1` for weekly paying-member counts and frames profitability as "11+ Patron / 35 Non-Patron members"; the May-26 Client Services report narrates revenue client-by-client (Reactor $154K = 33%, Replit −$26K MoM, top-clients list) — `Stacks::ClientRevenue` computes exactly those rows; Hugh explicitly asked for total-invoiced / invoice-pass volume per entity — `InvoicePass` has a 388-line admin surface and no tool.
+
+## Global Constraints (additions to the assessment's)
+
+- **No member PII:** `get_membership_stats` returns COUNTS and plan-mix aggregates only — never member names/emails (the reports need counts of *paying members*; individual identity is irrelevant and stays out).
+- Client names in `get_client_revenue` are fine (business data; the reports name clients).
+- All the established house conventions (Responses.ok/error, per-row rescue-skip, enum errors listing valid values, clamps, read_only annotations, sorted endpoint-array updates, `mcp_payload` test helper, jsonb key-order caution, `travel_to` pins).
+- Cache/synced-data only (H1). If any Optix read path lazily fetches, guard it the way `IncomeSeries` guards `QboInvoice` (stored attributes only, skip + count).
+
+### Task 0: Research + payload finalization + env gate
+- [ ] `bin/rails test test/services/mcp/tools_test.rb` runs green (env gate; `db:test:prepare` if needed).
+- [ ] Read and note (file:line): the Optix models (`app/models/optix_*.rb`) + admin surfaces (`app/admin/optix_*.rb`) — how paying-member counts per location are derived (the `/admin/optix_organizations/:id` weekly-count report the controller references), how "paying" is distinguished, how plans map Patron/Non-Patron, how/when the Optix sync runs; `app/models/invoice_pass.rb` + `app/admin/invoice_passes.rb` — pass→trackers→qbo totals, month semantics, per-entity attribution; `lib/stacks/client_revenue.rb` — the Row(client, month, amount) construction, studio-share, external-client scoping, the skipped-tracker counting.
+- [ ] Finalize the three payload shapes within the sketches below, adjusting to model reality (document deviations in commit bodies).
+
+### Task 1: `get_membership_stats`
+Sketch: `{as_of, locations: [{location, paying_members, weekly_counts: [{week, count}] (trailing N weeks, clamp 4..26, default 13), plan_mix: [{plan_type, count}], growth_4w_pct}], total_paying_members}`. Mirror the admin org report's counting logic exactly (it is the controller's reference surface — "paying members only"). Counts only, no PII. TDD; registry + sorted endpoint-array; commit.
+
+### Task 2: `get_invoice_passes`
+Sketch: `{months_back (clamp 1..24, default 6), passes: [{month, completed_at?, entities: [{entity, invoiced_total, invoice_count, status_mix: {paid, unpaid, overdue, ...}}], total_invoiced}], mom: [{month, total_invoiced}]}`. Read synced QboInvoice STORED data only (IncomeSeries-style guard, skip+count blank rows). Entity attribution via each invoice's qbo_account → enterprise, echoed per the entity axis. TDD; commit.
+
+### Task 3: `get_client_revenue`
+Sketch: `{months_back (clamp 1..24, default 6), scope note (external clients, countable revenue per Stacks::ClientRevenue), clients: [{client, monthly: [{month, amount}], total, share_of_total_pct}] sorted by total desc, top param (clamp 1..50, default 15), skipped_tracker_count, mom_totals: [{month, total}]}` + optional `studio` param using the studio-share path. Reuse `Stacks::ClientRevenue` (one instance per call — heed its un-memoized/thread-safety comment); never rebuild the math. TDD; commit.
+
+### Task 4: Wrap
+- [ ] Endpoint array = 26 sorted names + one `tools/call` round-trip per new tool.
+- [ ] Full `test/services/mcp` + endpoint + touched model tests green; run `bin/rails test` full suite once, report pre-existing failures without fixing.
+- [ ] Commit; do NOT push.
+
+## Self-review notes
+Scope covers exactly the three audited gaps; budgets/projections (Google Sheets) deliberately out of scope — noted in the stacksbot-side report. The stacksbot wiring (stacks-bi contract extension + monthly transition keys) happens after merge+deploy, not in this repo.

--- a/docs/superpowers/plans/2026-08-05-mcp-close-report-tools.md
+++ b/docs/superpowers/plans/2026-08-05-mcp-close-report-tools.md
@@ -14,9 +14,9 @@
 - Cache/synced-data only (H1). If any Optix read path lazily fetches, guard it the way `IncomeSeries` guards `QboInvoice` (stored attributes only, skip + count).
 
 ### Task 0: Research + payload finalization + env gate
-- [ ] `bin/rails test test/services/mcp/tools_test.rb` runs green (env gate; `db:test:prepare` if needed).
-- [ ] Read and note (file:line): the Optix models (`app/models/optix_*.rb`) + admin surfaces (`app/admin/optix_*.rb`) — how paying-member counts per location are derived (the `/admin/optix_organizations/:id` weekly-count report the controller references), how "paying" is distinguished, how plans map Patron/Non-Patron, how/when the Optix sync runs; `app/models/invoice_pass.rb` + `app/admin/invoice_passes.rb` — pass→trackers→qbo totals, month semantics, per-entity attribution; `lib/stacks/client_revenue.rb` — the Row(client, month, amount) construction, studio-share, external-client scoping, the skipped-tracker counting.
-- [ ] Finalize the three payload shapes within the sketches below, adjusting to model reality (document deviations in commit bodies).
+- [x] `bin/rails test test/services/mcp/tools_test.rb` runs green (env gate; `db:test:prepare` if needed).
+- [x] Read and note (file:line): the Optix models (`app/models/optix_*.rb`) + admin surfaces (`app/admin/optix_*.rb`) — how paying-member counts per location are derived (the `/admin/optix_organizations/:id` weekly-count report the controller references), how "paying" is distinguished, how plans map Patron/Non-Patron, how/when the Optix sync runs; `app/models/invoice_pass.rb` + `app/admin/invoice_passes.rb` — pass→trackers→qbo totals, month semantics, per-entity attribution; `lib/stacks/client_revenue.rb` — the Row(client, month, amount) construction, studio-share, external-client scoping, the skipped-tracker counting.
+- [x] Finalize the three payload shapes within the sketches below, adjusting to model reality (document deviations in commit bodies).
 
 ### Task 1: `get_membership_stats`
 Sketch: `{as_of, locations: [{location, paying_members, weekly_counts: [{week, count}] (trailing N weeks, clamp 4..26, default 13), plan_mix: [{plan_type, count}], growth_4w_pct}], total_paying_members}`. Mirror the admin org report's counting logic exactly (it is the controller's reference surface — "paying members only"). Counts only, no PII. TDD; registry + sorted endpoint-array; commit.

--- a/lib/stacks/client_revenue.rb
+++ b/lib/stacks/client_revenue.rb
@@ -23,9 +23,15 @@ class Stacks::ClientRevenue
     @rows = build_rows
   end
 
+  # NEVER preload :qbo_invoice here — the AR association matches on qbo_id
+  # alone, and qbo_id is only composite-unique with qbo_account_id. A
+  # preloaded wrong-account invoice would win inside
+  # HasQboInvoiceViaCompositeKey#qbo_invoice (cross-account collisions would
+  # corrupt revenue rows and the nightly snapshot); unloaded, the concern
+  # does the correct (qbo_account_id, qbo_id) lookup.
   def self.all_trackers
     InvoiceTracker
-      .includes(:invoice_pass, :qbo_invoice, forecast_client: :enterprise_forecast_client)
+      .includes(:invoice_pass, forecast_client: :enterprise_forecast_client)
       .to_a
   end
 

--- a/lib/stacks/client_revenue.rb
+++ b/lib/stacks/client_revenue.rb
@@ -10,6 +10,11 @@ class Stacks::ClientRevenue
 
   attr_reader :skipped_tracker_count
 
+  # The raw Row(client, month, amount) set, oldest data first by construction
+  # order. Exposed for read-only consumers (e.g. the MCP client-revenue tool)
+  # so they reuse this math instead of rebuilding it.
+  attr_reader :rows
+
   def initialize(studio, preloaded_studios = Studio.all, trackers = nil)
     @studio = studio
     @preloaded_studios = preloaded_studios

--- a/test/integration/mcp_endpoint_test.rb
+++ b/test/integration/mcp_endpoint_test.rb
@@ -57,7 +57,7 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
     assert body.key?("result"), "Expected JSON-RPC result key, got: #{body.inspect}"
     tool_names = body["result"]["tools"].map { |t| t["name"] }
     assert_includes tool_names, "search", "Expected 'search' tool in: #{tool_names.inspect}"
-    assert_equal %w[explore_okr find_contributor get_ar_aging get_capacity get_document get_enterprise_health get_executive_dashboard get_membership_stats get_okr_grid get_person_metrics get_project_burnup get_project_contributors get_project_cost_breakdown get_quarterly_report get_resourcing_projections get_studio_health list_documents list_open_admin_tasks list_overdue_invoices list_payable_bills list_project_trackers list_projects_at_risk list_sources search], tool_names.sort,
+    assert_equal %w[explore_okr find_contributor get_ar_aging get_capacity get_document get_enterprise_health get_executive_dashboard get_invoice_passes get_membership_stats get_okr_grid get_person_metrics get_project_burnup get_project_contributors get_project_cost_breakdown get_quarterly_report get_resourcing_projections get_studio_health list_documents list_open_admin_tasks list_overdue_invoices list_payable_bills list_project_trackers list_projects_at_risk list_sources search], tool_names.sort,
       "Expected all registered tools, got: #{tool_names.inspect}"
   end
 

--- a/test/integration/mcp_endpoint_test.rb
+++ b/test/integration/mcp_endpoint_test.rb
@@ -371,7 +371,10 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
     assert_equal "Sanctuary Computer Inc", entity["entity"]
     assert_equal 1200.0, entity["invoiced_total"]
     assert_equal({ "paid" => 1 }, entity["status_mix"])
-    assert_equal [{ "month" => "2026-07-01", "total_invoiced" => 1200.0 }], payload["mom"]
+    assert_equal [{ "month" => "2026-06-01", "total_invoiced" => 0.0 },
+                  { "month" => "2026-07-01", "total_invoiced" => 1200.0 },
+                  { "month" => "2026-08-01", "total_invoiced" => 0.0 }], payload["mom"],
+      "mom zero-fills pass-less months across the window"
   end
 
   test "tools/call round-trip for get_client_revenue returns client x month rows" do

--- a/test/integration/mcp_endpoint_test.rb
+++ b/test/integration/mcp_endpoint_test.rb
@@ -57,7 +57,7 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
     assert body.key?("result"), "Expected JSON-RPC result key, got: #{body.inspect}"
     tool_names = body["result"]["tools"].map { |t| t["name"] }
     assert_includes tool_names, "search", "Expected 'search' tool in: #{tool_names.inspect}"
-    assert_equal %w[explore_okr find_contributor get_ar_aging get_capacity get_document get_enterprise_health get_executive_dashboard get_okr_grid get_person_metrics get_project_burnup get_project_contributors get_project_cost_breakdown get_quarterly_report get_resourcing_projections get_studio_health list_documents list_open_admin_tasks list_overdue_invoices list_payable_bills list_project_trackers list_projects_at_risk list_sources search], tool_names.sort,
+    assert_equal %w[explore_okr find_contributor get_ar_aging get_capacity get_document get_enterprise_health get_executive_dashboard get_membership_stats get_okr_grid get_person_metrics get_project_burnup get_project_contributors get_project_cost_breakdown get_quarterly_report get_resourcing_projections get_studio_health list_documents list_open_admin_tasks list_overdue_invoices list_payable_bills list_project_trackers list_projects_at_risk list_sources search], tool_names.sort,
       "Expected all registered tools, got: #{tool_names.inspect}"
   end
 

--- a/test/integration/mcp_endpoint_test.rb
+++ b/test/integration/mcp_endpoint_test.rb
@@ -330,6 +330,72 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
     assert_equal true, payload["degraded"]
   end
 
+  test "tools/call round-trip for get_membership_stats returns counts with no member PII" do
+    travel_to Time.zone.parse("2026-08-04 12:00:00")
+    org = OptixOrganization.create!(name: "Endpoint Org", synced_at: Time.zone.now)
+    loc = OptixLocation.create!(optix_id: "ep-loc", optix_organization: org, name: "Annex")
+    tpl = OptixPlanTemplate.create!(optix_id: "ep-tpl", optix_organization: org, name: "Patron Membership")
+    OptixPlanTemplateLocation.create!(optix_plan_template_id: tpl.optix_id, optix_location_id: loc.optix_id)
+    OptixUser.create!(optix_id: "ep-user", optix_organization: org, email: "member@example.com", name: "Member")
+    OptixAccountPlan.create!(optix_id: "ep-plan", optix_organization: org,
+      optix_plan_template_id: tpl.optix_id, access_usage_user_optix_id: "ep-user",
+      status: "ACTIVE", start_timestamp: 10.weeks.ago.to_i)
+
+    payload = call_tool("get_membership_stats", { "weeks" => 6 })
+
+    assert_equal "Endpoint Org", payload["organization"]
+    assert_equal 1, payload["total_paying_members"]
+    annex = payload["locations"].find { |l| l["location"] == "Annex" }
+    assert_equal 1, annex["paying_members"]
+    assert_equal 1, annex["patron_members"]
+    assert_equal 6, annex["weekly_counts"].length
+    assert_equal [{ "plan_type" => "Patron Membership", "count" => 1 }], annex["plan_mix"]
+    refute_includes response.body, "member@example.com", "no member PII may cross the endpoint"
+    refute_includes response.body, "ep-user"
+  end
+
+  test "tools/call round-trip for get_invoice_passes attributes entities from stored data" do
+    travel_to Time.zone.parse("2026-08-04 12:00:00")
+    pass = InvoicePass.create!(start_of_month: Date.new(2026, 7, 1))
+    client = ForecastClient.create!(forecast_id: 88_200_001, name: "Endpoint Client")
+    qa = Enterprise.find(enterprises(:sanctuary).id).qbo_account
+    QboInvoice.create!(qbo_account: qa, qbo_id: "ep-inv",
+      data: { "total" => 1200.0, "balance" => 0.0, "email_status" => "EmailSent", "due_date" => "2026-08-15" })
+    InvoiceTracker.create!(invoice_pass: pass, forecast_client_id: client.forecast_id,
+      qbo_account: qa, qbo_invoice_id: "ep-inv", blueprint: { "lines" => {} })
+
+    payload = call_tool("get_invoice_passes", { "months_back" => 3 })
+
+    assert_equal ["2026-07-01"], payload["passes"].map { |p| p["month"] }
+    entity = payload["passes"].first["entities"].first
+    assert_equal "Sanctuary Computer Inc", entity["entity"]
+    assert_equal 1200.0, entity["invoiced_total"]
+    assert_equal({ "paid" => 1 }, entity["status_mix"])
+    assert_equal [{ "month" => "2026-07-01", "total_invoiced" => 1200.0 }], payload["mom"]
+  end
+
+  test "tools/call round-trip for get_client_revenue returns client x month rows" do
+    travel_to Time.zone.parse("2026-08-04 12:00:00")
+    make_studio!
+    pass = InvoicePass.create!(start_of_month: Date.new(2026, 7, 1))
+    client = ForecastClient.create!(forecast_id: 88_300_001, name: "Endpoint Revenue Client")
+    qa = Enterprise.find(enterprises(:sanctuary).id).qbo_account
+    QboInvoice.create!(qbo_account: qa, qbo_id: "ep-rev",
+      data: { "total" => 4000.0, "balance" => 0.0, "email_status" => "EmailSent", "due_date" => "2026-08-15" })
+    InvoiceTracker.create!(invoice_pass: pass, forecast_client_id: client.forecast_id,
+      qbo_account: qa, qbo_invoice_id: "ep-rev", blueprint: { "lines" => {} })
+
+    payload = call_tool("get_client_revenue", { "months_back" => 2 })
+
+    assert_equal "garden3d", payload["studio"]
+    row = payload["clients"].find { |c| c["client"] == "Endpoint Revenue Client" }
+    assert_equal 4000.0, row["total"]
+    assert_equal [{ "month" => "2026-07-01", "amount" => 4000.0 }, { "month" => "2026-08-01", "amount" => 0.0 }],
+      row["monthly"]
+    assert_equal 4000.0, payload["total_revenue"]
+    assert_equal 0, payload["skipped_tracker_count"]
+  end
+
   test "find_contributor is exposed on the read surface and returns matches" do
     ForecastPerson.create!(forecast_id: 7_654_321, first_name: "Hugh", last_name: "Person",
       email: "hugh@sanctuary.computer", archived: false, roles: [], updated_at: Time.current)

--- a/test/integration/mcp_endpoint_test.rb
+++ b/test/integration/mcp_endpoint_test.rb
@@ -57,7 +57,7 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
     assert body.key?("result"), "Expected JSON-RPC result key, got: #{body.inspect}"
     tool_names = body["result"]["tools"].map { |t| t["name"] }
     assert_includes tool_names, "search", "Expected 'search' tool in: #{tool_names.inspect}"
-    assert_equal %w[explore_okr find_contributor get_ar_aging get_capacity get_document get_enterprise_health get_executive_dashboard get_invoice_passes get_membership_stats get_okr_grid get_person_metrics get_project_burnup get_project_contributors get_project_cost_breakdown get_quarterly_report get_resourcing_projections get_studio_health list_documents list_open_admin_tasks list_overdue_invoices list_payable_bills list_project_trackers list_projects_at_risk list_sources search], tool_names.sort,
+    assert_equal %w[explore_okr find_contributor get_ar_aging get_capacity get_client_revenue get_document get_enterprise_health get_executive_dashboard get_invoice_passes get_membership_stats get_okr_grid get_person_metrics get_project_burnup get_project_contributors get_project_cost_breakdown get_quarterly_report get_resourcing_projections get_studio_health list_documents list_open_admin_tasks list_overdue_invoices list_payable_bills list_project_trackers list_projects_at_risk list_sources search], tool_names.sort,
       "Expected all registered tools, got: #{tool_names.inspect}"
   end
 

--- a/test/services/mcp/client_revenue_tool_test.rb
+++ b/test/services/mcp/client_revenue_tool_test.rb
@@ -98,6 +98,30 @@ class Mcp::ClientRevenueToolTest < ActiveSupport::TestCase
     )
   end
 
+  test 'cross-account qbo_id collisions resolve each tracker to its own account invoice' do
+    # qbo_id is only composite-unique with qbo_account_id. A qbo_id-only
+    # preload in Stacks::ClientRevenue.all_trackers would hand one account's
+    # invoice to BOTH trackers (this also protects the nightly snapshot).
+    one_qa = QboAccount.create!(enterprise: enterprises(:one), client_id: 'c',
+                                client_secret: 's', realm_id: "r-#{SecureRandom.hex(4)}")
+    QboInvoice.create!(qbo_account: @qa, qbo_id: 'cr-dup',
+                       data: { 'total' => 999.0, 'email_status' => 'EmailSent', 'balance' => 0.0, 'due_date' => '2026-08-15' })
+    QboInvoice.create!(qbo_account: one_qa, qbo_id: 'cr-dup',
+                       data: { 'total' => 100.0, 'email_status' => 'EmailSent', 'balance' => 0.0, 'due_date' => '2026-08-15' })
+    InvoiceTracker.create!(invoice_pass: @july, forecast_client_id: @reactor.forecast_id,
+                           qbo_account: @qa, qbo_invoice_id: 'cr-dup', blueprint: { 'lines' => {} })
+    InvoiceTracker.create!(invoice_pass: @july, forecast_client_id: @replit.forecast_id,
+                           qbo_account: one_qa, qbo_invoice_id: 'cr-dup', blueprint: { 'lines' => {} })
+
+    payload = mcp_payload(Mcp::GetClientRevenueTool.call(server_context: {}))
+
+    reactor = payload['clients'].find { |c| c['client'] == 'Reactor' }
+    replit = payload['clients'].find { |c| c['client'] == 'Replit' }
+    assert_equal 999.0, reactor['total']
+    assert_equal 100.0, replit['total'], "Replit must report its own account's invoice total"
+    assert_equal 1099.0, payload['total_revenue']
+  end
+
   test 'top clamps 1..50 and trims the client list without changing the window totals' do
     seed!
 

--- a/test/services/mcp/client_revenue_tool_test.rb
+++ b/test/services/mcp/client_revenue_tool_test.rb
@@ -1,0 +1,154 @@
+require 'test_helper'
+
+class Mcp::ClientRevenueToolTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::TimeHelpers
+
+  setup do
+    travel_to Time.zone.parse('2026-08-04 12:00:00')
+    @tb, @g3d = make_studio!
+    @qa = Enterprise.find(enterprises(:sanctuary).id).qbo_account
+
+    @reactor = ForecastClient.create!(forecast_id: 9201, name: 'Reactor')
+    @replit = ForecastClient.create!(forecast_id: 9202, name: 'Replit')
+
+    @may = InvoicePass.create!(start_of_month: Date.new(2026, 5, 1))
+    @june = InvoicePass.create!(start_of_month: Date.new(2026, 6, 1))
+    @july = InvoicePass.create!(start_of_month: Date.new(2026, 7, 1))
+
+    # ClientRevenue's own guard skips blank-data mirrors; nothing here may
+    # ever fire QboInvoice's lazy live sync.
+    QboInvoice.any_instance.expects(:sync!).never
+  end
+
+  def invoiced_tracker!(pass, client, qbo_id, total, blueprint: { 'lines' => {} }, data_extra: {})
+    QboInvoice.create!(qbo_account: @qa, qbo_id: qbo_id,
+                       data: { 'total' => total, 'email_status' => 'EmailSent', 'balance' => 0.0, 'due_date' => '2026-08-15' }.merge(data_extra))
+    InvoiceTracker.create!(invoice_pass: pass, forecast_client_id: client.forecast_id,
+                           qbo_account: @qa, qbo_invoice_id: qbo_id, blueprint: blueprint)
+  end
+
+  def seed!
+    invoiced_tracker!(@may, @reactor, 'cr-1', 1000.0)
+    invoiced_tracker!(@june, @reactor, 'cr-2', 2000.0)
+    invoiced_tracker!(@july, @reactor, 'cr-3', 3000.0)
+    invoiced_tracker!(@june, @replit, 'cr-4', 1000.0)
+
+    # Voided invoice: not countable revenue.
+    invoiced_tracker!(@july, @replit, 'cr-void', 9999.0,
+                      data_extra: { 'email_status' => 'NotSet', 'private_note' => 'Voided by accountant' })
+
+    # Internal client (mapped to an enterprise): never countable.
+    internal = ForecastClient.create!(forecast_id: 9203, name: 'Internal Corp')
+    EnterpriseForecastClient.create!(enterprise: enterprises(:sanctuary), forecast_client: internal)
+    invoiced_tracker!(@july, internal, 'cr-int', 5000.0)
+
+    # Blank stored data: skipped + counted by ClientRevenue's guard. Its own
+    # client — trackers are unique per (forecast_client, invoice_pass).
+    blanky = ForecastClient.create!(forecast_id: 9204, name: 'Blanky')
+    QboInvoice.create!(qbo_account: @qa, qbo_id: 'cr-blank', data: {})
+    InvoiceTracker.create!(invoice_pass: @july, forecast_client_id: blanky.forecast_id,
+                           qbo_account: @qa, qbo_invoice_id: 'cr-blank', blueprint: { 'lines' => {} })
+
+    # Outside every window this test uses.
+    old = InvoicePass.create!(start_of_month: Date.new(2024, 1, 1))
+    invoiced_tracker!(old, @reactor, 'cr-old', 77_777.0)
+  end
+
+  test 'client-by-month revenue rows for garden3d: full totals, external clients, top-N by total' do
+    seed!
+
+    payload = mcp_payload(Mcp::GetClientRevenueTool.call(server_context: {}))
+
+    assert_equal '2026-08-04', payload['as_of']
+    assert_equal 'garden3d', payload['studio']
+    assert_equal 6, payload['months_back']
+    assert_includes payload['scope'], 'External clients'
+
+    assert_equal %w[Reactor Replit], payload['clients'].map { |c| c['client'] },
+      'sorted by window total desc; voided + internal + out-of-window rows never appear'
+
+    reactor = payload['clients'].first
+    assert_equal 6000.0, reactor['total']
+    assert_equal 85.7, reactor['share_of_total_pct']
+    assert_equal(
+      [{ 'month' => '2026-03-01', 'amount' => 0.0 },
+       { 'month' => '2026-04-01', 'amount' => 0.0 },
+       { 'month' => '2026-05-01', 'amount' => 1000.0 },
+       { 'month' => '2026-06-01', 'amount' => 2000.0 },
+       { 'month' => '2026-07-01', 'amount' => 3000.0 },
+       { 'month' => '2026-08-01', 'amount' => 0.0 }],
+      reactor['monthly'], 'zero-filled across the whole window, oldest first'
+    )
+
+    replit = payload['clients'].last
+    assert_equal 1000.0, replit['total']
+    assert_equal 14.3, replit['share_of_total_pct']
+
+    assert_equal 7000.0, payload['total_revenue']
+    assert_equal 2, payload['client_count']
+    assert_equal 1, payload['skipped_tracker_count'], 'the blank-data mirror is skipped and counted'
+    assert_equal(
+      [{ 'month' => '2026-03-01', 'total' => 0.0 },
+       { 'month' => '2026-04-01', 'total' => 0.0 },
+       { 'month' => '2026-05-01', 'total' => 1000.0 },
+       { 'month' => '2026-06-01', 'total' => 3000.0 },
+       { 'month' => '2026-07-01', 'total' => 3000.0 },
+       { 'month' => '2026-08-01', 'total' => 0.0 }],
+      payload['mom_totals']
+    )
+  end
+
+  test 'top clamps 1..50 and trims the client list without changing the window totals' do
+    seed!
+
+    payload = mcp_payload(Mcp::GetClientRevenueTool.call(top: 1, server_context: {}))
+    assert_equal ['Reactor'], payload['clients'].map { |c| c['client'] }
+    assert_equal 7000.0, payload['total_revenue'], 'window totals cover clients beyond the top-N cut'
+    assert_equal 2, payload['client_count']
+
+    payload = mcp_payload(Mcp::GetClientRevenueTool.call(top: 0, server_context: {}))
+    assert_equal 1, payload['clients'].length, 'top clamps up to 1'
+  end
+
+  test 'months_back clamps 1..24 and windows the rows' do
+    seed!
+
+    payload = mcp_payload(Mcp::GetClientRevenueTool.call(months_back: 100, server_context: {}))
+    assert_equal 24, payload['months_back']
+    assert_equal 24, payload['mom_totals'].length
+    assert_equal 7000.0, payload['total_revenue'], 'even the widest window excludes the 2024 rows'
+
+    payload = mcp_payload(Mcp::GetClientRevenueTool.call(months_back: 2, server_context: {}))
+    assert_equal %w[2026-07-01 2026-08-01], payload['mom_totals'].map { |m| m['month'] }
+    assert_equal 3000.0, payload['total_revenue']
+  end
+
+  test 'a sub-studio takes its pro-rata blueprint share instead of full invoice totals' do
+    ForecastPerson.create!(forecast_id: 9301, first_name: 'Tee', last_name: 'Bee', roles: ['Thoughtbot'])
+    ForecastPerson.create!(forecast_id: 9302, first_name: 'Gee', last_name: 'Dee', roles: ['garden3d'])
+
+    invoiced_tracker!(@july, @reactor, 'cr-split', 2000.0, blueprint: {
+      'lines' => {
+        'Tee Bee work' => { 'id' => '1', 'quantity' => 10, 'unit_price' => 100.0, 'forecast_person' => 9301 },
+        'Gee Dee work' => { 'id' => '2', 'quantity' => 10, 'unit_price' => 100.0, 'forecast_person' => 9302 },
+      },
+    })
+    # A tracker with no usable blueprint lines is omitted from sub-studio
+    # numbers (it still counts for garden3d).
+    invoiced_tracker!(@june, @replit, 'cr-nolines', 1000.0)
+
+    payload = mcp_payload(Mcp::GetClientRevenueTool.call(studio: 'tb', server_context: {}))
+
+    assert_equal 'Thoughtbot', payload['studio']
+    assert_equal ['Reactor'], payload['clients'].map { |c| c['client'] }
+    assert_equal 1000.0, payload['clients'].first['total'], 'half the blueprint value → half the invoice total'
+    assert_equal 1000.0, payload['total_revenue']
+  end
+
+  test 'unknown studio errors listing the valid studios' do
+    err = mcp_payload(Mcp::GetClientRevenueTool.call(studio: 'nope', server_context: {}))
+    assert_includes err['error'], "Unknown studio 'nope'"
+    assert_includes err['error'], 'garden3d'
+    assert_includes err['error'], 'Thoughtbot'
+  end
+end

--- a/test/services/mcp/client_revenue_tool_test.rb
+++ b/test/services/mcp/client_revenue_tool_test.rb
@@ -169,6 +169,25 @@ class Mcp::ClientRevenueToolTest < ActiveSupport::TestCase
     assert_equal 1000.0, payload['total_revenue']
   end
 
+  test 'a sent invoice with malformed stored data is skipped and counted, dropping its revenue' do
+    # EmailSent with no due_date: QboInvoice#status raises inside
+    # ClientRevenue's voided check, so the tracker is skipped + counted.
+    # DIVERGES from get_invoice_passes, which buckets the same row as status
+    # `unknown` and still counts its total.
+    weird = ForecastClient.create!(forecast_id: 9205, name: 'Weird Data Client')
+    QboInvoice.create!(qbo_account: @qa, qbo_id: 'cr-weird',
+                       data: { 'total' => 100.0, 'balance' => 100.0, 'email_status' => 'EmailSent' })
+    InvoiceTracker.create!(invoice_pass: @july, forecast_client_id: weird.forecast_id,
+                           qbo_account: @qa, qbo_invoice_id: 'cr-weird', blueprint: { 'lines' => {} })
+
+    payload = mcp_payload(Mcp::GetClientRevenueTool.call(server_context: {}))
+
+    refute payload['clients'].any? { |c| c['client'] == 'Weird Data Client' },
+      'the malformed tracker contributes no revenue row'
+    assert_equal 0.0, payload['total_revenue']
+    assert_equal 1, payload['skipped_tracker_count']
+  end
+
   test 'unknown studio errors listing the valid studios' do
     err = mcp_payload(Mcp::GetClientRevenueTool.call(studio: 'nope', server_context: {}))
     assert_includes err['error'], "Unknown studio 'nope'"

--- a/test/services/mcp/invoice_passes_tool_test.rb
+++ b/test/services/mcp/invoice_passes_tool_test.rb
@@ -95,10 +95,30 @@ class Mcp::InvoicePassesToolTest < ActiveSupport::TestCase
     assert_equal 0, one['skipped_invoices']
 
     assert_equal(
-      [{ 'month' => '2026-06-01', 'total_invoiced' => 2000.0 },
-       { 'month' => '2026-07-01', 'total_invoiced' => 1750.0 }],
-      payload['mom']
+      [{ 'month' => '2026-03-01', 'total_invoiced' => 0.0 },
+       { 'month' => '2026-04-01', 'total_invoiced' => 0.0 },
+       { 'month' => '2026-05-01', 'total_invoiced' => 0.0 },
+       { 'month' => '2026-06-01', 'total_invoiced' => 2000.0 },
+       { 'month' => '2026-07-01', 'total_invoiced' => 1750.0 },
+       { 'month' => '2026-08-01', 'total_invoiced' => 0.0 }],
+      payload['mom'], 'zero-filled across the whole window, oldest first'
     )
+  end
+
+  test 'future passes are excluded from passes and the mom series' do
+    seed_july!
+    future = InvoicePass.create!(start_of_month: Date.new(2026, 9, 1))
+    invoice!('inv-future', { 'total' => 5555.0, 'balance' => 0.0, 'email_status' => 'EmailSent', 'due_date' => '2026-10-15' })
+    tracker!(future, @client, qbo_invoice_id: 'inv-future', blueprint: { 'lines' => {} })
+
+    payload = mcp_payload(Mcp::GetInvoicePassesTool.call(server_context: {}))
+
+    assert_equal %w[2026-06-01 2026-07-01], payload['passes'].map { |p| p['month'] },
+      'a pass dated after the current month never appears'
+    assert_equal %w[2026-03-01 2026-04-01 2026-05-01 2026-06-01 2026-07-01 2026-08-01],
+      payload['mom'].map { |m| m['month'] },
+      'the mom series stops at the current month'
+    refute payload['mom'].any? { |m| m['total_invoiced'] == 5555.0 }
   end
 
   test 'the same qbo_id in two qbo_accounts resolves each tracker to its own account invoice' do
@@ -200,9 +220,12 @@ class Mcp::InvoicePassesToolTest < ActiveSupport::TestCase
     assert_equal 24, payload['months_back']
     assert_equal %w[2026-06-01 2026-07-01], payload['passes'].map { |p| p['month'] },
       'even the widest window excludes the 2023 pass'
+    assert_equal 24, payload['mom'].length, 'mom zero-fills every month of the window'
 
     payload = mcp_payload(Mcp::GetInvoicePassesTool.call(months_back: 0, server_context: {}))
     assert_equal 1, payload['months_back']
     assert_equal [], payload['passes'], 'no pass exists for the current month'
+    assert_equal [{ 'month' => '2026-08-01', 'total_invoiced' => 0.0 }], payload['mom'],
+      'a pass-less current month still gets a zero mom row'
   end
 end

--- a/test/services/mcp/invoice_passes_tool_test.rb
+++ b/test/services/mcp/invoice_passes_tool_test.rb
@@ -1,0 +1,139 @@
+require 'test_helper'
+
+class Mcp::InvoicePassesToolTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::TimeHelpers
+
+  setup do
+    travel_to Time.zone.parse('2026-08-04 12:00:00')
+    @sanctuary = enterprises(:sanctuary)
+    # Fixtures attach TWO qbo_accounts to sanctuary; pin the one has_one picks.
+    @sanct_qa = Enterprise.find(@sanctuary.id).qbo_account
+    @one = enterprises(:one)
+    @one_qa = QboAccount.create!(enterprise: @one, client_id: 'c', client_secret: 's', realm_id: "r-#{SecureRandom.hex(4)}")
+
+    @client = ForecastClient.create!(forecast_id: 9101, name: 'Reactor')
+    @client_b = ForecastClient.create!(forecast_id: 9102, name: 'Replit')
+    @client_c = ForecastClient.create!(forecast_id: 9103, name: 'Curology')
+    @client_d = ForecastClient.create!(forecast_id: 9104, name: 'Left Field')
+    @client_e = ForecastClient.create!(forecast_id: 9105, name: 'Koto')
+
+    @june = InvoicePass.create!(start_of_month: Date.new(2026, 6, 1), completed_at: Time.zone.parse('2026-07-03 10:00:00'))
+    @july = InvoicePass.create!(start_of_month: Date.new(2026, 7, 1))
+    @ancient = InvoicePass.create!(start_of_month: Date.new(2023, 1, 1))
+
+    # QboInvoice#data lazily live-syncs (and can DESTROY the row) when the
+    # stored jsonb is blank — the tool must only ever read stored attributes.
+    QboInvoice.any_instance.expects(:sync!).never
+  end
+
+  def invoice!(qbo_id, data, account: @sanct_qa)
+    QboInvoice.create!(qbo_account: account, qbo_id: qbo_id, data: data)
+  end
+
+  def tracker!(pass, client, qbo_invoice_id: nil, account: @sanct_qa, blueprint: nil)
+    InvoiceTracker.create!(
+      invoice_pass: pass,
+      forecast_client_id: client.forecast_id,
+      qbo_account: account,
+      qbo_invoice_id: qbo_invoice_id,
+      blueprint: blueprint,
+    )
+  end
+
+  def seed_july!
+    invoice!('inv-paid', { 'total' => 1000.0, 'balance' => 0.0, 'email_status' => 'EmailSent', 'due_date' => '2026-08-15' })
+    tracker!(@july, @client, qbo_invoice_id: 'inv-paid', blueprint: { 'lines' => {} })
+
+    invoice!('inv-overdue', { 'total' => 500.0, 'balance' => 500.0, 'email_status' => 'EmailSent', 'due_date' => '2026-07-20' })
+    tracker!(@july, @client_b, qbo_invoice_id: 'inv-overdue', blueprint: { 'lines' => {} })
+
+    invoice!('inv-one', { 'total' => 250.0, 'balance' => 250.0, 'email_status' => 'EmailSent', 'due_date' => '2026-09-01' }, account: @one_qa)
+    tracker!(@july, @client_c, qbo_invoice_id: 'inv-one', account: @one_qa, blueprint: { 'lines' => {} })
+
+    # Unsynced mirror (blank stored data): skipped + counted, NEVER synced live.
+    invoice!('inv-blank', {})
+    tracker!(@july, @client_d, qbo_invoice_id: 'inv-blank', blueprint: { 'lines' => {} })
+
+    # No invoice yet, no blueprint: the tracker is not_made.
+    tracker!(@july, @client_e)
+  end
+
+  test 'per-pass per-entity invoiced totals, status mix and MoM series from stored data only' do
+    seed_july!
+    invoice!('inv-june', { 'total' => 2000.0, 'balance' => 0.0, 'email_status' => 'EmailSent', 'due_date' => '2026-07-01' })
+    tracker!(@june, @client, qbo_invoice_id: 'inv-june', blueprint: { 'lines' => {} })
+
+    payload = mcp_payload(Mcp::GetInvoicePassesTool.call(server_context: {}))
+
+    assert_equal '2026-08-04', payload['as_of']
+    assert_equal 6, payload['months_back']
+    assert_equal %w[2026-06-01 2026-07-01], payload['passes'].map { |p| p['month'] },
+      'oldest first; the 2023 pass is outside the window'
+
+    june = payload['passes'].first
+    assert_equal 'June 2026', june['label']
+    assert_equal @june.completed_at.iso8601, june['completed_at']
+    assert_equal false, june['missing_hours']
+    assert_equal 2000.0, june['total_invoiced']
+
+    july = payload['passes'].last
+    assert_nil july['completed_at']
+    assert_equal 1750.0, july['total_invoiced']
+    assert_equal ['One LLC', 'Sanctuary Computer Inc'], july['entities'].map { |e| e['entity'] },
+      'entities sorted by name; only entities with trackers in the pass appear'
+
+    sanct = july['entities'].find { |e| e['entity'] == 'Sanctuary Computer Inc' }
+    assert_equal 1500.0, sanct['invoiced_total']
+    assert_equal 2, sanct['invoice_count']
+    assert_equal({ 'paid' => 1, 'unpaid_overdue' => 1, 'not_made' => 1 }, sanct['status_mix'])
+    assert_equal 1, sanct['skipped_invoices'], 'the blank-data mirror is skipped and counted'
+
+    one = july['entities'].find { |e| e['entity'] == 'One LLC' }
+    assert_equal 250.0, one['invoiced_total']
+    assert_equal 1, one['invoice_count']
+    assert_equal({ 'unpaid' => 1 }, one['status_mix'])
+    assert_equal 0, one['skipped_invoices']
+
+    assert_equal(
+      [{ 'month' => '2026-06-01', 'total_invoiced' => 2000.0 },
+       { 'month' => '2026-07-01', 'total_invoiced' => 1750.0 }],
+      payload['mom']
+    )
+  end
+
+  test 'a sent invoice with malformed stored data still counts its total, as status unknown' do
+    # EmailSent with no due_date: QboInvoice#status raises on Date.parse.
+    invoice!('inv-weird', { 'total' => 100.0, 'balance' => 100.0, 'email_status' => 'EmailSent' })
+    tracker!(@july, @client, qbo_invoice_id: 'inv-weird', blueprint: { 'lines' => {} })
+
+    sanct = mcp_payload(Mcp::GetInvoicePassesTool.call(server_context: {}))['passes']
+      .find { |p| p['month'] == '2026-07-01' }['entities']
+      .find { |e| e['entity'] == 'Sanctuary Computer Inc' }
+
+    assert_equal 100.0, sanct['invoiced_total']
+    assert_equal({ 'unknown' => 1 }, sanct['status_mix'])
+  end
+
+  test 'a pass stuck on missing hours is flagged' do
+    # Keys must round-trip through DateTime#iso8601 (the model looks the
+    # latest pass up by re-serializing the parsed key): +00:00, never Z.
+    @july.update!(data: { 'reminder_passes' => { '2026-08-01T09:00:00+00:00' => ['Someone Behind'] } })
+
+    july = mcp_payload(Mcp::GetInvoicePassesTool.call(server_context: {}))['passes']
+      .find { |p| p['month'] == '2026-07-01' }
+    assert_equal true, july['missing_hours']
+  end
+
+  test 'months_back clamps to 1..24 and windows the passes' do
+    seed_july!
+
+    payload = mcp_payload(Mcp::GetInvoicePassesTool.call(months_back: 100, server_context: {}))
+    assert_equal 24, payload['months_back']
+    assert_equal %w[2026-06-01 2026-07-01], payload['passes'].map { |p| p['month'] },
+      'even the widest window excludes the 2023 pass'
+
+    payload = mcp_payload(Mcp::GetInvoicePassesTool.call(months_back: 0, server_context: {}))
+    assert_equal 1, payload['months_back']
+    assert_equal [], payload['passes'], 'no pass exists for the current month'
+  end
+end

--- a/test/services/mcp/invoice_passes_tool_test.rb
+++ b/test/services/mcp/invoice_passes_tool_test.rb
@@ -122,6 +122,23 @@ class Mcp::InvoicePassesToolTest < ActiveSupport::TestCase
     assert_equal({ 'unpaid' => 1 }, one['status_mix'])
   end
 
+  test 'a tracker with an invoice but no blueprint reports status impossible, total still counted' do
+    # Mirrors InvoiceTracker#status precedence: qbo_invoice present +
+    # blueprint.nil? => :impossible, never the invoice's own status. The
+    # total still counts (parity with InvoicePass#value, which sums every
+    # linked invoice regardless of blueprint).
+    invoice!('inv-impossible', { 'total' => 400.0, 'balance' => 0.0, 'email_status' => 'EmailSent', 'due_date' => '2026-08-15' })
+    tracker!(@july, @client, qbo_invoice_id: 'inv-impossible', blueprint: nil)
+
+    sanct = mcp_payload(Mcp::GetInvoicePassesTool.call(server_context: {}))['passes']
+      .find { |p| p['month'] == '2026-07-01' }['entities']
+      .find { |e| e['entity'] == 'Sanctuary Computer Inc' }
+
+    assert_equal 400.0, sanct['invoiced_total']
+    assert_equal 1, sanct['invoice_count']
+    assert_equal({ 'impossible' => 1 }, sanct['status_mix'])
+  end
+
   test 'a sent invoice with malformed stored data still counts its total, as status unknown' do
     # EmailSent with no due_date: QboInvoice#status raises on Date.parse.
     invoice!('inv-weird', { 'total' => 100.0, 'balance' => 100.0, 'email_status' => 'EmailSent' })

--- a/test/services/mcp/invoice_passes_tool_test.rb
+++ b/test/services/mcp/invoice_passes_tool_test.rb
@@ -162,6 +162,37 @@ class Mcp::InvoicePassesToolTest < ActiveSupport::TestCase
     assert_equal true, july['missing_hours']
   end
 
+  test 'a completed pass whose latest reminder pass is empty is not missing hours' do
+    # The production-common completed-pass shape: Automator writes a reminder
+    # pass on EVERY run (lib/stacks/automator.rb), so completed passes carry
+    # reminder_passes whose latest value is {} (nobody left to remind).
+    @june.update!(data: { 'reminder_passes' => {
+      '2026-06-25T09:00:00+00:00' => { 'someone@example.com' => { 'missing_allocation' => 8 } },
+      '2026-07-01T09:00:00+00:00' => {},
+    } })
+
+    june = mcp_payload(Mcp::GetInvoicePassesTool.call(server_context: {}))['passes']
+      .find { |p| p['month'] == '2026-06-01' }
+    assert_equal false, june['missing_hours'],
+      'an empty latest reminder pass means everyone recorded hours'
+  end
+
+  test 'a voided invoice still counts in invoiced_total and appears as voided in the status mix' do
+    # Parity with the admin value column (InvoicePass#value counts every
+    # linked invoice); the status mix is where voided is separated out.
+    invoice!('inv-void', { 'total' => 800.0, 'balance' => 0.0, 'email_status' => 'NotSet',
+                           'private_note' => 'Voided by accountant' })
+    tracker!(@july, @client, qbo_invoice_id: 'inv-void', blueprint: { 'lines' => {} })
+
+    sanct = mcp_payload(Mcp::GetInvoicePassesTool.call(server_context: {}))['passes']
+      .find { |p| p['month'] == '2026-07-01' }['entities']
+      .find { |e| e['entity'] == 'Sanctuary Computer Inc' }
+
+    assert_equal 800.0, sanct['invoiced_total'], 'voided totals still count (admin value parity)'
+    assert_equal 1, sanct['invoice_count']
+    assert_equal({ 'voided' => 1 }, sanct['status_mix'])
+  end
+
   test 'months_back clamps to 1..24 and windows the passes' do
     seed_july!
 

--- a/test/services/mcp/invoice_passes_tool_test.rb
+++ b/test/services/mcp/invoice_passes_tool_test.rb
@@ -101,6 +101,27 @@ class Mcp::InvoicePassesToolTest < ActiveSupport::TestCase
     )
   end
 
+  test 'the same qbo_id in two qbo_accounts resolves each tracker to its own account invoice' do
+    # qbo_id is only composite-unique with qbo_account_id (Deel-style ID
+    # collision). A qbo_id-only preload would hand one account's invoice to
+    # BOTH trackers; each entity must report its own account's total.
+    invoice!('inv-dup', { 'total' => 999.0, 'balance' => 0.0, 'email_status' => 'EmailSent', 'due_date' => '2026-08-15' })
+    invoice!('inv-dup', { 'total' => 100.0, 'balance' => 100.0, 'email_status' => 'EmailSent', 'due_date' => '2026-09-01' }, account: @one_qa)
+    tracker!(@july, @client, qbo_invoice_id: 'inv-dup', blueprint: { 'lines' => {} })
+    tracker!(@july, @client_b, qbo_invoice_id: 'inv-dup', account: @one_qa, blueprint: { 'lines' => {} })
+
+    july = mcp_payload(Mcp::GetInvoicePassesTool.call(server_context: {}))['passes']
+      .find { |p| p['month'] == '2026-07-01' }
+
+    sanct = july['entities'].find { |e| e['entity'] == 'Sanctuary Computer Inc' }
+    assert_equal 999.0, sanct['invoiced_total']
+    assert_equal({ 'paid' => 1 }, sanct['status_mix'])
+
+    one = july['entities'].find { |e| e['entity'] == 'One LLC' }
+    assert_equal 100.0, one['invoiced_total'], "One LLC must report its own invoice, not sanctuary's"
+    assert_equal({ 'unpaid' => 1 }, one['status_mix'])
+  end
+
   test 'a sent invoice with malformed stored data still counts its total, as status unknown' do
     # EmailSent with no due_date: QboInvoice#status raises on Date.parse.
     invoice!('inv-weird', { 'total' => 100.0, 'balance' => 100.0, 'email_status' => 'EmailSent' })

--- a/test/services/mcp/membership_stats_tool_test.rb
+++ b/test/services/mcp/membership_stats_tool_test.rb
@@ -126,6 +126,62 @@ class Mcp::MembershipStatsToolTest < ActiveSupport::TestCase
     refute_includes raw, 'Secret'
   end
 
+  test 'a stale-sync ACTIVE plan past its end_timestamp is out of the counts but still in plan_mix' do
+    # Optix status can lag reality. Weekly counts and total_paying_members are
+    # timestamp-derived, so an ACTIVE-status plan whose end_timestamp already
+    # passed drops out of both; plan_mix is status-derived, so it stays.
+    user!('u-stale')
+    plan!('u-stale', @patron_tpl, started: Date.new(2026, 1, 1), ended: Date.new(2026, 7, 1))
+
+    payload = mcp_payload(Mcp::GetMembershipStatsTool.call(server_context: {}))
+    annex = payload['locations'].find { |l| l['location'] == 'Annex' }
+
+    assert_equal 0, payload['total_paying_members']
+    assert_equal 0, annex['weekly_counts'].last['total']
+    assert_equal 0, annex['paying_members']
+    assert_equal [{ 'plan_type' => 'Patron Membership', 'count' => 1 }], annex['plan_mix'],
+      'the status-derived plan mix still lists the stale ACTIVE plan'
+  end
+
+  test 'an in_all_locations plan counts at every location, so per-location sums exceed the distinct total' do
+    user!('u-roamer')
+    plan!('u-roamer', @roamer_tpl, started: Date.new(2026, 5, 1))
+
+    payload = mcp_payload(Mcp::GetMembershipStatsTool.call(server_context: {}))
+    annex = payload['locations'].find { |l| l['location'] == 'Annex' }
+    brooklyn = payload['locations'].find { |l| l['location'] == 'Brooklyn' }
+
+    [annex, brooklyn].each do |loc|
+      assert_equal [{ 'plan_type' => 'Roamer', 'count' => 1 }], loc['plan_mix'],
+        "#{loc['location']} plan_mix must fold the all-locations plan in"
+      assert_equal 1, loc['weekly_counts'].last['total'],
+        "#{loc['location']} weekly counts must include the all-locations member"
+      assert_equal 1, loc['paying_members']
+    end
+
+    assert_equal 1, payload['total_paying_members'], 'org-wide the member is distinct-counted once'
+    per_location_sum = payload['locations'].sum { |l| l['paying_members'] }
+    assert_operator per_location_sum, :>, payload['total_paying_members'],
+      'per-location sums exceed the org-wide distinct total by construction'
+  end
+
+  test 'an ACTIVE plan canceled mid-window drops from weeks after the cancel, plan_mix keeps it' do
+    user!('u-cancel')
+    plan!('u-cancel', @patron_tpl, started: Date.new(2026, 1, 1), canceled: Date.new(2026, 7, 15))
+
+    payload = mcp_payload(Mcp::GetMembershipStatsTool.call(server_context: {}))
+    annex = payload['locations'].find { |l| l['location'] == 'Annex' }
+    by_week = annex['weekly_counts'].to_h { |w| [w['week_end'], w['total']] }
+
+    assert_equal 1, by_week['2026-07-12'], 'still a member the week before the cancel'
+    assert_equal 0, by_week['2026-07-19'], 'gone from the first week ending after the cancel'
+    assert_equal 0, by_week['2026-08-09']
+    assert_equal 0, annex['paying_members']
+    assert_equal 0, payload['total_paying_members']
+    assert_equal [{ 'plan_type' => 'Patron Membership', 'count' => 1 }], annex['plan_mix'],
+      'the status-derived plan mix still lists the canceled-but-ACTIVE plan'
+  end
+
   test 'growth_4w_pct is nil when there is no 4-weeks-ago baseline' do
     user!('u-new')
     plan!('u-new', @patron_tpl, started: Date.new(2026, 8, 3))

--- a/test/services/mcp/membership_stats_tool_test.rb
+++ b/test/services/mcp/membership_stats_tool_test.rb
@@ -1,0 +1,158 @@
+require 'test_helper'
+
+class Mcp::MembershipStatsToolTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::TimeHelpers
+
+  setup do
+    # Tuesday. week_end_wday defaults to Sunday (0), so the most recent
+    # week-end marker is 2026-08-09 and week ends step back 7 days at a time.
+    travel_to Time.zone.parse('2026-08-04 12:00:00')
+    @org = OptixOrganization.create!(name: 'Test Org', synced_at: Time.zone.parse('2026-08-04 03:00:00'))
+    @annex = OptixLocation.create!(optix_id: 'loc-a', optix_organization: @org, name: 'Annex')
+    @brooklyn = OptixLocation.create!(optix_id: 'loc-b', optix_organization: @org, name: 'Brooklyn')
+
+    @patron_tpl = template!('tpl-patron', 'Patron Membership', locations: [@annex])
+    @hot_desk_tpl = template!('tpl-hot', 'Hot Desk', locations: [@annex])
+    @roamer_tpl = template!('tpl-roam', 'Roamer', in_all_locations: true)
+  end
+
+  def template!(optix_id, name, locations: [], in_all_locations: false)
+    tpl = OptixPlanTemplate.create!(
+      optix_id: optix_id, optix_organization: @org, name: name,
+      in_all_locations: in_all_locations,
+    )
+    locations.each do |loc|
+      OptixPlanTemplateLocation.create!(optix_plan_template_id: tpl.optix_id, optix_location_id: loc.optix_id)
+    end
+    tpl
+  end
+
+  def user!(optix_id)
+    OptixUser.create!(optix_id: optix_id, optix_organization: @org,
+                      email: "#{optix_id}@example.com", name: 'Secret', last_name: 'Person')
+  end
+
+  def plan!(user_id, template, status: 'ACTIVE', started:, ended: nil, canceled: nil)
+    OptixAccountPlan.create!(
+      optix_id: SecureRandom.hex(6),
+      optix_organization: @org,
+      optix_plan_template_id: template.optix_id,
+      access_usage_user_optix_id: user_id,
+      status: status,
+      start_timestamp: started.to_time.to_i,
+      end_timestamp: ended&.to_time&.to_i,
+      canceled_timestamp: canceled&.to_time&.to_i,
+    )
+  end
+
+  def seed_members!
+    user!('u-patron')
+    plan!('u-patron', @patron_tpl, started: Date.new(2026, 5, 1))
+
+    user!('u-hot')
+    plan!('u-hot', @hot_desk_tpl, started: Date.new(2026, 7, 27)) # only in the final 2 weeks
+
+    # Ended before the latest week (timestamp), status ENDED (not paying).
+    user!('u-roam')
+    plan!('u-roam', @roamer_tpl, status: 'ENDED',
+          started: Date.new(2026, 3, 1), ended: Date.new(2026, 8, 1))
+
+    # Holds BOTH a patron and a non-patron plan: patron wins, never
+    # double-counted across the two columns.
+    user!('u-both')
+    plan!('u-both', @patron_tpl, started: Date.new(2026, 5, 1))
+    plan!('u-both', @hot_desk_tpl, started: Date.new(2026, 5, 1))
+  end
+
+  test 'per-location weekly counts, patron split, plan mix and totals — counts only, no PII' do
+    seed_members!
+
+    payload = mcp_payload(Mcp::GetMembershipStatsTool.call(server_context: {}))
+
+    assert_equal '2026-08-04', payload['as_of']
+    assert_equal 'Test Org', payload['organization']
+    assert_equal @org.synced_at.iso8601, payload['synced_at']
+    assert_equal 13, payload['weeks']
+
+    assert_equal %w[Annex Brooklyn], payload['locations'].map { |l| l['location'] }
+    annex = payload['locations'].find { |l| l['location'] == 'Annex' }
+    brooklyn = payload['locations'].find { |l| l['location'] == 'Brooklyn' }
+
+    # 13 trailing weeks, oldest first, ending at the upcoming Sunday.
+    assert_equal 13, annex['weekly_counts'].length
+    assert_equal '2026-08-09', annex['weekly_counts'].last['week_end']
+    assert_equal '2026-05-17', annex['weekly_counts'].first['week_end']
+
+    # Latest week at Annex: u-patron + u-both patrons; u-hot non-patron;
+    # u-roam's all-locations plan ended 2026-08-01 so it no longer counts.
+    latest = annex['weekly_counts'].last
+    assert_equal 2, latest['patron']
+    assert_equal 1, latest['non_patron']
+    assert_equal 3, latest['total']
+    assert_equal 3, annex['paying_members']
+    assert_equal 2, annex['patron_members']
+    assert_equal 1, annex['non_patron_members']
+
+    # 4 weeks earlier (2026-07-12): u-patron + u-both patrons, u-roam roams in.
+    four_weeks_ago = annex['weekly_counts'][-5]
+    assert_equal '2026-07-12', four_weeks_ago['week_end']
+    assert_equal 2, four_weeks_ago['patron']
+    assert_equal 1, four_weeks_ago['non_patron']
+    assert_equal 3, four_weeks_ago['total']
+    assert_equal 0.0, annex['growth_4w_pct']
+
+    # Brooklyn only ever saw the all-locations Roamer, gone by the latest week.
+    assert_equal 1, brooklyn['weekly_counts'][-5]['total']
+    assert_equal 0, brooklyn['weekly_counts'].last['total']
+    assert_equal 0, brooklyn['paying_members']
+    assert_equal(-100.0, brooklyn['growth_4w_pct'])
+
+    # Plan mix is the CURRENT paying roster (ACTIVE/IN_TRIAL): the ENDED
+    # Roamer plan never appears. Patron 2 (u-patron, u-both) + Hot Desk 2
+    # (u-hot, u-both) at Annex; Brooklyn has no location-specific paying plans.
+    assert_equal(
+      [{ 'plan_type' => 'Hot Desk', 'count' => 2 }, { 'plan_type' => 'Patron Membership', 'count' => 2 }],
+      annex['plan_mix'].sort_by { |r| r['plan_type'] }
+    )
+    assert_equal [], brooklyn['plan_mix']
+
+    # Org-wide distinct paying members right now: u-patron, u-hot, u-both.
+    assert_equal 3, payload['total_paying_members']
+
+    # NO member PII, ever: no names, no emails, no user ids.
+    raw = payload.to_json
+    refute_includes raw, 'u-patron'
+    refute_includes raw, '@example.com'
+    refute_includes raw, 'Secret'
+  end
+
+  test 'growth_4w_pct is nil when there is no 4-weeks-ago baseline' do
+    user!('u-new')
+    plan!('u-new', @patron_tpl, started: Date.new(2026, 8, 3))
+
+    payload = mcp_payload(Mcp::GetMembershipStatsTool.call(server_context: {}))
+    annex = payload['locations'].find { |l| l['location'] == 'Annex' }
+    assert_equal 1, annex['paying_members']
+    assert_nil annex['growth_4w_pct'], 'zero members 4 weeks ago: no growth percentage'
+  end
+
+  test 'weeks parameter clamps to 4..26' do
+    seed_members!
+
+    payload = mcp_payload(Mcp::GetMembershipStatsTool.call(weeks: 100, server_context: {}))
+    assert_equal 26, payload['weeks']
+    assert_equal 26, payload['locations'].first['weekly_counts'].length
+
+    payload = mcp_payload(Mcp::GetMembershipStatsTool.call(weeks: 1, server_context: {}))
+    assert_equal 4, payload['weeks']
+    assert_equal 4, payload['locations'].first['weekly_counts'].length
+    assert_nil payload['locations'].first['growth_4w_pct'],
+      'a 4-week window has no 4-weeks-earlier row to compare against'
+  end
+
+  test 'errors when no Optix organization has been synced' do
+    @org.destroy!
+    err = mcp_payload(Mcp::GetMembershipStatsTool.call(server_context: {}))
+    assert_includes err['error'], 'No Optix organization'
+  end
+end


### PR DESCRIPTION
Closes the three signal gaps found by auditing the controller's actual monthly-close reports (📈 Financial Reports): Optix paying-member counts/growth (the Apr-26 report's reference surface), invoice-pass volume per entity (Hugh's named signal), and per-client monthly revenue attribution (the May-26 report's narrative spine). Plan: docs/superpowers/plans/2026-08-05-mcp-close-report-tools.md. No member PII — counts and plan mix only. Same loop as #169: TDD → adversarial review → merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)