### PR TITLE
Permission grants: lead-in-training access (global or per-project)

### DIFF
--- a/app/admin/admin_users.rb
+++ b/app/admin/admin_users.rb
@@ -30,6 +30,14 @@ ActiveAdmin.register AdminUser do
       :purchased_at,
       :_edit,
       :_destroy
+    ],
+    permission_grants_attributes: [
+      :id,
+      :permission,
+      :subject_id,
+      :notes,
+      :granted_by_id,
+      :_destroy
     ]
   menu label: "Everybody", parent: "Team", priority: 1
   actions :index, :show, :edit, :update
@@ -73,11 +81,19 @@ ActiveAdmin.register AdminUser do
   end
 
   member_action :demote_admin_user, method: :post do
+    unless current_admin_user.is_admin?
+      redirect_to admin_admin_user_path(resource), alert: "Only admins can do that."
+      return
+    end
     resource.update!(roles: [])
     redirect_to admin_admin_user_path(resource), notice: "Success!"
   end
 
   member_action :promote_admin_user, method: :post do
+    unless current_admin_user.is_admin?
+      redirect_to admin_admin_user_path(resource), alert: "Only admins can do that."
+      return
+    end
     resource.update!(roles: ["admin"])
     redirect_to admin_admin_user_path(resource), notice: "Success!"
   end
@@ -96,6 +112,24 @@ ActiveAdmin.register AdminUser do
           snapshot_row = g3d&.snapshot&.dig("month")&.find { |g| g["label"] == period_label }
           snapshot_row ? snapshot_row["utilization"].to_h : {}
         end
+    end
+
+    # Permission grants are admin-managed only. The form hides them from
+    # non-admins, but leads pass the authorization adapter for AdminUser
+    # updates, so strip the params server-side too. New grants get
+    # granted_by stamped from the acting admin, never from the client.
+    def update
+      attrs = params.dig(:admin_user, :permission_grants_attributes)
+      if attrs.present?
+        if current_admin_user.is_admin?
+          attrs.each do |_key, grant_attrs|
+            grant_attrs[:granted_by_id] = current_admin_user.id if grant_attrs[:id].blank?
+          end
+        else
+          params[:admin_user].delete(:permission_grants_attributes)
+        end
+      end
+      super
     end
   end
 
@@ -198,6 +232,17 @@ JS
           a.input :amount
           a.input :note
           a.input :purchased_at
+        end
+
+        f.has_many :permission_grants, heading: "Permission Grants", allow_destroy: true do |a|
+          a.input :permission, as: :select, collection: PermissionGrant::PERMISSIONS, include_blank: false
+          a.input :subject_id,
+            as: :select,
+            collection: ProjectTracker.order(:name).pluck(:name, :id),
+            include_blank: "All projects",
+            label: "Scope to project",
+            hint: "Leave blank for lead-level access to everything (same as someone who has led a project — for leads-in-training). Pick a project to limit them to read-only access to that project's tracker and invoices."
+          a.input :notes, hint: "Why this grant exists, e.g. 'Account Lead training, Q3 cohort'."
         end
       end
     end

--- a/app/admin/invoice_passes.rb
+++ b/app/admin/invoice_passes.rb
@@ -58,34 +58,41 @@ ActiveAdmin.register InvoicePass do
 
   index download_links: false, title: "Monthly Invoicing" do
     column :start_of_month
-    column :value do |resource|
-      number_to_currency(resource.value)
-    end
-    column :outstanding do |resource|
-      number_to_currency(resource.balance)
-    end
-    column :surplus do |resource|
-      number_to_currency(resource.surplus)
-    end
-    column :invoicing_statuses do |resource|
-      div do
-        if resource.statuses == :missing_hours
-          span("Missing hours", class: "pill missing_hours")
-        else
-          resource.statuses.each do |status, count|
-            span("#{count}x #{status.to_s.humanize}", class: "pill #{status}")
+
+    # Aggregate financials/statuses expose company-wide revenue data.
+    # Project-scoped grantees only get :read on InvoicePass so they can
+    # navigate to their own invoice trackers — they don't get to see
+    # everyone else's numbers, so gate these columns to admins/leads.
+    if current_admin_user.is_admin? || current_admin_user.can_act_as_lead?
+      column :value do |resource|
+        number_to_currency(resource.value)
+      end
+      column :outstanding do |resource|
+        number_to_currency(resource.balance)
+      end
+      column :surplus do |resource|
+        number_to_currency(resource.surplus)
+      end
+      column :invoicing_statuses do |resource|
+        div do
+          if resource.statuses == :missing_hours
+            span("Missing hours", class: "pill missing_hours")
+          else
+            resource.statuses.each do |status, count|
+              span("#{count}x #{status.to_s.humanize}", class: "pill #{status}")
+            end
           end
         end
       end
-    end
 
-    column :payout_statuses do |resource|
-      div do
-        if resource.payout_statuses == :missing_hours
-          span("Missing hours", class: "pill missing_hours")
-        else
-          resource.payout_statuses.each do |status, count|
-            span("#{count}x #{status.to_s.humanize}", class: "pill #{status}")
+      column :payout_statuses do |resource|
+        div do
+          if resource.payout_statuses == :missing_hours
+            span("Missing hours", class: "pill missing_hours")
+          else
+            resource.payout_statuses.each do |status, count|
+              span("#{count}x #{status.to_s.humanize}", class: "pill #{status}")
+            end
           end
         end
       end
@@ -98,14 +105,22 @@ ActiveAdmin.register InvoicePass do
 
   show title: :invoice_month do
 
-    hours_report = Stacks::Automator.discover_people_missing_hours_for_month(
-      [],
-      resource.start_of_month,
-    ).map do |d|
-      {
-        forecast_person: d[:forecast_data],
-        missing_allocation: d[:missing_allocation]
-      }
+    # Same company-wide exposure concern as the index aggregates: the
+    # missing-hours report lists every contributor's name + missing
+    # allocation, not just those tied to the viewer's scoped projects.
+    # Scoped grantees get an empty report — the partial no-ops on empty.
+    hours_report = if current_admin_user.is_admin? || current_admin_user.can_act_as_lead?
+      Stacks::Automator.discover_people_missing_hours_for_month(
+        [],
+        resource.start_of_month,
+      ).map do |d|
+        {
+          forecast_person: d[:forecast_data],
+          missing_allocation: d[:missing_allocation]
+        }
+      end
+    else
+      []
     end
 
     render 'invoice_pass', { invoice_pass: invoice_pass, hours_report: hours_report }

--- a/app/models/admin_authorization.rb
+++ b/app/models/admin_authorization.rb
@@ -22,7 +22,16 @@ class AdminAuthorization < ActiveAdmin::AuthorizationAdapter
     scoped_ids = user.lead_scoped_project_tracker_ids
     return collection if scoped_ids.empty?
 
-    case collection.klass.name
+    # ActiveAdmin calls scope_collection with whatever scoped_collection
+    # returns. Resources that override scoped_collection (e.g. InvoicePass)
+    # hand us an ActiveRecord::Relation, but top-level resources fall back to
+    # InheritedResources' end_of_association_chain, which for a bare model
+    # (no association scoping applied yet) is the model Class itself — and a
+    # Class doesn't respond to #klass. Resolve to the actual model class
+    # either way rather than assuming a Relation.
+    model = collection.respond_to?(:klass) ? collection.klass : collection
+
+    case model.name
     when "ProjectTracker"
       collection.where(id: scoped_ids)
     when "InvoiceTracker"

--- a/app/models/admin_authorization.rb
+++ b/app/models/admin_authorization.rb
@@ -12,16 +12,38 @@ class AdminAuthorization < ActiveAdmin::AuthorizationAdapter
   ].freeze
   OWN_LEDGER_ITEM_DENY = [:update, :destroy].freeze
 
-  # def scope_collection(collection, action = nil)
-  #   # This automatically filters the Index page
-  #   if user.admin?
-  #     collection
-  #   else
-  #     # Ensure users only see records they own
-  #     # This assumes the model has a user_id or similar relation
-  #     collection.where(user_id: user.id)
-  #   end
-  # end
+  # Narrows index pages for users whose only access comes from
+  # project-scoped "lead" grants. Admins and (actual or granted) leads see
+  # everything. ActiveAdmin calls this automatically for every index via
+  # apply_authorization_scope.
+  def scope_collection(collection, action = :read)
+    return collection if user.is_admin? || user.can_act_as_lead?
+
+    scoped_ids = user.lead_scoped_project_tracker_ids
+    return collection if scoped_ids.empty?
+
+    case collection.klass.name
+    when "ProjectTracker"
+      collection.where(id: scoped_ids)
+    when "InvoiceTracker"
+      forecast_project_ids = ProjectTrackerForecastProject
+        .where(project_tracker_id: scoped_ids)
+        .pluck(:forecast_project_id)
+      return collection.none if forecast_project_ids.empty?
+
+      collection.where(<<~SQL.squish, forecast_project_ids)
+        invoice_trackers.blueprint IS NOT NULL
+        AND jsonb_typeof(invoice_trackers.blueprint -> 'lines') = 'object'
+        AND EXISTS (
+          SELECT 1
+          FROM jsonb_each(invoice_trackers.blueprint -> 'lines') AS line
+          WHERE (line.value ->> 'forecast_project')::bigint IN (?)
+        )
+      SQL
+    else
+      collection
+    end
+  end
 
   def authorized?(action, subject = nil)
     if subject.is_a?(ContributorAdjustment) || subject == ContributorAdjustment
@@ -32,7 +54,22 @@ class AdminAuthorization < ActiveAdmin::AuthorizationAdapter
       return user.is_admin?
     end
 
-    return true if (user.is_admin? || user.has_led_projects?)
+    return true if (user.is_admin? || user.can_act_as_lead?)
+
+    # Project-scoped "lead" grants (leads-in-training limited to specific
+    # projects): read-only visibility into the granted ProjectTrackers, the
+    # InvoiceTrackers that bill them, and the InvoicePass containers needed
+    # to navigate to those trackers. scope_collection narrows the index
+    # pages; this handles class-level (menu/index) and per-record checks.
+    if action == :read
+      scoped_ids = user.lead_scoped_project_tracker_ids
+      if scoped_ids.any?
+        return true if [ProjectTracker, InvoiceTracker, InvoicePass].include?(subject)
+        return true if subject.is_a?(InvoicePass)
+        return true if subject.is_a?(ProjectTracker) && scoped_ids.include?(subject.id)
+        return true if subject.is_a?(InvoiceTracker) && (subject.project_trackers.map(&:id) & scoped_ids).any?
+      end
+    end
 
     if subject.is_a?(AdminUser)
       return true if subject == user && action == :read

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -548,6 +548,9 @@ class AdminUser < ApplicationRecord
   has_many :enterprise_admins, dependent: :destroy
   has_many :administered_enterprises, through: :enterprise_admins, source: :enterprise
 
+  has_many :permission_grants, dependent: :destroy
+  accepts_nested_attributes_for :permission_grants, allow_destroy: true
+
   def admin_of?(enterprise)
     return false if enterprise.nil?
     is_admin? || enterprise_admins.exists?(enterprise_id: enterprise.id)
@@ -555,6 +558,18 @@ class AdminUser < ApplicationRecord
 
   def has_led_projects?
     return AccountLeadPeriod.where(admin_user_id: self.id).any? || ProjectLeadPeriod.where(admin_user_id: self.id).any?
+  end
+
+  # Lead-level ActiveAdmin access: either they've actually held a lead
+  # period, or an admin granted them global "lead" permission (a
+  # lead-in-training). Scoped grants deliberately don't count here.
+  def can_act_as_lead?
+    has_led_projects? || permission_grants.global.for_permission("lead").any?
+  end
+
+  # ProjectTracker ids this user may read via project-scoped "lead" grants.
+  def lead_scoped_project_tracker_ids
+    permission_grants.for_permission("lead").where(subject_type: "ProjectTracker").pluck(:subject_id)
   end
 
   def is_on_old_deal?

--- a/app/models/permission_grant.rb
+++ b/app/models/permission_grant.rb
@@ -1,0 +1,29 @@
+# An explicit, admin-granted permission for an AdminUser. A grant with no
+# subject is global (e.g. a lead-in-training who should see everything a
+# real lead sees); a grant with a subject narrows the permission to that
+# record. Extend PERMISSIONS / SUBJECT_TYPES to add new kinds — the shape
+# needs no schema change.
+class PermissionGrant < ApplicationRecord
+  PERMISSIONS = %w[lead].freeze
+  SUBJECT_TYPES = %w[ProjectTracker].freeze
+
+  belongs_to :admin_user
+  belongs_to :granted_by, class_name: "AdminUser", optional: true
+  belongs_to :subject, polymorphic: true, optional: true
+
+  before_validation do
+    self.subject_type = "ProjectTracker" if subject_id.present? && subject_type.blank?
+    self.subject_type = nil if subject_id.blank?
+  end
+
+  validates :permission, inclusion: { in: PERMISSIONS }
+  validates :subject_type, inclusion: { in: SUBJECT_TYPES }, allow_nil: true
+  validates :permission, uniqueness: { scope: [:admin_user_id, :subject_type, :subject_id] }
+
+  scope :global, -> { where(subject_type: nil, subject_id: nil) }
+  scope :for_permission, ->(p) { where(permission: p) }
+
+  def global?
+    subject_type.nil? && subject_id.nil?
+  end
+end

--- a/app/models/project_tracker.rb
+++ b/app/models/project_tracker.rb
@@ -59,6 +59,8 @@ class ProjectTracker < ApplicationRecord
   accepts_nested_attributes_for :project_lead_periods, allow_destroy: true
   has_many :project_leads, through: :project_lead_periods, source: :admin_user
 
+  has_many :permission_grants, as: :subject, dependent: :destroy
+
   scope :complete, -> {
     where.not(work_completed_at: nil)
       .includes(:project_capsule).where(

--- a/app/views/admin/admin_users/_show.html.erb
+++ b/app/views/admin/admin_users/_show.html.erb
@@ -87,3 +87,33 @@
     </div>
   </div>
 </div>
+
+<% if current_admin_user.is_admin? && resource.permission_grants.any? %>
+  <div class="panel">
+    <h3>Permission Grants</h3>
+    <div class="panel_contents">
+      <table border="0" cellspacing="0" cellpadding="0" class="index_table index">
+        <thead>
+          <tr>
+            <th class="col">Permission</th>
+            <th class="col">Scope</th>
+            <th class="col">Granted By</th>
+            <th class="col">Notes</th>
+            <th class="col">Granted At</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% resource.permission_grants.each do |grant| %>
+            <tr>
+              <td class="col"><%= grant.permission.humanize %></td>
+              <td class="col"><%= grant.global? ? "All projects" : (grant.subject.respond_to?(:name) ? grant.subject.name : "#{grant.subject_type} ##{grant.subject_id}") %></td>
+              <td class="col"><%= grant.granted_by&.email %></td>
+              <td class="col"><%= grant.notes %></td>
+              <td class="col"><%= grant.created_at.to_date %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/contributor_payouts/_show.html.erb
+++ b/app/views/admin/contributor_payouts/_show.html.erb
@@ -6,7 +6,7 @@
   <%= resource.in_sync? ? "Reconciled" : "Unreconciled" %>
 </p>
 
-<% if current_admin_user.has_led_projects? %>
+<% if current_admin_user.can_act_as_lead? %>
   <%= link_to "Invoice Tracker", admin_invoice_pass_invoice_tracker_path(resource.invoice_tracker.invoice_pass, resource.invoice_tracker), class: "nag", style: "margin-right: 6px;" %>
 <% end %>
 

--- a/db/migrate/20260804000001_create_permission_grants.rb
+++ b/db/migrate/20260804000001_create_permission_grants.rb
@@ -1,0 +1,23 @@
+class CreatePermissionGrants < ActiveRecord::Migration[6.1]
+  def change
+    create_table :permission_grants do |t|
+      t.references :admin_user, null: false, foreign_key: true
+      t.string :permission, null: false
+      t.string :subject_type
+      t.bigint :subject_id
+      t.references :granted_by, foreign_key: { to_table: :admin_users }
+      t.text :notes
+      t.timestamps
+    end
+
+    add_index :permission_grants, [:subject_type, :subject_id]
+    add_index :permission_grants, [:admin_user_id, :permission],
+      unique: true,
+      where: "subject_type IS NULL AND subject_id IS NULL",
+      name: "index_permission_grants_unique_global"
+    add_index :permission_grants, [:admin_user_id, :permission, :subject_type, :subject_id],
+      unique: true,
+      where: "subject_id IS NOT NULL",
+      name: "index_permission_grants_unique_scoped"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_07_30_000002) do
+ActiveRecord::Schema.define(version: 2026_08_04_000001) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -833,6 +833,22 @@ ActiveRecord::Schema.define(version: 2026_07_30_000002) do
     t.index ["review_id"], name: "index_peer_reviews_on_review_id"
   end
 
+  create_table "permission_grants", force: :cascade do |t|
+    t.bigint "admin_user_id", null: false
+    t.string "permission", null: false
+    t.string "subject_type"
+    t.bigint "subject_id"
+    t.bigint "granted_by_id"
+    t.text "notes"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["admin_user_id", "permission", "subject_type", "subject_id"], name: "index_permission_grants_unique_scoped", unique: true, where: "(subject_id IS NOT NULL)"
+    t.index ["admin_user_id", "permission"], name: "index_permission_grants_unique_global", unique: true, where: "((subject_type IS NULL) AND (subject_id IS NULL))"
+    t.index ["admin_user_id"], name: "index_permission_grants_on_admin_user_id"
+    t.index ["granted_by_id"], name: "index_permission_grants_on_granted_by_id"
+    t.index ["subject_type", "subject_id"], name: "index_permission_grants_on_subject_type_and_subject_id"
+  end
+
   create_table "periodic_reports", force: :cascade do |t|
     t.integer "period_gradation", default: 0, null: false
     t.date "period_starts_at", null: false
@@ -1473,6 +1489,8 @@ ActiveRecord::Schema.define(version: 2026_07_30_000002) do
   add_foreign_key "pay_stubs", "pay_cycles"
   add_foreign_key "peer_reviews", "admin_users"
   add_foreign_key "peer_reviews", "reviews"
+  add_foreign_key "permission_grants", "admin_users"
+  add_foreign_key "permission_grants", "admin_users", column: "granted_by_id"
   add_foreign_key "periodic_reports", "notifications"
   add_foreign_key "pre_profit_share_purchases", "admin_users"
   add_foreign_key "profit_share_payments", "admin_users"

--- a/docs/superpowers/plans/2026-08-04-permission-grants.md
+++ b/docs/superpowers/plans/2026-08-04-permission-grants.md
@@ -1,0 +1,815 @@
+# Permission Grants (Lead-in-Training Access) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let admins grant lead-equivalent ActiveAdmin access to people who have never held a lead period, globally or scoped (read-only) to specific projects, via a new extensible `permission_grants` table.
+
+**Architecture:** A `PermissionGrant` row is `{admin_user, permission, optional polymorphic subject, granted_by, notes}`. A global `"lead"` grant (no subject) makes `AdminUser#can_act_as_lead?` true, which replaces `has_led_projects?` at the master gate in `AdminAuthorization#authorized?`. A project-scoped grant (subject = a `ProjectTracker`) does NOT pass that gate; instead new adapter rules allow read-only access to the granted ProjectTrackers and the InvoiceTrackers billing them, and a new `scope_collection` implementation filters those two index pages.
+
+**Tech Stack:** Rails 6.1, Ruby 3.1.7, PostgreSQL (jsonb), ActiveAdmin 2.9 (custom `AuthorizationAdapter`), minitest + mocha, Devise integration-test helpers.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-08-04-permission-grants-design.md`.
+- `AdminUser#has_led_projects?` keeps its exact current meaning (has actually held an `AccountLeadPeriod`/`ProjectLeadPeriod`); authorization call sites move to the new `can_act_as_lead?`.
+- Never touch `AccountLeadPeriod`/`ProjectLeadPeriod` data or models (they drive compensation).
+- `PermissionGrant::PERMISSIONS = %w[lead]` and `SUBJECT_TYPES = %w[ProjectTracker]` are the only allow-lists; extending the system later means adding strings there.
+- Scoped grants are strictly read-only (`:read` only — ActiveAdmin maps index/show to `:read`; custom member actions pass through verbatim and must stay denied).
+- Tests run with `bin/rails test <path>`. The full suite must pass before the PR.
+- Commit messages end with: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+- Working dir: `/Users/hhff/Documents/Code/stacks/.claude/worktrees/per-project-stacks-permissions` (branch `worktree-per-project-stacks-permissions`).
+
+---
+
+### Task 1: PermissionGrant model + migration
+
+**Files:**
+- Create: `db/migrate/20260804000001_create_permission_grants.rb`
+- Create: `app/models/permission_grant.rb`
+- Test: `test/models/permission_grant_test.rb`
+
+**Interfaces:**
+- Produces: `PermissionGrant` (AR model) with `PERMISSIONS`, `SUBJECT_TYPES` constants; associations `admin_user`, `granted_by` (AdminUser, optional), `subject` (polymorphic, optional); scopes `.global`, `.for_permission(p)`; predicate `#global?`. Auto-defaults `subject_type` to `"ProjectTracker"` when only `subject_id` is given.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/models/permission_grant_test.rb`:
+
+```ruby
+require 'test_helper'
+
+class PermissionGrantTest < ActiveSupport::TestCase
+  def make_user(email)
+    AdminUser.create!(email: email, password: "password12345")
+  end
+
+  test "a global lead grant is valid and global?" do
+    user = make_user("trainee@sanctuary.computer")
+    granter = make_user("granter@sanctuary.computer")
+    grant = PermissionGrant.create!(admin_user: user, permission: "lead", granted_by: granter)
+    assert grant.global?
+    assert_includes PermissionGrant.global.for_permission("lead"), grant
+  end
+
+  test "permission must be in the allow-list" do
+    user = make_user("trainee@sanctuary.computer")
+    grant = PermissionGrant.new(admin_user: user, permission: "superuser")
+    refute grant.valid?
+    assert grant.errors[:permission].any?
+  end
+
+  test "subject_type defaults to ProjectTracker when only subject_id is set" do
+    user = make_user("trainee@sanctuary.computer")
+    pt = ProjectTracker.create!(name: "Some Project")
+    grant = PermissionGrant.create!(admin_user: user, permission: "lead", subject_id: pt.id)
+    assert_equal "ProjectTracker", grant.subject_type
+    assert_equal pt, grant.subject
+    refute grant.global?
+  end
+
+  test "duplicate grants are rejected" do
+    user = make_user("trainee@sanctuary.computer")
+    PermissionGrant.create!(admin_user: user, permission: "lead")
+    dup = PermissionGrant.new(admin_user: user, permission: "lead")
+    refute dup.valid?
+
+    pt = ProjectTracker.create!(name: "Some Project")
+    PermissionGrant.create!(admin_user: user, permission: "lead", subject: pt)
+    scoped_dup = PermissionGrant.new(admin_user: user, permission: "lead", subject: pt)
+    refute scoped_dup.valid?
+  end
+
+  test "subject_type outside the allow-list is rejected" do
+    user = make_user("trainee@sanctuary.computer")
+    grant = PermissionGrant.new(admin_user: user, permission: "lead", subject_type: "Studio", subject_id: 1)
+    refute grant.valid?
+    assert grant.errors[:subject_type].any?
+  end
+end
+```
+
+If `ProjectTracker.create!(name: ...)` fails a model validation, inspect `app/models/project_tracker.rb` validations and add the minimal required attributes — do not stub.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bin/rails test test/models/permission_grant_test.rb`
+Expected: FAIL/ERROR with `uninitialized constant PermissionGrant`
+
+- [ ] **Step 3: Write migration and model**
+
+Create `db/migrate/20260804000001_create_permission_grants.rb`:
+
+```ruby
+class CreatePermissionGrants < ActiveRecord::Migration[6.1]
+  def change
+    create_table :permission_grants do |t|
+      t.references :admin_user, null: false, foreign_key: true
+      t.string :permission, null: false
+      t.string :subject_type
+      t.bigint :subject_id
+      t.references :granted_by, foreign_key: { to_table: :admin_users }
+      t.text :notes
+      t.timestamps
+    end
+
+    add_index :permission_grants, [:subject_type, :subject_id]
+    add_index :permission_grants, [:admin_user_id, :permission],
+      unique: true,
+      where: "subject_type IS NULL AND subject_id IS NULL",
+      name: "index_permission_grants_unique_global"
+    add_index :permission_grants, [:admin_user_id, :permission, :subject_type, :subject_id],
+      unique: true,
+      where: "subject_id IS NOT NULL",
+      name: "index_permission_grants_unique_scoped"
+  end
+end
+```
+
+Create `app/models/permission_grant.rb`:
+
+```ruby
+# An explicit, admin-granted permission for an AdminUser. A grant with no
+# subject is global (e.g. a lead-in-training who should see everything a
+# real lead sees); a grant with a subject narrows the permission to that
+# record. Extend PERMISSIONS / SUBJECT_TYPES to add new kinds — the shape
+# needs no schema change.
+class PermissionGrant < ApplicationRecord
+  PERMISSIONS = %w[lead].freeze
+  SUBJECT_TYPES = %w[ProjectTracker].freeze
+
+  belongs_to :admin_user
+  belongs_to :granted_by, class_name: "AdminUser", optional: true
+  belongs_to :subject, polymorphic: true, optional: true
+
+  before_validation do
+    self.subject_type = "ProjectTracker" if subject_id.present? && subject_type.blank?
+    self.subject_type = nil if subject_id.blank?
+  end
+
+  validates :permission, inclusion: { in: PERMISSIONS }
+  validates :subject_type, inclusion: { in: SUBJECT_TYPES }, allow_nil: true
+  validates :permission, uniqueness: { scope: [:admin_user_id, :subject_type, :subject_id] }
+
+  scope :global, -> { where(subject_type: nil, subject_id: nil) }
+  scope :for_permission, ->(p) { where(permission: p) }
+
+  def global?
+    subject_type.nil? && subject_id.nil?
+  end
+end
+```
+
+If the repo has no `ApplicationRecord` (check `app/models/application_record.rb`), inherit from `ActiveRecord::Base` like the model next to it (`app/models/account_lead_period.rb`) does.
+
+- [ ] **Step 4: Migrate and run the test**
+
+Run: `bin/rails db:migrate && bin/rails db:test:prepare && bin/rails test test/models/permission_grant_test.rb`
+Expected: PASS (all 5 tests). `db/schema.rb` will be updated by the migration — commit that too.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add db/migrate/20260804000001_create_permission_grants.rb db/schema.rb app/models/permission_grant.rb test/models/permission_grant_test.rb
+git commit -m "feat: PermissionGrant model — extensible admin-granted permissions
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: AdminUser predicates + ProjectTracker association
+
+**Files:**
+- Modify: `app/models/admin_user.rb` (associations block near the top ~line 1-30; predicates near `has_led_projects?` at ~line 556)
+- Modify: `app/models/project_tracker.rb` (associations block ~line 42-60)
+- Test: `test/models/admin_user_permission_grants_test.rb`
+
+**Interfaces:**
+- Consumes: `PermissionGrant` from Task 1.
+- Produces: `AdminUser#can_act_as_lead?` → Boolean; `AdminUser#lead_scoped_project_tracker_ids` → Array<Integer>; `AdminUser` `has_many :permission_grants` (+ `accepts_nested_attributes_for ... allow_destroy: true`); `ProjectTracker has_many :permission_grants, as: :subject, dependent: :destroy`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/models/admin_user_permission_grants_test.rb`:
+
+```ruby
+require 'test_helper'
+
+class AdminUserPermissionGrantsTest < ActiveSupport::TestCase
+  def make_user(email)
+    AdminUser.create!(email: email, password: "password12345")
+  end
+
+  test "can_act_as_lead? is true for someone who actually led a project" do
+    user = make_user("led@sanctuary.computer")
+    pt = ProjectTracker.create!(name: "Led Project")
+    ProjectLeadPeriod.create!(project_tracker: pt, admin_user: user,
+      started_at: Date.new(2025, 1, 1), ended_at: Date.new(2025, 3, 31))
+    assert user.can_act_as_lead?
+  end
+
+  test "can_act_as_lead? is true with a global lead grant and false otherwise" do
+    user = make_user("trainee@sanctuary.computer")
+    refute user.can_act_as_lead?
+    PermissionGrant.create!(admin_user: user, permission: "lead")
+    assert user.reload.can_act_as_lead?
+  end
+
+  test "a project-scoped grant does NOT make can_act_as_lead? true, but appears in lead_scoped_project_tracker_ids" do
+    user = make_user("scoped@sanctuary.computer")
+    pt = ProjectTracker.create!(name: "Scoped Project")
+    PermissionGrant.create!(admin_user: user, permission: "lead", subject: pt)
+    refute user.can_act_as_lead?
+    assert_equal [pt.id], user.lead_scoped_project_tracker_ids
+  end
+
+  test "destroying a project tracker destroys grants scoped to it" do
+    user = make_user("scoped@sanctuary.computer")
+    pt = ProjectTracker.create!(name: "Doomed Project")
+    PermissionGrant.create!(admin_user: user, permission: "lead", subject: pt)
+    pt.destroy!
+    assert_equal [], user.reload.permission_grants
+  end
+
+  test "destroying a user destroys their grants" do
+    user = make_user("leaving@sanctuary.computer")
+    grant = PermissionGrant.create!(admin_user: user, permission: "lead")
+    user.destroy!
+    refute PermissionGrant.exists?(grant.id)
+  end
+end
+```
+
+If `ProjectLeadPeriod.create!` fails validation (it validates full-month periods), keep `started_at` on the 1st and `ended_at` on the last day of a month as shown.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bin/rails test test/models/admin_user_permission_grants_test.rb`
+Expected: FAIL with `undefined method 'can_act_as_lead?'`
+
+- [ ] **Step 3: Implement**
+
+In `app/models/admin_user.rb`, add to the association block at the top of the class (after `has_many :enterprise_admins, dependent: :destroy`):
+
+```ruby
+  has_many :permission_grants, dependent: :destroy
+  accepts_nested_attributes_for :permission_grants, allow_destroy: true
+```
+
+Directly below `has_led_projects?` (~line 556), add:
+
+```ruby
+  # Lead-level ActiveAdmin access: either they've actually held a lead
+  # period, or an admin granted them global "lead" permission (a
+  # lead-in-training). Scoped grants deliberately don't count here.
+  def can_act_as_lead?
+    has_led_projects? || permission_grants.global.for_permission("lead").any?
+  end
+
+  # ProjectTracker ids this user may read via project-scoped "lead" grants.
+  def lead_scoped_project_tracker_ids
+    permission_grants.for_permission("lead").where(subject_type: "ProjectTracker").pluck(:subject_id)
+  end
+```
+
+In `app/models/project_tracker.rb`, add after the `project_lead_periods` associations (~line 60):
+
+```ruby
+  has_many :permission_grants, as: :subject, dependent: :destroy
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `bin/rails test test/models/admin_user_permission_grants_test.rb test/models/permission_grant_test.rb`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/models/admin_user.rb app/models/project_tracker.rb test/models/admin_user_permission_grants_test.rb
+git commit -m "feat: AdminUser#can_act_as_lead? + scoped grant lookup
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: AdminAuthorization — global gate swap, scoped read rules, index scoping
+
+**Files:**
+- Modify: `app/models/admin_authorization.rb` (replace commented-out `scope_collection` at lines 15-24; edit gate at line 35; insert scoped-rules block after it)
+- Modify: `app/views/admin/contributor_payouts/_show.html.erb:9` (`has_led_projects?` → `can_act_as_lead?`)
+- Test: `test/models/admin_authorization_test.rb`
+
+**Interfaces:**
+- Consumes: `AdminUser#can_act_as_lead?`, `#lead_scoped_project_tracker_ids` (Task 2).
+- Produces: `AdminAuthorization#authorized?(action, subject)` honoring grants; `AdminAuthorization#scope_collection(collection, action = :read)` filtering `ProjectTracker` / `InvoiceTracker` relations for scoped-only users. (ActiveAdmin's `apply_authorization_scope` calls `scope_collection` on every index automatically — data_access.rb `COLLECTION_APPLIES` — so no controller changes are needed.)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/models/admin_authorization_test.rb`:
+
+```ruby
+require 'test_helper'
+
+class AdminAuthorizationTest < ActiveSupport::TestCase
+  def auth_for(user)
+    AdminAuthorization.new(nil, user)
+  end
+
+  def make_user(email)
+    AdminUser.create!(email: email, password: "password12345")
+  end
+
+  test "a user with no grants and no lead history has no ProjectTracker access" do
+    user = make_user("nobody@sanctuary.computer")
+    refute auth_for(user).authorized?(:read, ProjectTracker)
+  end
+
+  test "a global lead grant confers the same blanket access as having led" do
+    user = make_user("trainee@sanctuary.computer")
+    PermissionGrant.create!(admin_user: user, permission: "lead")
+    auth = auth_for(user)
+    assert auth.authorized?(:read, ProjectTracker)
+    assert auth.authorized?(:update, ProjectTracker.new)
+    assert auth.authorized?(:read, InvoiceTracker)
+    assert auth.authorized?(:read, Studio)
+  end
+
+  test "a project-scoped grant gives read-only access to that project" do
+    user = make_user("scoped@sanctuary.computer")
+    pt_mine = ProjectTracker.create!(name: "Mine")
+    pt_other = ProjectTracker.create!(name: "Other")
+    PermissionGrant.create!(admin_user: user, permission: "lead", subject: pt_mine)
+
+    auth = auth_for(user)
+    # class-level reads so menus and index pages render
+    assert auth.authorized?(:read, ProjectTracker)
+    assert auth.authorized?(:read, InvoiceTracker)
+    assert auth.authorized?(:read, InvoicePass)
+    # record-level reads limited to the granted project
+    assert auth.authorized?(:read, pt_mine)
+    refute auth.authorized?(:read, pt_other)
+    # strictly read-only
+    refute auth.authorized?(:update, pt_mine)
+    refute auth.authorized?(:destroy, pt_mine)
+    refute auth.authorized?(:create, ProjectTracker)
+    # no blanket access to anything else
+    refute auth.authorized?(:read, Studio)
+  end
+
+  test "scoped grant allows reading only invoice trackers billing the granted project" do
+    user = make_user("scoped2@sanctuary.computer")
+    pt = ProjectTracker.create!(name: "Mine")
+    fp = ForecastProject.create!(name: "Mine FP", code: "MINE-1")
+    other_fp = ForecastProject.create!(name: "Other FP", code: "OTHR-1")
+    ProjectTrackerForecastProject.create!(project_tracker: pt, forecast_project: fp)
+    PermissionGrant.create!(admin_user: user, permission: "lead", subject: pt)
+
+    in_scope = InvoiceTracker.new(blueprint: { "lines" => { "0" => { "forecast_project" => fp.id } } })
+    out_of_scope = InvoiceTracker.new(blueprint: { "lines" => { "0" => { "forecast_project" => other_fp.id } } })
+
+    auth = auth_for(user)
+    assert auth.authorized?(:read, in_scope)
+    refute auth.authorized?(:read, out_of_scope)
+    refute auth.authorized?(:toggle_ownership, in_scope)
+  end
+
+  test "scope_collection filters ProjectTracker index to granted projects" do
+    user = make_user("scoped3@sanctuary.computer")
+    pt_mine = ProjectTracker.create!(name: "Mine")
+    ProjectTracker.create!(name: "Other")
+    PermissionGrant.create!(admin_user: user, permission: "lead", subject: pt_mine)
+
+    assert_equal [pt_mine.id], auth_for(user).scope_collection(ProjectTracker.all).pluck(:id)
+  end
+
+  test "scope_collection filters InvoiceTracker index via blueprint forecast projects" do
+    user = make_user("scoped4@sanctuary.computer")
+    pt = ProjectTracker.create!(name: "Mine")
+    fp = ForecastProject.create!(name: "Mine FP", code: "MINE-2")
+    other_fp = ForecastProject.create!(name: "Other FP", code: "OTHR-2")
+    ProjectTrackerForecastProject.create!(project_tracker: pt, forecast_project: fp)
+    PermissionGrant.create!(admin_user: user, permission: "lead", subject: pt)
+
+    ip = InvoicePass.create!(start_of_month: Date.new(2031, 1, 1))
+    fc_mine = ForecastClient.create!(forecast_id: 910001, name: "Client Mine")
+    fc_other = ForecastClient.create!(forecast_id: 910002, name: "Client Other")
+    qbo = qbo_accounts(:one)
+    it_mine = InvoiceTracker.create!(forecast_client: fc_mine, invoice_pass: ip, qbo_account: qbo,
+      blueprint: { "lines" => { "0" => { "forecast_project" => fp.id } } })
+    InvoiceTracker.create!(forecast_client: fc_other, invoice_pass: ip, qbo_account: qbo,
+      blueprint: { "lines" => { "0" => { "forecast_project" => other_fp.id } } })
+    InvoiceTracker.create!(forecast_client: ForecastClient.create!(forecast_id: 910003, name: "Nil BP"),
+      invoice_pass: ip, qbo_account: qbo, blueprint: nil)
+
+    assert_equal [it_mine.id], auth_for(user).scope_collection(InvoiceTracker.all).pluck(:id)
+  end
+
+  test "scope_collection leaves collections untouched for admins, leads, and unrelated classes" do
+    admin = make_user("adm@sanctuary.computer")
+    admin.update!(roles: ["admin"])
+    lead_grantee = make_user("gl@sanctuary.computer")
+    PermissionGrant.create!(admin_user: lead_grantee, permission: "lead")
+    ProjectTracker.create!(name: "A")
+
+    assert_equal ProjectTracker.count, auth_for(admin).scope_collection(ProjectTracker.all).count
+    assert_equal ProjectTracker.count, auth_for(lead_grantee).scope_collection(ProjectTracker.all).count
+
+    scoped = make_user("sc@sanctuary.computer")
+    PermissionGrant.create!(admin_user: scoped, permission: "lead", subject: ProjectTracker.first)
+    assert_equal AdminUser.count, auth_for(scoped).scope_collection(AdminUser.all).count
+  end
+
+  test "existing contributor fallback rules still work for users without grants" do
+    user = make_user("plain@sanctuary.computer")
+    auth = auth_for(user)
+    assert auth.authorized?(:read, user)          # own AdminUser record
+    assert auth.authorized?(:read, Survey)
+    refute auth.authorized?(:read, InvoiceTracker)
+  end
+end
+```
+
+Adjust record creation only if a model validation demands another attribute (e.g. `InvoiceTracker` uniqueness on `[forecast_client_id, invoice_pass_id]` is why each tracker gets its own client). Do not weaken assertions.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bin/rails test test/models/admin_authorization_test.rb`
+Expected: the global-grant, scoped, and scope_collection tests FAIL (adapter still checks `has_led_projects?` and has no `scope_collection`).
+
+- [ ] **Step 3: Implement the adapter changes**
+
+In `app/models/admin_authorization.rb`:
+
+**(a)** Replace the commented-out `scope_collection` block (lines 15-24) with:
+
+```ruby
+  # Narrows index pages for users whose only access comes from
+  # project-scoped "lead" grants. Admins and (actual or granted) leads see
+  # everything. ActiveAdmin calls this automatically for every index via
+  # apply_authorization_scope.
+  def scope_collection(collection, action = :read)
+    return collection if user.is_admin? || user.can_act_as_lead?
+
+    scoped_ids = user.lead_scoped_project_tracker_ids
+    return collection if scoped_ids.empty?
+
+    case collection.klass.name
+    when "ProjectTracker"
+      collection.where(id: scoped_ids)
+    when "InvoiceTracker"
+      forecast_project_ids = ProjectTrackerForecastProject
+        .where(project_tracker_id: scoped_ids)
+        .pluck(:forecast_project_id)
+      return collection.none if forecast_project_ids.empty?
+
+      collection.where(<<~SQL.squish, forecast_project_ids)
+        invoice_trackers.blueprint IS NOT NULL
+        AND jsonb_typeof(invoice_trackers.blueprint -> 'lines') = 'object'
+        AND EXISTS (
+          SELECT 1
+          FROM jsonb_each(invoice_trackers.blueprint -> 'lines') AS line
+          WHERE (line.value ->> 'forecast_project')::bigint IN (?)
+        )
+      SQL
+    else
+      collection
+    end
+  end
+```
+
+**(b)** Change line 35 from
+
+```ruby
+    return true if (user.is_admin? || user.has_led_projects?)
+```
+
+to
+
+```ruby
+    return true if (user.is_admin? || user.can_act_as_lead?)
+```
+
+**(c)** Immediately after that line, insert:
+
+```ruby
+    # Project-scoped "lead" grants (leads-in-training limited to specific
+    # projects): read-only visibility into the granted ProjectTrackers, the
+    # InvoiceTrackers that bill them, and the InvoicePass containers needed
+    # to navigate to those trackers. scope_collection narrows the index
+    # pages; this handles class-level (menu/index) and per-record checks.
+    if action == :read
+      scoped_ids = user.lead_scoped_project_tracker_ids
+      if scoped_ids.any?
+        return true if [ProjectTracker, InvoiceTracker, InvoicePass].include?(subject)
+        return true if subject.is_a?(InvoicePass)
+        return true if subject.is_a?(ProjectTracker) && scoped_ids.include?(subject.id)
+        return true if subject.is_a?(InvoiceTracker) && (subject.project_trackers.map(&:id) & scoped_ids).any?
+      end
+    end
+```
+
+**(d)** In `app/views/admin/contributor_payouts/_show.html.erb` line 9, change `current_admin_user.has_led_projects?` to `current_admin_user.can_act_as_lead?`.
+
+- [ ] **Step 4: Run the adapter tests, then the model tests from Tasks 1-2**
+
+Run: `bin/rails test test/models/admin_authorization_test.rb test/models/permission_grant_test.rb test/models/admin_user_permission_grants_test.rb`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/models/admin_authorization.rb app/views/admin/contributor_payouts/_show.html.erb test/models/admin_authorization_test.rb
+git commit -m "feat: honor permission grants in AdminAuthorization (global + project-scoped read-only)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Admin UI — grant management on AdminUser + guard promote/demote
+
+**Files:**
+- Modify: `app/admin/admin_users.rb` (permit_params ~line 2-33; member_actions ~line 75-83; controller block ~line 85; form ~line 197-201)
+- Modify: `app/views/admin/admin_users/_show.html.erb` (append Permission Grants panel)
+- Test: `test/integration/admin_permission_grants_test.rb`
+
+**Interfaces:**
+- Consumes: `PermissionGrant::PERMISSIONS`, `AdminUser accepts_nested_attributes_for :permission_grants` (Tasks 1-2).
+- Produces: admin-only nested form + show panel for grants; `granted_by` stamped server-side; `promote_admin_user`/`demote_admin_user` gated by `current_admin_user.is_admin?`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/integration/admin_permission_grants_test.rb`:
+
+```ruby
+require 'test_helper'
+
+class AdminPermissionGrantsTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @admin = AdminUser.create!(
+      email: "hugh@sanctuary.computer",
+      password: 'password12345', password_confirmation: 'password12345',
+      roles: ['admin']
+    )
+    @trainee = AdminUser.create!(
+      email: "trainee@sanctuary.computer",
+      password: 'password12345', password_confirmation: 'password12345'
+    )
+  end
+
+  test "an admin can create a global lead grant from the edit form" do
+    sign_in @admin
+    put admin_admin_user_path(@trainee), params: {
+      admin_user: {
+        permission_grants_attributes: {
+          "0" => { permission: "lead", subject_id: "", notes: "AL training" }
+        }
+      }
+    }
+    assert_equal 1, @trainee.reload.permission_grants.count
+    grant = @trainee.permission_grants.first
+    assert grant.global?
+    assert_equal @admin.id, grant.granted_by_id
+    assert @trainee.can_act_as_lead?
+  end
+
+  test "an admin can create a project-scoped grant" do
+    pt = ProjectTracker.create!(name: "Training Project")
+    sign_in @admin
+    put admin_admin_user_path(@trainee), params: {
+      admin_user: {
+        permission_grants_attributes: {
+          "0" => { permission: "lead", subject_id: pt.id.to_s }
+        }
+      }
+    }
+    grant = @trainee.reload.permission_grants.first
+    assert_equal pt, grant.subject
+    refute @trainee.can_act_as_lead?
+    assert_equal [pt.id], @trainee.lead_scoped_project_tracker_ids
+  end
+
+  test "a non-admin (even a global grantee) cannot create grants" do
+    PermissionGrant.create!(admin_user: @trainee, permission: "lead", granted_by: @admin)
+    sign_in @trainee
+    put admin_admin_user_path(@trainee), params: {
+      admin_user: {
+        profit_share_notes: "hi",
+        permission_grants_attributes: {
+          "0" => { permission: "lead", subject_id: "", notes: "sneaky second grant" }
+        }
+      }
+    }
+    assert_equal 1, @trainee.reload.permission_grants.count
+  end
+
+  test "a non-admin lead cannot promote themselves to admin" do
+    PermissionGrant.create!(admin_user: @trainee, permission: "lead", granted_by: @admin)
+    sign_in @trainee
+    post promote_admin_user_admin_admin_user_path(@trainee)
+    refute @trainee.reload.is_admin?
+  end
+
+  test "a non-admin lead cannot demote an admin" do
+    PermissionGrant.create!(admin_user: @trainee, permission: "lead", granted_by: @admin)
+    sign_in @trainee
+    post demote_admin_user_admin_admin_user_path(@admin)
+    assert @admin.reload.is_admin?
+  end
+
+  test "an admin can still promote and demote" do
+    sign_in @admin
+    post promote_admin_user_admin_admin_user_path(@trainee)
+    assert @trainee.reload.is_admin?
+    post demote_admin_user_admin_admin_user_path(@trainee)
+    refute @trainee.reload.is_admin?
+  end
+
+  test "the show page lists grants for admins" do
+    PermissionGrant.create!(admin_user: @trainee, permission: "lead", granted_by: @admin, notes: "Q3 cohort")
+    sign_in @admin
+    get admin_admin_user_path(@trainee)
+    assert_response :success
+    assert_includes response.body, "Permission Grants"
+    assert_includes response.body, "Q3 cohort"
+  end
+end
+```
+
+Note: `@admin` demoting/promoting relies on `is_admin?` including the `is_hugh?` email backdoor — that's why `@admin` uses Hugh's email AND `roles: ['admin']` (the demote test targets `@trainee`, not `@admin`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bin/rails test test/integration/admin_permission_grants_test.rb`
+Expected: FAIL — grants not created (param not permitted), promote test FAILS because the trainee CAN currently self-promote (this failure proves the live escalation hole), show page lacks the panel.
+
+- [ ] **Step 3: Implement**
+
+In `app/admin/admin_users.rb`:
+
+**(a)** Append to `permit_params` (after `pre_profit_share_purchases_attributes`):
+
+```ruby
+    permission_grants_attributes: [
+      :id,
+      :permission,
+      :subject_id,
+      :notes,
+      :granted_by_id,
+      :_destroy
+    ]
+```
+
+**(b)** Replace the two unguarded member_actions (lines 75-83) with:
+
+```ruby
+  member_action :demote_admin_user, method: :post do
+    unless current_admin_user.is_admin?
+      redirect_to admin_admin_user_path(resource), alert: "Only admins can do that."
+      return
+    end
+    resource.update!(roles: [])
+    redirect_to admin_admin_user_path(resource), notice: "Success!"
+  end
+
+  member_action :promote_admin_user, method: :post do
+    unless current_admin_user.is_admin?
+      redirect_to admin_admin_user_path(resource), alert: "Only admins can do that."
+      return
+    end
+    resource.update!(roles: ["admin"])
+    redirect_to admin_admin_user_path(resource), notice: "Success!"
+  end
+```
+
+**(c)** Inside the existing `controller do` block, add:
+
+```ruby
+    # Permission grants are admin-managed only. The form hides them from
+    # non-admins, but leads pass the authorization adapter for AdminUser
+    # updates, so strip the params server-side too. New grants get
+    # granted_by stamped from the acting admin, never from the client.
+    def update
+      attrs = params.dig(:admin_user, :permission_grants_attributes)
+      if attrs.present?
+        if current_admin_user.is_admin?
+          attrs.each do |_key, grant_attrs|
+            grant_attrs[:granted_by_id] = current_admin_user.id if grant_attrs[:id].blank?
+          end
+        else
+          params[:admin_user].delete(:permission_grants_attributes)
+        end
+      end
+      super
+    end
+```
+
+**(d)** In the form, after the `pre_profit_share_purchases` `has_many` block (~line 201, still inside `if current_admin_user.is_admin?`), add:
+
+```ruby
+        f.has_many :permission_grants, heading: "Permission Grants", allow_destroy: true do |a|
+          a.input :permission, as: :select, collection: PermissionGrant::PERMISSIONS, include_blank: false
+          a.input :subject_id,
+            as: :select,
+            collection: ProjectTracker.order(:name).pluck(:name, :id),
+            include_blank: "All projects",
+            label: "Scope to project",
+            hint: "Leave blank for lead-level access to everything (same as someone who has led a project — for leads-in-training). Pick a project to limit them to read-only access to that project's tracker and invoices."
+          a.input :notes, hint: "Why this grant exists, e.g. 'Account Lead training, Q3 cohort'."
+        end
+```
+
+**(e)** In `app/views/admin/admin_users/_show.html.erb`, append at the end of the file:
+
+```erb
+<% if current_admin_user.is_admin? && resource.permission_grants.any? %>
+  <div class="panel">
+    <h3>Permission Grants</h3>
+    <div class="panel_contents">
+      <table border="0" cellspacing="0" cellpadding="0" class="index_table index">
+        <thead>
+          <tr>
+            <th class="col">Permission</th>
+            <th class="col">Scope</th>
+            <th class="col">Granted By</th>
+            <th class="col">Notes</th>
+            <th class="col">Granted At</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% resource.permission_grants.each do |grant| %>
+            <tr>
+              <td class="col"><%= grant.permission.humanize %></td>
+              <td class="col"><%= grant.global? ? "All projects" : (grant.subject.respond_to?(:name) ? grant.subject.name : "#{grant.subject_type} ##{grant.subject_id}") %></td>
+              <td class="col"><%= grant.granted_by&.email %></td>
+              <td class="col"><%= grant.notes %></td>
+              <td class="col"><%= grant.created_at.to_date %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+<% end %>
+```
+
+- [ ] **Step 4: Run the integration tests**
+
+Run: `bin/rails test test/integration/admin_permission_grants_test.rb`
+Expected: PASS (all 8)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/admin/admin_users.rb app/views/admin/admin_users/_show.html.erb test/integration/admin_permission_grants_test.rb
+git commit -m "feat: manage permission grants from the AdminUser admin; guard promote/demote
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Full-suite verification and PR
+
+**Files:**
+- No new files. Possibly fix fallout surfaced by the full suite.
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: green suite, pushed branch `feat/permission-grants`, open PR to `main`.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `bin/rails test`
+Expected: 0 failures, 0 errors. If a pre-existing test asserts on `has_led_projects?`-driven authorization, update it to the new `can_act_as_lead?` reality only if the test's intent is authorization; otherwise investigate before touching it.
+
+- [ ] **Step 2: Push and open the PR**
+
+```bash
+git checkout -b feat/permission-grants
+git push -u origin feat/permission-grants
+gh pr create --base main --title "Permission grants: lead-in-training access (global or per-project)" --body "$(cat <<'EOF'
+## Summary
+- New `permission_grants` table + `PermissionGrant` model: `{admin_user, permission, optional polymorphic subject, granted_by, notes}` — extensible to new permissions/scopes without schema changes
+- Global `"lead"` grant ⇒ `AdminUser#can_act_as_lead?` ⇒ identical ActiveAdmin access to someone who has actually led (for team/account leads in training)
+- Project-scoped grant ⇒ read-only access to that project's ProjectTracker + the InvoiceTrackers billing it (index pages filtered via new `AdminAuthorization#scope_collection`)
+- Admins manage grants from the Everybody (AdminUser) edit form; grants panel on the show page; `granted_by` stamped server-side
+- Hardening: `promote_admin_user` / `demote_admin_user` member actions now verify `is_admin?` server-side (previously only the link was hidden — any lead could POST to self-promote)
+
+## Defaulted decisions (see spec)
+- Scoped grants are read-only; write-within-scope would be a new permission string later
+- Global grants pass the same master gate as real leads (full lead-equivalent visibility)
+- Scoped grantees can read InvoicePass pages (needed to navigate to their invoice trackers)
+- No `expires_at` — training grants are revoked manually
+
+Spec: `docs/superpowers/specs/2026-08-04-permission-grants-design.md`
+Plan: `docs/superpowers/plans/2026-08-04-permission-grants.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-08-04-permission-grants-design.md
+++ b/docs/superpowers/specs/2026-08-04-permission-grants-design.md
@@ -105,9 +105,10 @@ gate falls through:
    filter that resolves granted projects → `ProjectTrackerForecastProject` →
    forecast_project ids → `EXISTS (SELECT 1 FROM jsonb_each(blueprint->'lines') l
    WHERE (l.value->>'forecast_project')::bigint IN (...))`. `InvoicePass` is not
-   row-filtered (it's just a monthly container); its show page must render only
-   trackers the viewer is authorized to read (guard the tracker table rows with
-   `authorized?(:read, tracker)` in `app/admin/invoice_passes.rb`).
+   row-filtered (it's just a monthly container). Its show partial renders only
+   error tables — trackers are listed on the nested InvoiceTracker index
+   (`admin_invoice_pass_invoice_trackers_path`), which `scope_collection`
+   filters, so no view changes are needed there.
 4. Keep the existing `Dashboard` page allowance (already present for everyone).
 
 ### Admin UI (`app/admin/admin_users.rb`)

--- a/docs/superpowers/specs/2026-08-04-permission-grants-design.md
+++ b/docs/superpowers/specs/2026-08-04-permission-grants-design.md
@@ -1,0 +1,173 @@
+# Permission Grants: Lead-in-Training Access — Design
+
+**Date:** 2026-08-04
+**Branch:** `worktree-per-project-stacks-permissions`
+
+## Problem
+
+Access to the financial/BI surface of ActiveAdmin (Invoice Trackers, Project Trackers,
+Studios, explorers, etc.) is gated by a single check in
+`AdminAuthorization#authorized?`:
+
+```ruby
+return true if (user.is_admin? || user.has_led_projects?)
+```
+
+`AdminUser#has_led_projects?` returns true only if the person has **ever** held an
+`AccountLeadPeriod` or `ProjectLeadPeriod`. People training to become team leads or
+account leads have never held one, so there is no way to give them that visibility
+without making them full admins or fabricating a lead period (which would corrupt
+compensation data — `AccountLeadPeriod#taking_percent` drives real payouts).
+
+We need admins to be able to grant a person lead-equivalent access explicitly, and the
+mechanism must be extensible to **scoped** grants: a person may be limited to seeing
+only the Project Trackers and Invoice Trackers pertaining to specific projects, or be
+given all projects.
+
+## Approaches considered
+
+1. **Add a `"lead_in_training"` value to the existing `admin_users.roles` text[]
+   column.** Lowest friction (no migration), but stringly-typed, has no room for
+   per-project scoping, no audit trail of who granted it, and the exact-array-equality
+   `AdminUser.admin` scope (`where(roles: ["admin"])`) breaks the moment a user holds
+   two roles.
+2. **Reuse the lead-period tables with a "training" flag.** Rejected outright:
+   `AccountLeadPeriod` drives compensation (`taking_percent`), and
+   `has_led_projects?` semantics ("ever led") would become untrustworthy.
+3. **A `permission_grants` table — one row per grant, with an optional polymorphic
+   subject for scoping.** (Recommended.) This generalizes the existing
+   `enterprise_admins` precedent (a join table read by a predicate with a super-admin
+   bypass) into a reusable shape: `{admin_user, permission, subject?, granted_by,
+   notes}`. A grant with no subject is global; a grant with a subject is scoped to
+   that record. New permission kinds and new subject types are added by extending two
+   allow-lists — no new tables.
+
+## Design
+
+### Data model
+
+New table `permission_grants`:
+
+| column | type | notes |
+|---|---|---|
+| `admin_user_id` | bigint, null: false, FK | who holds the permission |
+| `permission` | string, null: false | initially only `"lead"` |
+| `subject_type` / `subject_id` | string / bigint, nullable | polymorphic scope; both nil ⇒ global |
+| `granted_by_id` | bigint, nullable, FK → admin_users | audit: who granted it |
+| `notes` | text | why (e.g. "AL training, Q3 cohort") |
+| timestamps | | |
+
+Indexes: unique on `[admin_user_id, permission, subject_type, subject_id]`; plain on
+`[subject_type, subject_id]`.
+
+`PermissionGrant` model:
+
+- `belongs_to :admin_user`, `belongs_to :granted_by, class_name: "AdminUser",
+  optional: true`, `belongs_to :subject, polymorphic: true, optional: true`
+- `PERMISSIONS = %w[lead]`, `SUBJECT_TYPES = %w[ProjectTracker]` — validated
+  inclusion (subject_type only when present). Extending the system later = adding a
+  string to one of these arrays plus the enforcement for it.
+- Scopes: `global` (`subject_type: nil`), `for_permission(p)`.
+
+### Predicates on `AdminUser`
+
+- `has_many :permission_grants, dependent: :destroy` (+ `accepts_nested_attributes_for`)
+- `can_act_as_lead?` → `has_led_projects? || permission_grants.global.for_permission("lead").any?`
+- `lead_scoped_project_tracker_ids` → subject ids of `"lead"` grants scoped to
+  `ProjectTracker` (memoized per request-ish usage is fine; keep it a simple query).
+
+`has_led_projects?` keeps its exact current meaning ("has actually held a lead
+period") — compensation and reporting code can keep relying on it. Authorization
+call sites move to `can_act_as_lead?`:
+
+- `admin_authorization.rb:35` → `return true if user.is_admin? || user.can_act_as_lead?`
+- `app/views/admin/contributor_payouts/_show.html.erb:9` → `can_act_as_lead?`
+
+So a **global** `"lead"` grant is exactly equivalent to having led before — same
+blanket ActiveAdmin access a real lead gets today. A **scoped** grant deliberately
+does *not* pass that line; it gets only the narrow rules below.
+
+### Scoped access enforcement (`AdminAuthorization`)
+
+For a user whose only standing is project-scoped `"lead"` grants, after the global
+gate falls through:
+
+1. **Class-level reads** (menus + index actions): allow `:read`/`:index` on
+   `ProjectTracker` and `InvoiceTracker` classes when
+   `lead_scoped_project_tracker_ids.any?`. Also allow `:read` on `InvoicePass`
+   (invoice trackers are only reachable through their pass's show page).
+2. **Record-level reads**: allow `:read` on a `ProjectTracker` instance iff its id is
+   in the granted set; allow `:read` on an `InvoiceTracker` instance iff
+   `invoice_tracker.project_trackers` intersects the granted set. Scoped access is
+   **read-only** — no create/update/destroy, no member actions.
+3. **Index scoping**: re-enable `scope_collection` in the adapter. For scoped-only
+   users, filter `ProjectTracker` to granted ids and `InvoiceTracker` via a SQL
+   filter that resolves granted projects → `ProjectTrackerForecastProject` →
+   forecast_project ids → `EXISTS (SELECT 1 FROM jsonb_each(blueprint->'lines') l
+   WHERE (l.value->>'forecast_project')::bigint IN (...))`. `InvoicePass` is not
+   row-filtered (it's just a monthly container); its show page must render only
+   trackers the viewer is authorized to read (guard the tracker table rows with
+   `authorized?(:read, tracker)` in `app/admin/invoice_passes.rb`).
+4. Keep the existing `Dashboard` page allowance (already present for everyone).
+
+### Admin UI (`app/admin/admin_users.rb`)
+
+- Show page: a "Permission Grants" panel (visible to admins) listing each grant —
+  permission, scope ("All projects" / project name), granted by, notes, granted at.
+- Edit form (inside the existing `if current_admin_user.is_admin?` block):
+  `f.has_many :permission_grants, allow_destroy: true` with permission select
+  (`PermissionGrant::PERMISSIONS`), an optional `subject_id` select over
+  `ProjectTracker` (labelled "Scope to project — leave blank for all projects", with
+  hidden/derived `subject_type: "ProjectTracker"` when a project is chosen), and
+  notes. `granted_by` is set automatically to `current_admin_user`, never from
+  params.
+- `permit_params` gains `permission_grants_attributes`; the controller strips
+  `permission_grants_attributes` from params unless `current_admin_user.is_admin?`
+  (the form gate alone is UI-only — leads pass the adapter and could otherwise POST
+  grants to themselves).
+
+### Hardening (in scope because this widens who passes the adapter)
+
+`member_action :promote_admin_user`, `:demote_admin_user` in
+`app/admin/admin_users.rb` currently have **no controller-side guard** — only the
+`action_item` link is hidden. Any lead (and now any global grantee) could POST to
+them directly and self-promote to admin. Add explicit
+`current_admin_user.is_admin?` guards to both (impersonate already has one).
+
+### Testing
+
+New `test/models/admin_authorization_test.rb` (first authorization tests in the app)
+plus `test/models/permission_grant_test.rb`:
+
+- Global grant ⇒ `can_act_as_lead?` true, adapter authorizes ProjectTracker /
+  InvoiceTracker reads and writes exactly as a period-holding lead.
+- No grant, no periods ⇒ unchanged fallback behavior (contributor ledger rules).
+- Scoped grant ⇒ read allowed on in-scope ProjectTracker/InvoiceTracker instances,
+  denied on out-of-scope instances, denied for `:update`/`:destroy` everywhere;
+  `scope_collection` filters both indexes correctly (jsonb filter verified against a
+  real blueprint fixture).
+- Promote/demote member actions reject non-admins (controller test).
+- `PermissionGrant` validations: permission/subject_type inclusion, uniqueness.
+
+### Error handling
+
+- Deleting a `ProjectTracker` with grants pointing at it: `dependent: :destroy` via a
+  `has_many :permission_grants, as: :subject` on `ProjectTracker` so grants can't
+  dangle.
+- A scoped user with zero surviving grants degrades gracefully to the existing
+  non-lead fallback ladder (no crash, just no access).
+
+## Defaulted decisions (flagged for PR review)
+
+1. **Scoped grants are read-only** (index/show only). "Only see invoice trackers and
+   project trackers" was read literally; write access within a project scope can be a
+   follow-up permission (e.g. `"lead_write"`) without schema changes.
+2. **Global grants are full lead-equivalents** — they pass the same line-35 gate, so
+   they see everything a real lead sees (not just trackers). That is what "similar to
+   the current permission" was taken to mean.
+3. **Scoped grants also allow `:read` on `InvoicePass`** so scoped users can navigate
+   to their invoice trackers; the pass show page hides other clients' tracker rows.
+4. **Polymorphic subject** rather than a bare `project_tracker_id` FK, so future
+   scopes (Studio, Enterprise) need no migration.
+5. **No expiry column.** Training grants are revoked manually; add `expires_at` later
+   if needed.

--- a/docs/superpowers/specs/2026-08-04-permission-grants-design.md
+++ b/docs/superpowers/specs/2026-08-04-permission-grants-design.md
@@ -167,7 +167,10 @@ plus `test/models/permission_grant_test.rb`:
    they see everything a real lead sees (not just trackers). That is what "similar to
    the current permission" was taken to mean.
 3. **Scoped grants also allow `:read` on `InvoicePass`** so scoped users can navigate
-   to their invoice trackers; the pass show page hides other clients' tracker rows.
+   to their invoice trackers. The final review found the InvoicePass index rendered
+   company-wide monthly aggregates (value / outstanding / surplus / status counts) and
+   the show page a company-wide missing-hours report; both are now gated behind
+   `is_admin? || can_act_as_lead?`, leaving only month navigation for scoped users.
 4. **Polymorphic subject** rather than a bare `project_tracker_id` FK, so future
    scopes (Studio, Enterprise) need no migration.
 5. **No expiry column.** Training grants are revoked manually; add `expires_at` later

--- a/test/integration/admin_permission_grants_test.rb
+++ b/test/integration/admin_permission_grants_test.rb
@@ -97,4 +97,26 @@ class AdminPermissionGrantsTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "Permission Grants"
     assert_includes response.body, "Q3 cohort"
   end
+
+  test "a project-scoped grantee cannot see company-wide invoicing aggregates on the invoice passes index" do
+    pt = make_project_tracker("Training Project")
+    PermissionGrant.create!(admin_user: @trainee, permission: "lead", subject: pt, granted_by: @admin)
+    InvoicePass.create!(start_of_month: Date.today.beginning_of_month)
+
+    sign_in @trainee
+    get admin_invoice_passes_path
+    assert_response :success
+    refute_includes response.body, "Outstanding"
+    refute_includes response.body, "Surplus"
+  end
+
+  test "an admin can see company-wide invoicing aggregates on the invoice passes index" do
+    InvoicePass.create!(start_of_month: Date.today.beginning_of_month)
+
+    sign_in @admin
+    get admin_invoice_passes_path
+    assert_response :success
+    assert_includes response.body, "Outstanding"
+    assert_includes response.body, "Surplus"
+  end
 end

--- a/test/integration/admin_permission_grants_test.rb
+++ b/test/integration/admin_permission_grants_test.rb
@@ -119,4 +119,20 @@ class AdminPermissionGrantsTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "Outstanding"
     assert_includes response.body, "Surplus"
   end
+
+  test "a project-scoped grantee hitting an index with no scoped_collection override does not 500" do
+    pt = make_project_tracker("Training Project")
+    PermissionGrant.create!(admin_user: @trainee, permission: "lead", subject: pt, granted_by: @admin)
+
+    # /admin/ledgers has no scoped_collection override, so ActiveAdmin hands
+    # scope_collection the bare Ledger class (via InheritedResources'
+    # end_of_association_chain) rather than a Relation. The trainee isn't
+    # authorized to read Ledger at all, so the expected outcome is a clean
+    # access-denied redirect — not a NoMethodError on Class#klass.
+    sign_in @trainee
+    get admin_ledgers_path
+    assert_response :redirect
+    assert_redirected_to admin_root_path
+    assert_equal "You are not authorized to perform this action.", flash[:error]
+  end
 end

--- a/test/integration/admin_permission_grants_test.rb
+++ b/test/integration/admin_permission_grants_test.rb
@@ -1,0 +1,100 @@
+require 'test_helper'
+
+class AdminPermissionGrantsTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  def make_project_tracker(name)
+    pt = ProjectTracker.new(name: name)
+    pt.save!(validate: false)
+    pt
+  end
+
+  setup do
+    @admin = AdminUser.create!(
+      email: "hugh@sanctuary.computer",
+      password: 'password12345', password_confirmation: 'password12345',
+      roles: ['admin']
+    )
+    @trainee = AdminUser.create!(
+      email: "trainee@sanctuary.computer",
+      password: 'password12345', password_confirmation: 'password12345'
+    )
+  end
+
+  test "an admin can create a global lead grant from the edit form" do
+    sign_in @admin
+    put admin_admin_user_path(@trainee), params: {
+      admin_user: {
+        permission_grants_attributes: {
+          "0" => { permission: "lead", subject_id: "", notes: "AL training" }
+        }
+      }
+    }
+    assert_equal 1, @trainee.reload.permission_grants.count
+    grant = @trainee.permission_grants.first
+    assert grant.global?
+    assert_equal @admin.id, grant.granted_by_id
+    assert @trainee.can_act_as_lead?
+  end
+
+  test "an admin can create a project-scoped grant" do
+    pt = make_project_tracker("Training Project")
+    sign_in @admin
+    put admin_admin_user_path(@trainee), params: {
+      admin_user: {
+        permission_grants_attributes: {
+          "0" => { permission: "lead", subject_id: pt.id.to_s }
+        }
+      }
+    }
+    grant = @trainee.reload.permission_grants.first
+    assert_equal pt, grant.subject
+    refute @trainee.can_act_as_lead?
+    assert_equal [pt.id], @trainee.lead_scoped_project_tracker_ids
+  end
+
+  test "a non-admin (even a global grantee) cannot create grants" do
+    PermissionGrant.create!(admin_user: @trainee, permission: "lead", granted_by: @admin)
+    sign_in @trainee
+    put admin_admin_user_path(@trainee), params: {
+      admin_user: {
+        profit_share_notes: "hi",
+        permission_grants_attributes: {
+          "0" => { permission: "lead", subject_id: "", notes: "sneaky second grant" }
+        }
+      }
+    }
+    assert_equal 1, @trainee.reload.permission_grants.count
+  end
+
+  test "a non-admin lead cannot promote themselves to admin" do
+    PermissionGrant.create!(admin_user: @trainee, permission: "lead", granted_by: @admin)
+    sign_in @trainee
+    post promote_admin_user_admin_admin_user_path(@trainee)
+    refute @trainee.reload.is_admin?
+  end
+
+  test "a non-admin lead cannot demote an admin" do
+    PermissionGrant.create!(admin_user: @trainee, permission: "lead", granted_by: @admin)
+    sign_in @trainee
+    post demote_admin_user_admin_admin_user_path(@admin)
+    assert @admin.reload.is_admin?
+  end
+
+  test "an admin can still promote and demote" do
+    sign_in @admin
+    post promote_admin_user_admin_admin_user_path(@trainee)
+    assert @trainee.reload.is_admin?
+    post demote_admin_user_admin_admin_user_path(@trainee)
+    refute @trainee.reload.is_admin?
+  end
+
+  test "the show page lists grants for admins" do
+    PermissionGrant.create!(admin_user: @trainee, permission: "lead", granted_by: @admin, notes: "Q3 cohort")
+    sign_in @admin
+    get admin_admin_user_path(@trainee)
+    assert_response :success
+    assert_includes response.body, "Permission Grants"
+    assert_includes response.body, "Q3 cohort"
+  end
+end

--- a/test/integration/mcp_endpoint_test.rb
+++ b/test/integration/mcp_endpoint_test.rb
@@ -233,7 +233,14 @@ class McpEndpointTest < ActionDispatch::IntegrationTest
     tr = ProjectTracker.new(name: "T", runn_project_id: 91_100)
     tr.save(validate: false)
     fp = ForecastPerson.create!(forecast_id: rand(1..2_000_000_000), email: "ada@x.com", data: {})
-    contributor = Contributor.create!(forecast_person: fp)
+    # ForecastPerson's after_create already made this person's Contributor. Creating
+    # another here would leave two rows sharing one email, and the tool resolves
+    # contributor_id_by_email last-write-wins over a scope ordered by email alone —
+    # so the winner between duplicates is arbitrary and the assertion below flaps.
+    contributor = fp.contributor
+    assert_equal 1,
+      Contributor.unscoped.joins(:forecast_person).where(forecast_people: { email: "ada@x.com" }).count,
+      "exactly one contributor must resolve to this email, or contributor_id is ambiguous"
     ProjectedAssignment.create!(source_key: "world:1", project_tracker: tr, contributor: contributor,
       start_date: (today + 1), end_date: (today + 20), minutes_per_day: 480,
       runn_assignment_id: 2, managed_by: "detector")

--- a/test/models/admin_authorization_test.rb
+++ b/test/models/admin_authorization_test.rb
@@ -1,0 +1,127 @@
+require 'test_helper'
+
+class AdminAuthorizationTest < ActiveSupport::TestCase
+  def auth_for(user)
+    AdminAuthorization.new(nil, user)
+  end
+
+  def make_user(email)
+    AdminUser.create!(email: email, password: "password12345")
+  end
+
+  def make_project_tracker(name)
+    pt = ProjectTracker.new(name: name)
+    pt.save!(validate: false)
+    pt
+  end
+
+  test "a user with no grants and no lead history has no ProjectTracker access" do
+    user = make_user("nobody@sanctuary.computer")
+    refute auth_for(user).authorized?(:read, ProjectTracker)
+  end
+
+  test "a global lead grant confers the same blanket access as having led" do
+    user = make_user("trainee@sanctuary.computer")
+    PermissionGrant.create!(admin_user: user, permission: "lead")
+    auth = auth_for(user)
+    assert auth.authorized?(:read, ProjectTracker)
+    assert auth.authorized?(:update, ProjectTracker.new)
+    assert auth.authorized?(:read, InvoiceTracker)
+    assert auth.authorized?(:read, Studio)
+  end
+
+  test "a project-scoped grant gives read-only access to that project" do
+    user = make_user("scoped@sanctuary.computer")
+    pt_mine = make_project_tracker("Mine")
+    pt_other = make_project_tracker("Other")
+    PermissionGrant.create!(admin_user: user, permission: "lead", subject: pt_mine)
+
+    auth = auth_for(user)
+    # class-level reads so menus and index pages render
+    assert auth.authorized?(:read, ProjectTracker)
+    assert auth.authorized?(:read, InvoiceTracker)
+    assert auth.authorized?(:read, InvoicePass)
+    # record-level reads limited to the granted project
+    assert auth.authorized?(:read, pt_mine)
+    refute auth.authorized?(:read, pt_other)
+    # strictly read-only
+    refute auth.authorized?(:update, pt_mine)
+    refute auth.authorized?(:destroy, pt_mine)
+    refute auth.authorized?(:create, ProjectTracker)
+    # no blanket access to anything else
+    refute auth.authorized?(:read, Studio)
+  end
+
+  test "scoped grant allows reading only invoice trackers billing the granted project" do
+    user = make_user("scoped2@sanctuary.computer")
+    pt = make_project_tracker("Mine")
+    fc = ForecastClient.create!(forecast_id: 920001, name: "Client")
+    fp = ForecastProject.create!(forecast_id: 930001, name: "Mine FP", code: "MINE-1", forecast_client: fc)
+    other_fp = ForecastProject.create!(forecast_id: 930002, name: "Other FP", code: "OTHR-1", forecast_client: fc)
+    ProjectTrackerForecastProject.create!(project_tracker: pt, forecast_project: fp)
+    PermissionGrant.create!(admin_user: user, permission: "lead", subject: pt)
+
+    in_scope = InvoiceTracker.new(blueprint: { "lines" => { "0" => { "forecast_project" => fp.id } } })
+    out_of_scope = InvoiceTracker.new(blueprint: { "lines" => { "0" => { "forecast_project" => other_fp.id } } })
+
+    auth = auth_for(user)
+    assert auth.authorized?(:read, in_scope)
+    refute auth.authorized?(:read, out_of_scope)
+    refute auth.authorized?(:toggle_ownership, in_scope)
+  end
+
+  test "scope_collection filters ProjectTracker index to granted projects" do
+    user = make_user("scoped3@sanctuary.computer")
+    pt_mine = make_project_tracker("Mine")
+    make_project_tracker("Other")
+    PermissionGrant.create!(admin_user: user, permission: "lead", subject: pt_mine)
+
+    assert_equal [pt_mine.id], auth_for(user).scope_collection(ProjectTracker.all).pluck(:id)
+  end
+
+  test "scope_collection filters InvoiceTracker index via blueprint forecast projects" do
+    user = make_user("scoped4@sanctuary.computer")
+    pt = make_project_tracker("Mine")
+    fc = ForecastClient.create!(forecast_id: 920002, name: "Client")
+    fp = ForecastProject.create!(forecast_id: 930003, name: "Mine FP", code: "MINE-2", forecast_client: fc)
+    other_fp = ForecastProject.create!(forecast_id: 930004, name: "Other FP", code: "OTHR-2", forecast_client: fc)
+    ProjectTrackerForecastProject.create!(project_tracker: pt, forecast_project: fp)
+    PermissionGrant.create!(admin_user: user, permission: "lead", subject: pt)
+
+    ip = InvoicePass.create!(start_of_month: Date.new(2031, 1, 1))
+    fc_mine = ForecastClient.create!(forecast_id: 910001, name: "Client Mine")
+    fc_other = ForecastClient.create!(forecast_id: 910002, name: "Client Other")
+    qbo = qbo_accounts(:one)
+    it_mine = InvoiceTracker.create!(forecast_client: fc_mine, invoice_pass: ip, qbo_account: qbo,
+      blueprint: { "lines" => { "0" => { "forecast_project" => fp.id } } })
+    InvoiceTracker.create!(forecast_client: fc_other, invoice_pass: ip, qbo_account: qbo,
+      blueprint: { "lines" => { "0" => { "forecast_project" => other_fp.id } } })
+    InvoiceTracker.create!(forecast_client: ForecastClient.create!(forecast_id: 910003, name: "Nil BP"),
+      invoice_pass: ip, qbo_account: qbo, blueprint: nil)
+
+    assert_equal [it_mine.id], auth_for(user).scope_collection(InvoiceTracker.all).pluck(:id)
+  end
+
+  test "scope_collection leaves collections untouched for admins, leads, and unrelated classes" do
+    admin = make_user("adm@sanctuary.computer")
+    admin.update!(roles: ["admin"])
+    lead_grantee = make_user("gl@sanctuary.computer")
+    PermissionGrant.create!(admin_user: lead_grantee, permission: "lead")
+    make_project_tracker("A")
+
+    assert_equal ProjectTracker.count, auth_for(admin).scope_collection(ProjectTracker.all).count
+    assert_equal ProjectTracker.count, auth_for(lead_grantee).scope_collection(ProjectTracker.all).count
+
+    scoped = make_user("sc@sanctuary.computer")
+    PermissionGrant.create!(admin_user: scoped, permission: "lead", subject: ProjectTracker.first)
+    assert_equal AdminUser.count, auth_for(scoped).scope_collection(AdminUser.all).count
+  end
+
+  test "existing contributor fallback rules still work for users without grants" do
+    user = make_user("plain@sanctuary.computer")
+    auth = auth_for(user)
+    assert auth.authorized?(:read, user)          # own AdminUser record
+    assert auth.authorized?(:read, Survey)
+    refute auth.authorized?(:read, InvoiceTracker)
+  end
+end

--- a/test/models/admin_authorization_test.rb
+++ b/test/models/admin_authorization_test.rb
@@ -102,6 +102,27 @@ class AdminAuthorizationTest < ActiveSupport::TestCase
     assert_equal [it_mine.id], auth_for(user).scope_collection(InvoiceTracker.all).pluck(:id)
   end
 
+  test "scope_collection filters a bare model Class (ActiveAdmin's end_of_association_chain) to granted projects" do
+    user = make_user("scoped5@sanctuary.computer")
+    pt_mine = make_project_tracker("Mine")
+    make_project_tracker("Other")
+    PermissionGrant.create!(admin_user: user, permission: "lead", subject: pt_mine)
+
+    # Top-level resources without a scoped_collection override hand
+    # ActiveAdmin (and thus scope_collection) the bare model Class, not a
+    # Relation. Must not raise NoMethodError on #klass.
+    assert_equal [pt_mine.id], auth_for(user).scope_collection(ProjectTracker).pluck(:id)
+  end
+
+  test "scope_collection leaves a bare unrelated model Class unchanged" do
+    user = make_user("scoped6@sanctuary.computer")
+    pt_mine = make_project_tracker("Mine")
+    PermissionGrant.create!(admin_user: user, permission: "lead", subject: pt_mine)
+
+    result = auth_for(user).scope_collection(Ledger)
+    assert_equal Ledger, result
+  end
+
   test "scope_collection leaves collections untouched for admins, leads, and unrelated classes" do
     admin = make_user("adm@sanctuary.computer")
     admin.update!(roles: ["admin"])

--- a/test/models/admin_user_permission_grants_test.rb
+++ b/test/models/admin_user_permission_grants_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+class AdminUserPermissionGrantsTest < ActiveSupport::TestCase
+  def make_user(email)
+    AdminUser.create!(email: email, password: "password12345")
+  end
+
+  def make_project_tracker(name)
+    pt = ProjectTracker.new(name: name)
+    pt.save!(validate: false)
+    pt
+  end
+
+  test "can_act_as_lead? is true for someone who actually led a project" do
+    user = make_user("led@sanctuary.computer")
+    pt = make_project_tracker("Led Project")
+    ProjectLeadPeriod.create!(project_tracker: pt, admin_user: user,
+      started_at: Date.new(2025, 1, 1), ended_at: Date.new(2025, 3, 31))
+    assert user.can_act_as_lead?
+  end
+
+  test "can_act_as_lead? is true with a global lead grant and false otherwise" do
+    user = make_user("trainee@sanctuary.computer")
+    refute user.can_act_as_lead?
+    PermissionGrant.create!(admin_user: user, permission: "lead")
+    assert user.reload.can_act_as_lead?
+  end
+
+  test "a project-scoped grant does NOT make can_act_as_lead? true, but appears in lead_scoped_project_tracker_ids" do
+    user = make_user("scoped@sanctuary.computer")
+    pt = make_project_tracker("Scoped Project")
+    PermissionGrant.create!(admin_user: user, permission: "lead", subject: pt)
+    refute user.can_act_as_lead?
+    assert_equal [pt.id], user.lead_scoped_project_tracker_ids
+  end
+
+  test "destroying a project tracker destroys grants scoped to it" do
+    user = make_user("scoped@sanctuary.computer")
+    pt = make_project_tracker("Doomed Project")
+    PermissionGrant.create!(admin_user: user, permission: "lead", subject: pt)
+    pt.destroy!
+    assert_equal [], user.reload.permission_grants
+  end
+
+  test "destroying a user destroys their grants" do
+    user = make_user("leaving@sanctuary.computer")
+    grant = PermissionGrant.create!(admin_user: user, permission: "lead")
+    user.destroy!
+    refute PermissionGrant.exists?(grant.id)
+  end
+end

--- a/test/models/permission_grant_test.rb
+++ b/test/models/permission_grant_test.rb
@@ -5,6 +5,12 @@ class PermissionGrantTest < ActiveSupport::TestCase
     AdminUser.create!(email: email, password: "password12345")
   end
 
+  def make_project_tracker(name)
+    pt = ProjectTracker.new(name: name)
+    pt.save!(validate: false)
+    pt
+  end
+
   test "a global lead grant is valid and global?" do
     user = make_user("trainee@sanctuary.computer")
     granter = make_user("granter@sanctuary.computer")
@@ -22,7 +28,7 @@ class PermissionGrantTest < ActiveSupport::TestCase
 
   test "subject_type defaults to ProjectTracker when only subject_id is set" do
     user = make_user("trainee@sanctuary.computer")
-    pt = ProjectTracker.create!(name: "Some Project")
+    pt = make_project_tracker("Some Project")
     grant = PermissionGrant.create!(admin_user: user, permission: "lead", subject_id: pt.id)
     assert_equal "ProjectTracker", grant.subject_type
     assert_equal pt, grant.subject
@@ -35,7 +41,7 @@ class PermissionGrantTest < ActiveSupport::TestCase
     dup = PermissionGrant.new(admin_user: user, permission: "lead")
     refute dup.valid?
 
-    pt = ProjectTracker.create!(name: "Some Project")
+    pt = make_project_tracker("Some Project")
     PermissionGrant.create!(admin_user: user, permission: "lead", subject: pt)
     scoped_dup = PermissionGrant.new(admin_user: user, permission: "lead", subject: pt)
     refute scoped_dup.valid?

--- a/test/models/permission_grant_test.rb
+++ b/test/models/permission_grant_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+class PermissionGrantTest < ActiveSupport::TestCase
+  def make_user(email)
+    AdminUser.create!(email: email, password: "password12345")
+  end
+
+  test "a global lead grant is valid and global?" do
+    user = make_user("trainee@sanctuary.computer")
+    granter = make_user("granter@sanctuary.computer")
+    grant = PermissionGrant.create!(admin_user: user, permission: "lead", granted_by: granter)
+    assert grant.global?
+    assert_includes PermissionGrant.global.for_permission("lead"), grant
+  end
+
+  test "permission must be in the allow-list" do
+    user = make_user("trainee@sanctuary.computer")
+    grant = PermissionGrant.new(admin_user: user, permission: "superuser")
+    refute grant.valid?
+    assert grant.errors[:permission].any?
+  end
+
+  test "subject_type defaults to ProjectTracker when only subject_id is set" do
+    user = make_user("trainee@sanctuary.computer")
+    pt = ProjectTracker.create!(name: "Some Project")
+    grant = PermissionGrant.create!(admin_user: user, permission: "lead", subject_id: pt.id)
+    assert_equal "ProjectTracker", grant.subject_type
+    assert_equal pt, grant.subject
+    refute grant.global?
+  end
+
+  test "duplicate grants are rejected" do
+    user = make_user("trainee@sanctuary.computer")
+    PermissionGrant.create!(admin_user: user, permission: "lead")
+    dup = PermissionGrant.new(admin_user: user, permission: "lead")
+    refute dup.valid?
+
+    pt = ProjectTracker.create!(name: "Some Project")
+    PermissionGrant.create!(admin_user: user, permission: "lead", subject: pt)
+    scoped_dup = PermissionGrant.new(admin_user: user, permission: "lead", subject: pt)
+    refute scoped_dup.valid?
+  end
+
+  test "subject_type outside the allow-list is rejected" do
+    user = make_user("trainee@sanctuary.computer")
+    grant = PermissionGrant.new(admin_user: user, permission: "lead", subject_type: "Studio", subject_id: 1)
+    refute grant.valid?
+    assert grant.errors[:subject_type].any?
+  end
+end


### PR DESCRIPTION
## Summary
- New `permission_grants` table + `PermissionGrant` model: `{admin_user, permission, optional polymorphic subject, granted_by, notes}` — extensible to new permissions/scopes without schema changes
- Global `"lead"` grant ⇒ `AdminUser#can_act_as_lead?` ⇒ identical ActiveAdmin access to someone who has actually led (for team/account leads in training)
- Project-scoped grant ⇒ read-only access to that project's ProjectTracker + the InvoiceTrackers billing it (index pages filtered via new `AdminAuthorization#scope_collection`; jsonb blueprint → ProjectTrackerForecastProject mapping)
- Admins manage grants from the Everybody (AdminUser) edit form; grants panel on the show page; `granted_by` stamped server-side, nested grant params stripped for non-admins
- Hardening: `promote_admin_user` / `demote_admin_user` member actions now verify `is_admin?` server-side (previously only the link was hidden — any lead could POST to self-promote; the TDD run reproduced the escalation before fixing it)
- Final-review fix: InvoicePass index company-wide aggregates (value/outstanding/surplus/status counts) and the show page's missing-hours report are now hidden from project-scoped grantees

## Defaulted decisions (see spec)
- Scoped grants are read-only; write-within-scope would be a new permission string later
- Global grants pass the same master gate as real leads (full lead-equivalent visibility)
- Scoped grantees can read InvoicePass pages for navigation only (aggregates gated)
- No `expires_at` — training grants are revoked manually

## Testing
- Full suite: 1032 runs, 2841 assertions — 1 failure which is a pre-existing evening-PDT timezone flake in `AdminUserTest` (salary-window `Date.today` vs UTC rollover; code untouched by this branch), 2 pre-existing skips
- New coverage: PermissionGrant validations, AdminUser predicates, adapter unit tests (global/scoped/read-only/scope_collection incl. jsonb filter against real rows), HTTP integration tests for grant injection, self-promotion, and aggregate gating

## Deferred follow-ups (from reviews)
- Memoize `can_act_as_lead?` / scoped ids at the adapter layer (query amplification on menu rendering)
- `on_delete: :nullify` for `permission_grants.granted_by_id`
- Guard lead-only `action_item` buttons on pages scoped users can see (dead-button UX)
- Numeric guard before `::bigint` cast in the blueprint jsonb filter for legacy data
- One HTTP-level test pinning member-action denial for scoped users

Spec: `docs/superpowers/specs/2026-08-04-permission-grants-design.md`
Plan: `docs/superpowers/plans/2026-08-04-permission-grants.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)