### PR TITLE
Scope profit share eligibility to the Sanctuary Computer umbrella

### DIFF
--- a/app/models/periodic_report.rb
+++ b/app/models/periodic_report.rb
@@ -21,6 +21,14 @@ class PeriodicReport < ApplicationRecord
   # Query param + `scope_studio_from_param` keys for quarterly report studio tabs (single source of truth).
   STUDIO_TAB_KEYS = %w[g3d xxix sanctu].freeze
 
+  # Profit share eligibility ruleset (Q2 2026 onward): elevated service is
+  # derived only from work attributed to these enterprises (hours on their
+  # billed clients, income on their ledgers), and only contributors with a
+  # company email address participate. Historical tenure (psu) intentionally
+  # stays network-wide — past quarters were earned under the old rules.
+  PROFIT_SHARE_ENTERPRISE_NAMES = [Enterprise::SANCTUARY_NAME, Enterprise::GARDEN3D_NAME].freeze
+  PROFIT_SHARE_EMAIL_DOMAINS = %w[sanctuary.computer xxix.co].freeze
+
   def self.create_for_period(period = Stacks::Period.new("Q4, 2025", Date.today.last_quarter.beginning_of_quarter, Date.today.last_quarter.end_of_quarter, :quarter))
     create!(
       period_gradation: period.gradation,
@@ -161,15 +169,64 @@ class PeriodicReport < ApplicationRecord
     @_us_cost_of_living_data ||= PeriodicReport.parsed_numbeo_cost_of_living_indices_by_country["United States"]
   end
 
+  def self.eligible_profit_share_email?(email)
+    PROFIT_SHARE_EMAIL_DOMAINS.include?(email.to_s.split("@").last.to_s.downcase)
+  end
+
+  def profit_share_enterprise_ids
+    @_profit_share_enterprise_ids ||= Enterprise.where(name: PROFIT_SHARE_ENTERPRISE_NAMES).pluck(:id)
+  end
+
+  # Per-month elevated service derived ONLY from profit-share enterprises, in
+  # contrast to Contributor#all_items_grouped_by_month's network-wide flag:
+  # hours count when the assignment's client bills through an in-scope
+  # enterprise, income when the payout/trueup sits on an in-scope ledger.
+  # `by_month` is the contributor's ledger walk (so items aren't re-queried);
+  # returns { Stacks::Period(month) => Boolean } for this report's quarter.
+  def profit_share_elevated_service_by_month(contributor, by_month)
+    scope_ids = profit_share_enterprise_ids
+    scoped_assignments = contributor.forecast_person.forecast_assignments
+      .includes(forecast_project: :forecast_client)
+      .where("end_date >= ? AND start_date <= ?", period.starts_at, period.ends_at)
+      .select do |fa|
+        forecast_client = fa.forecast_project&.forecast_client
+        # Clientless projects (e.g. Time Off) follow ForecastClient#billing_enterprise's
+        # unmapped-client default of Sanctuary.
+        enterprise = forecast_client ? forecast_client.billing_enterprise : Enterprise.sanctuary
+        scope_ids.include?(enterprise.id)
+      end
+
+    by_month.reduce({}) do |acc, (month, metadata)|
+      next acc unless month.starts_at >= period.starts_at && month.ends_at <= period.ends_at
+
+      hours = contributor.forecast_person.recorded_allocation_during_range_in_hours_from_assignments(
+        scoped_assignments, month.starts_at, month.ends_at
+      )
+      income = metadata[:items].reduce(0) do |sum, item|
+        if (item.is_a?(ContributorPayout) || item.is_a?(Trueup)) && scope_ids.include?(item.ledger.enterprise_id)
+          sum + item.amount
+        else
+          sum
+        end
+      end
+      acc[month] = Contributor.elevated_service?(total_hours: hours, total_income: income)
+      acc
+    end
+  end
+
   def tentative_profit_shares_by_contributor
     @_tentative_profit_shares_by_contributor ||= contributors.reduce({}) do |acc, contributor|
+      next acc unless PeriodicReport.eligible_profit_share_email?(contributor.forecast_person.email)
+
       ledger = contributor.all_items_grouped_by_month(false, nil, period.ends_at + 1.day)
+      scoped_elevated = profit_share_elevated_service_by_month(contributor, ledger[:by_month])
 
       attendance = ledger[:by_month].select{|p| p.starts_at >= period.starts_at && p.ends_at <= period.ends_at }.reduce({}) do |agg, tuple|
-        period, metadata = tuple
+        month, metadata = tuple
         m = metadata.dup
         m.delete(:items)
-        agg[period.label] = m
+        m[:elevated_service] = scoped_elevated[month]
+        agg[month.label] = m
         agg
       end
       elevated_service_months = attendance.values.select{|v| v[:elevated_service]}.count

--- a/test/models/periodic_report_test.rb
+++ b/test/models/periodic_report_test.rb
@@ -1,0 +1,126 @@
+require 'test_helper'
+
+class PeriodicReportTest < ActiveSupport::TestCase
+  setup do
+    Thread.current[:sanctuary_enterprise] = nil
+    Thread.current[:garden3d_enterprise] = nil
+    @sanctuary = enterprises(:sanctuary)
+    @garden3d = Enterprise.create!(name: Enterprise::GARDEN3D_NAME)
+    @other = enterprises(:one)
+    @report = PeriodicReport.create!(
+      period_gradation: :quarter,
+      period_starts_at: Date.new(2026, 4, 1),
+      period_label: "Q2, 2026"
+    )
+  end
+
+  def make_contributor!(email)
+    fp = ForecastPerson.create!(forecast_id: rand(1..2_000_000_000), email: email, data: {})
+    fp.contributor
+  end
+
+  def make_project_billed_through!(enterprise, name)
+    fc = ForecastClient.create!(forecast_id: rand(1..2_000_000_000), name: name)
+    EnterpriseForecastClient.create!(enterprise: enterprise, forecast_client: fc)
+    ForecastProject.create!(
+      forecast_id: rand(1..2_000_000_000),
+      name: "#{name} Project",
+      forecast_client: fc,
+      code: "#{name}-#{rand(10_000)}"
+    )
+  end
+
+  def assign_hours!(contributor, project, start_date, end_date, seconds_per_day = 8 * 60 * 60)
+    ForecastAssignment.create!(
+      forecast_id: rand(1..2_000_000_000),
+      forecast_person: contributor.forecast_person,
+      forecast_project: project,
+      start_date: start_date,
+      end_date: end_date,
+      allocation: seconds_per_day
+    )
+  end
+
+  def pay_trueup!(contributor, enterprise, month_start, amount)
+    pass = InvoicePass.find_or_create_by!(start_of_month: month_start) { |ip| ip.data = {} }
+    ledger = Ledger.find_or_create_for(enterprise: enterprise, contributor: contributor)
+    Trueup.create!(ledger: ledger, invoice_pass: pass, amount: amount, description: "test trueup")
+  end
+
+  def quarter_by_month(contributor)
+    contributor.all_items_grouped_by_month(
+      false, @report.period.starts_at, @report.period.ends_at + 1.day
+    )[:by_month]
+  end
+
+  test "eligible_profit_share_email? accepts only sanctuary.computer and xxix.co domains" do
+    assert PeriodicReport.eligible_profit_share_email?("kay@sanctuary.computer")
+    assert PeriodicReport.eligible_profit_share_email?("sam@xxix.co")
+    assert PeriodicReport.eligible_profit_share_email?("SAM@XXIX.CO")
+    refute PeriodicReport.eligible_profit_share_email?("info@driesbos.com")
+    refute PeriodicReport.eligible_profit_share_email?("kay@sanctuary.computer.evil.com")
+    refute PeriodicReport.eligible_profit_share_email?(nil)
+    refute PeriodicReport.eligible_profit_share_email?("")
+  end
+
+  test "elevated service counts hours only on clients billed through Sanctuary or garden3d" do
+    contributor = make_contributor!("worker@sanctuary.computer")
+    sanctuary_project = make_project_billed_through!(@sanctuary, "Sanctuary Client")
+    garden3d_project = make_project_billed_through!(@garden3d, "Garden3d Client")
+    other_project = make_project_billed_through!(@other, "Other Enterprise Client")
+
+    # ~240 recorded hours in each month — far past the 120hr elevated-service bar,
+    # but April's hours bill through an out-of-scope enterprise.
+    assign_hours!(contributor, other_project, Date.new(2026, 4, 1), Date.new(2026, 4, 30))
+    assign_hours!(contributor, sanctuary_project, Date.new(2026, 5, 1), Date.new(2026, 5, 31))
+    assign_hours!(contributor, garden3d_project, Date.new(2026, 6, 1), Date.new(2026, 6, 30))
+
+    flags = @report.profit_share_elevated_service_by_month(contributor, quarter_by_month(contributor))
+    by_label = flags.transform_keys(&:label)
+
+    refute by_label["April, 2026"], "hours billed through an out-of-scope enterprise must not count"
+    assert by_label["May, 2026"], "Sanctuary-billed hours count"
+    assert by_label["June, 2026"], "garden3d-billed hours count"
+  end
+
+  test "elevated service counts income only on Sanctuary or garden3d ledgers" do
+    contributor = make_contributor!("worker@sanctuary.computer")
+
+    pay_trueup!(contributor, @other, Date.new(2026, 4, 1), 20_000)
+    pay_trueup!(contributor, @sanctuary, Date.new(2026, 5, 1), 9_500)
+    pay_trueup!(contributor, @garden3d, Date.new(2026, 6, 1), 9_500)
+
+    flags = @report.profit_share_elevated_service_by_month(contributor, quarter_by_month(contributor))
+    by_label = flags.transform_keys(&:label)
+
+    refute by_label["April, 2026"], "income on an out-of-scope enterprise ledger must not count"
+    assert by_label["May, 2026"], "Sanctuary ledger income counts"
+    assert by_label["June, 2026"], "garden3d ledger income counts"
+  end
+
+  test "tentative profit shares exclude non-company emails and out-of-scope work" do
+    # conan@ is on the US cost-of-living override list, so no DeelPerson is needed.
+    eligible = make_contributor!("conan@sanctuary.computer")
+    wrong_email = make_contributor!("freelance@gmail.com")
+    wrong_enterprise = make_contributor!("elsewhere@sanctuary.computer")
+
+    sanctuary_project = make_project_billed_through!(@sanctuary, "Client A")
+    other_project = make_project_billed_through!(@other, "Client B")
+
+    [4, 5, 6].each do |month|
+      assign_hours!(eligible, sanctuary_project, Date.new(2026, month, 1), Date.new(2026, month, 28))
+      assign_hours!(wrong_email, sanctuary_project, Date.new(2026, month, 1), Date.new(2026, month, 28))
+      assign_hours!(wrong_enterprise, other_project, Date.new(2026, month, 1), Date.new(2026, month, 28))
+    end
+
+    result = @report.tentative_profit_shares_by_contributor
+    emails = result.values.map { |data| data[:email] }
+
+    assert_includes emails, "conan@sanctuary.computer"
+    refute_includes emails, "freelance@gmail.com", "company-email rule must exclude external addresses"
+    refute_includes emails, "elsewhere@sanctuary.computer", "enterprise-scope rule must exclude out-of-scope work"
+
+    eligible_data = result.values.find { |data| data[:email] == "conan@sanctuary.computer" }
+    assert_equal 3, eligible_data[:elevated_service_months]
+  end
+end


### PR DESCRIPTION
## Summary

Narrows profit share eligibility from the whole Garden 3D network to the Sanctuary Computer umbrella, per the Q2 2026 program change. Two new rules, both enforced in `PeriodicReport#tentative_profit_shares_by_contributor`:

1. **Enterprise scope** — a month only counts as elevated service if the work is attributable to **Sanctuary Computer Inc** or **garden3d, LLC**:
   - **Hours** count when the assignment's project bills through an in-scope enterprise (`forecast_client.billing_enterprise`; clientless projects like Time Off follow the existing unmapped-client default of Sanctuary).
   - **Income** (ContributorPayouts + Trueups) counts when the item sits on an in-scope enterprise's ledger.
   - The thresholds themselves are unchanged (120 hrs or $9k income per month, ≥1 qualifying month per quarter).
2. **Company email** — only contributors whose Forecast email is `@sanctuary.computer` or `@xxix.co` participate.

Both rules live in constants at the top of `PeriodicReport` (`PROFIT_SHARE_ENTERPRISE_NAMES`, `PROFIT_SHARE_EMAIL_DOMAINS`) so future adjustments are one-line changes.

## Deliberate non-changes

- **Historical tenure (psu) stays network-wide.** The tenure multiplier still counts all previously earned elevated-service months, since those quarters were earned under the old rules. Only the current quarter's qualification and `elevated_service_months` are scoped.
- **The profit share pool math is untouched** — same surplus, same successful-projects gate. Fewer eligible people means the same pool splits into proportionally larger shares.
- The network-wide elevated-service flag in `Contributor#all_items_grouped_by_month` is untouched; surveys, associate awards, and admin views that use it are unaffected. The scoped computation overrides the flag only inside the report's `attendance` blueprint.

## Impact (verified against production data, Q2 2026 / report #34)

28 recipients under the old rules → 23 under this ruleset:

- Dropped by enterprise scope: **ayaka@** (all Q2 hours bill through Index Space, LLC)
- Dropped by email rule: **Dries Bos, Armin, Aufi, Breanna** (external addresses; their Sanctuary/garden3d work would otherwise qualify)
- Reduced share: **elie@** (2 of 3 months qualify once out-of-scope hours are excluded)

## Testing

New `test/models/periodic_report_test.rb` covers:
- the email-domain gate (incl. case-insensitivity and lookalike-domain rejection)
- hours-based elevated service scoping (in-scope vs out-of-scope billed clients, garden3d included)
- income-based scoping (trueups on in-scope vs out-of-scope ledgers)
- end-to-end `tentative_profit_shares_by_contributor` exclusion of wrong-email and out-of-scope contributors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
